### PR TITLE
SC2: New mission orders

### DIFF
--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -34,6 +34,7 @@ from worlds.sc2wol import SC2WoLWorld
 from worlds.sc2wol.Items import lookup_id_to_name, get_full_item_list, ItemData, type_flaggroups, upgrade_numbers
 from worlds.sc2wol.Locations import SC2WOL_LOC_ID_OFFSET
 from worlds.sc2wol.MissionTables import lookup_id_to_mission
+from worlds.sc2wol import Options
 from worlds.sc2wol.Regions import MissionInfo
 
 import colorama
@@ -933,7 +934,7 @@ def calc_available_missions(ctx: SC2Context, unlocks=None):
     return available_missions
 
 
-def mission_reqs_completed(ctx: SC2Context, mission_name: str, missions_complete: int):
+def mission_reqs_completed(ctx: SC2Context, mission_name: str, missions_complete: int) -> bool:
     """Returns a bool signifying if the mission has all requirements complete and can be done
 
     Arguments:
@@ -941,7 +942,7 @@ def mission_reqs_completed(ctx: SC2Context, mission_name: str, missions_complete
     locations_to_check -- the mission string name to check
     missions_complete -- an int of how many missions have been completed
     mission_path -- a list of missions that have already been checked
-"""
+    """
     if len(ctx.mission_req_table[mission_name].required_world) >= 1:
         # A check for when the requirements are being or'd
         or_success = False
@@ -959,7 +960,12 @@ def mission_reqs_completed(ctx: SC2Context, mission_name: str, missions_complete
                     req_success = False
 
             # Grid-specific logic (to avoid long path checks and infinite recursion)
-            if ctx.mission_order in (3, 4):
+            if ctx.mission_order in (
+                Options.MissionOrder.option_grid,
+                Options.MissionOrder.option_mini_grid,
+                Options.MissionOrder.option_grid_4x6,
+                Options.MissionOrder.option_grid_5x6,
+            ):
                 if req_success:
                     return True
                 else:

--- a/worlds/sc2wol/Locations.py
+++ b/worlds/sc2wol/Locations.py
@@ -4,6 +4,7 @@ from BaseClasses import MultiWorld
 from .Options import get_option_value
 
 from BaseClasses import Location
+from .LogicMixin import SC2WoLLogic
 
 SC2WOL_LOC_ID_OFFSET = 1000
 
@@ -24,7 +25,7 @@ class LocationData(NamedTuple):
     name: str
     code: Optional[int]
     type: LocationType
-    rule: Callable = lambda state: True
+    rule: Callable[[SC2WoLLogic], bool] = lambda state: True
 
 
 def get_locations(multiworld: Optional[MultiWorld], player: Optional[int]) -> Tuple[LocationData, ...]:

--- a/worlds/sc2wol/MissionTables.py
+++ b/worlds/sc2wol/MissionTables.py
@@ -158,6 +158,64 @@ blitz_order = [
     FillMission(MissionPools.FINAL, [0, 1], "Final", number=5, or_requirements=True)
 ]
 
+grid_5x6_order = [
+    FillMission(MissionPools.HARD,    [1, 4],           "_1", or_requirements=True),
+    FillMission(MissionPools.MEDIUM,  [0, 5, 2],        "_1", or_requirements=True),
+    FillMission(MissionPools.EASY,    [1, 6, 3],        "_1", or_requirements=True),
+    FillMission(MissionPools.STARTER, [-1],             "_1", or_requirements=True),
+    FillMission(MissionPools.HARD,    [0, 5, 9],        "_2", or_requirements=True),
+    FillMission(MissionPools.HARD,    [1, 4, 10, 6],    "_2", or_requirements=True),
+    FillMission(MissionPools.MEDIUM,  [2, 5, 11, 7],    "_2", or_requirements=True),
+    FillMission(MissionPools.EASY,    [3, 6, 12, 8],    "_2", or_requirements=True),
+    FillMission(MissionPools.EASY,    [-1],             "_2", or_requirements=True),
+    FillMission(MissionPools.HARD,    [4, 10, 14],      "_3", or_requirements=True),
+    FillMission(MissionPools.HARD,    [5, 9, 15, 11],   "_3", or_requirements=True),
+    FillMission(MissionPools.HARD,    [6, 10, 16, 12],  "_3", or_requirements=True),
+    FillMission(MissionPools.MEDIUM,  [7, 11, 17, 13],  "_3", or_requirements=True),
+    FillMission(MissionPools.EASY,    [8, 12, 18],      "_3", or_requirements=True),
+    FillMission(MissionPools.HARD,    [9, 15, 19],      "_4", or_requirements=True),
+    FillMission(MissionPools.HARD,    [10, 14, 20, 16], "_4", or_requirements=True),
+    FillMission(MissionPools.HARD,    [11, 15, 21, 17], "_4", or_requirements=True),
+    FillMission(MissionPools.HARD,    [12, 16, 22, 18], "_4", or_requirements=True),
+    FillMission(MissionPools.MEDIUM,  [13, 17, 23],     "_4", or_requirements=True),
+    FillMission(MissionPools.HARD,    [14, 20, 24],     "_5", or_requirements=True),
+    FillMission(MissionPools.HARD,    [15, 19, 25, 21], "_5", or_requirements=True),
+    FillMission(MissionPools.HARD,    [16, 20, 26, 22], "_5", or_requirements=True),
+    FillMission(MissionPools.HARD,    [17, 21, 27, 23], "_5", or_requirements=True),
+    FillMission(MissionPools.HARD,    [18, 22, 28],     "_5", or_requirements=True),
+    FillMission(MissionPools.FINAL,   [19, 25],         "_6", or_requirements=True),
+    FillMission(MissionPools.HARD,    [20, 24, 26],     "_6", or_requirements=True),
+    FillMission(MissionPools.HARD,    [21, 25, 27],     "_6", or_requirements=True),
+    FillMission(MissionPools.HARD,    [22, 26, 28],     "_6", or_requirements=True),
+    FillMission(MissionPools.HARD,    [23, 27],         "_6", or_requirements=True),
+]
+
+grid_4x6_order = [
+    FillMission(MissionPools.HARD,    [1, 5],           "_1", or_requirements=True),
+    FillMission(MissionPools.HARD,    [0, 6, 2],        "_1", or_requirements=True),
+    FillMission(MissionPools.MEDIUM,  [1, 7, 3],        "_1", or_requirements=True),
+    FillMission(MissionPools.EASY,    [2, 8, 4],        "_1", or_requirements=True),
+    FillMission(MissionPools.STARTER, [-1],             "_1", or_requirements=True),
+    FillMission(MissionPools.HARD,    [0, 6, 11],       "_2", or_requirements=True),
+    FillMission(MissionPools.HARD,    [1, 5, 12, 7],    "_2", or_requirements=True),
+    FillMission(MissionPools.HARD,    [2, 6, 13, 8],    "_2", or_requirements=True),
+    FillMission(MissionPools.MEDIUM,  [3, 7, 14, 9],    "_2", or_requirements=True),
+    FillMission(MissionPools.EASY,    [4, 8, 15, 10],   "_2", or_requirements=True),
+    FillMission(MissionPools.STARTER, [-1],             "_2", or_requirements=True),
+    FillMission(MissionPools.HARD,    [5, 17, 12],      "_3", or_requirements=True),
+    FillMission(MissionPools.HARD,    [6, 11, 18, 13],  "_3", or_requirements=True),
+    FillMission(MissionPools.HARD,    [7, 12, 19, 14],  "_3", or_requirements=True),
+    FillMission(MissionPools.HARD,    [8, 13, 20, 15],  "_3", or_requirements=True),
+    FillMission(MissionPools.MEDIUM,  [9, 14, 21, 16],  "_3", or_requirements=True),
+    FillMission(MissionPools.EASY,    [10, 15, 22],     "_3", or_requirements=True),
+    FillMission(MissionPools.FINAL,   [11, 18],         "_4", or_requirements=True),
+    FillMission(MissionPools.HARD,    [12, 17, 19],     "_4", or_requirements=True),
+    FillMission(MissionPools.HARD,    [13, 18, 20],     "_4", or_requirements=True),
+    FillMission(MissionPools.HARD,    [14, 19, 21],     "_4", or_requirements=True),
+    FillMission(MissionPools.HARD,    [15, 20, 22],     "_4", or_requirements=True),
+    FillMission(MissionPools.MEDIUM,  [16, 21],         "_4", or_requirements=True),
+]
+
 mission_orders = [
     vanilla_shuffle_order,
     vanilla_shuffle_order,
@@ -167,7 +225,9 @@ mission_orders = [
     blitz_order,
     gauntlet_order,
     mini_gauntlet_order,
-    tiny_grid_order
+    tiny_grid_order,
+    grid_5x6_order,
+    grid_4x6_order,
 ]
 
 

--- a/worlds/sc2wol/Options.py
+++ b/worlds/sc2wol/Options.py
@@ -60,6 +60,8 @@ class MissionOrder(Choice):
     Gauntlet (7): Linear series of 7 random missions to complete the campaign.
     Mini Gauntlet (4): Linear series of 4 random missions to complete the campaign.
     Tiny Grid (4): A 2x2 version of Grid.  Complete the bottom-right mission to win.
+    Grid 5x6 (29): A 5x6 -1 version of Grid.  Two starting missions, and a grid containing all WoL missions. Complete the top-right mission to win.
+    Grid 4x6 (23): A 4x6 -1 version of Grid.  Perfect for excluding no-build missions. Complete the top-right mission to win.
     """
     display_name = "Mission Order"
     option_vanilla = 0
