### PR TITLE
Move the bot's requirements file to _sc2common root directory

### DIFF
--- a/worlds/_sc2common/requirements.txt
+++ b/worlds/_sc2common/requirements.txt
@@ -3,3 +3,4 @@ mpyq>=0.2.5
 portpicker>=1.5.2
 aiohttp>=3.8.4
 loguru>=0.7.0
+protobuf==3.20.3


### PR DESCRIPTION
`ModuleUpdate.py` only checks the top level directory of worlds in the worlds folder, so the requirements file needs to be moved for it to be detected.

This also adds a specific version of `protobuf` as a dependency, as required by `s2clientprotocol`.