### PR TITLE
SC2: Selecting an unavailable mission in the launcher no longer blanks the screen

### DIFF
--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -518,9 +518,9 @@ class SC2Context(CommonContext):
             def mission_callback(self, button):
                 if not self.launching:
                     mission_id: int = next(k for k, v in self.mission_id_to_button.items() if v == button)
-                    self.ctx.play_mission(mission_id)
-                    self.launching = mission_id
-                    Clock.schedule_once(self.finish_launching, 10)
+                    if self.ctx.play_mission(mission_id):
+                        self.launching = mission_id
+                        Clock.schedule_once(self.finish_launching, 10)
 
             def finish_launching(self, dt):
                 self.launching = False
@@ -538,7 +538,7 @@ class SC2Context(CommonContext):
         if self.sc2_run_task:
             self.sc2_run_task.cancel()
 
-    def play_mission(self, mission_id: int):
+    def play_mission(self, mission_id: int) -> bool:
         if self.missions_unlocked or \
                 is_mission_available(self, mission_id):
             if self.sc2_run_task:
@@ -550,10 +550,12 @@ class SC2Context(CommonContext):
                                    "checks will not be registered to server.")
             self.sc2_run_task = asyncio.create_task(starcraft_launch(self, mission_id),
                                                     name="Starcraft 2 Launch")
+            return True
         else:
             sc2_logger.info(
                 f"{lookup_id_to_mission[mission_id]} is not currently unlocked.  "
                 f"Use /unfinished or /available to see what is available.")
+            return False
 
     def build_location_to_mission_mapping(self):
         mission_id_to_location_ids: typing.Dict[int, typing.Set[int]] = {


### PR DESCRIPTION
## What is this fixing or adding?
Prior to this change, selecting an unavailable mission in the launcher would blank the screen with the "launching mission XXX" notification even though nothing was launching. It would take 10 seconds to clear, which was a bit of a pain for what could be a small misclick. This change just removes that, only setting the panel to the launching state if the mission was available.

Made issue #54 to track this issue.

## How was this tested?
I launched the client, connected, and tried to launch an unavailable mission. The screen did not blank.

Launching with the `/play` command still worked as before; launching available missions still works as before.