@@ -71,6 +73,8 @@ class MissionOrder(Choice):
     option_gauntlet = 6
     option_mini_gauntlet = 7
     option_tiny_grid = 8
+    option_grid_5x6 = 9
+    option_grid_4x6 = 10
 
 
 class PlayerColor(Choice):


### PR DESCRIPTION
## What is this fixing or adding?

I added two new mission orders to the game, targeting the demographic of people that want to play all WoL missions or all missions excluding no-build, while giving them more routing options rather than having to go through a 3-mission linear segment right at the start and end. The mission orders are 5x6-1 and 4x6-1, with the starting corner mission a cell to allow for two starting missions. The mission totals add up to 29, the number of missions in WoL, and 23, the number of build missions in WoL. The 23-mission variant can also be used to exclude Protoss missions, though no-build missions will thus still get mixed in unless explicitly excluded.

If not enough missions are available, either due to excluding missions or disabling `shuffle_protoss` or `shuffle_no_build`, then generation will always fail.

The new mission orders start from the bottom-left in the UI to avoid having to add more UI logic to add a gap at the top of a column.

Mission difficulties are set in concentric diagonals, with the first diagonal at starter, then easy, then medium, then all other missions are hard or final. I set the grid 5x6 option to have one starter and one easy option as the first two missions as an experiment, and didn't notice any issues with leaving it. I can either change it for consistency or leave it, I'm leaving it for now in the hopes it gives someone the option for a slightly more interesting starter mission someday.

### Alternative approaches
It could make sense to just add a "big grid" mission layout, that generates a grid big enough to include all non-excluded missions. It would cut down on complexity in the yaml in exchange for a bit more complexity in the generation, and a need to clearly communicate the rules for finding the grid dimensions.

## How was this tested?
I generated some single-player worlds with each option, changing around the excludes. 5x6 passes with no excludes, and errors with a "not enough missions" error message with excludes. 4x6 behaves the same way, but the threshold is at 23 missions instead of needing all 29.

I didn't push it too hard; it's possible the mission difficulty settings would have to be tuned downwards for cases where a lot of easy missions are excluded.

## If this makes graphical changes, please attach screenshots.
### 4x6 example
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/8a997990-510f-46bd-b209-ad809591484c)

### 5x6 example
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/e7dbbabd-2b77-4de1-8e95-36465878ba3c)
