### PR TITLE
SC2: new variable-size grid mission order

### DIFF
--- a/worlds/sc2wol/Client.py
+++ b/worlds/sc2wol/Client.py
@@ -276,6 +276,7 @@ class SC2Context(CommonContext):
     game_speed_override = -1
     mission_id_to_location_ids: typing.Dict[int, typing.List[int]] = {}
     last_bot: typing.Optional[ArchipelagoBot] = None
+    mission_generator_version = 0
 
     def __init__(self, *args, **kwargs):
         super(SC2Context, self).__init__(*args, **kwargs)
@@ -289,6 +290,7 @@ class SC2Context(CommonContext):
 
     def on_package(self, cmd: str, args: dict):
         if cmd in {"Connected"}:
+            self.mission_generator_version = args["slot_data"].get("mission_generator_version", 0)
             self.difficulty = args["slot_data"]["game_difficulty"]
             if "game_speed" in args["slot_data"]:
                 self.game_speed = args["slot_data"]["game_speed"]
@@ -458,7 +460,7 @@ class SC2Context(CommonContext):
                                 Label(text=category_display_name, size_hint_y=None, height=50, outline_width=1))
 
                             for mission in categories[category]:
-                                if (len(self.ctx.mission_req_table[mission]) > 6
+                                if (self.ctx.mission_generator_version > 0
                                     and MissionInfoUiFlags.PrependSpacer in MissionInfoUiFlags(self.ctx.mission_req_table[mission].ui_flags)
                                 ):
                                     column_spacer = Label(text='', size_hint_y=None, height=50)

--- a/worlds/sc2wol/Client.py
+++ b/worlds/sc2wol/Client.py
@@ -35,7 +35,7 @@ from worlds.sc2wol.Items import lookup_id_to_name, get_full_item_list, ItemData,
 from worlds.sc2wol.Locations import SC2WOL_LOC_ID_OFFSET
 from worlds.sc2wol.MissionTables import lookup_id_to_mission
 from worlds.sc2wol import Options
-from worlds.sc2wol.Regions import MissionInfo
+from worlds.sc2wol.Regions import MissionInfo, MissionInfoUiFlags
 
 import colorama
 from NetUtils import ClientStatus, NetworkItem, RawJSONtoTextParser, JSONtoTextParser, JSONMessagePart
@@ -458,6 +458,12 @@ class SC2Context(CommonContext):
                                 Label(text=category_display_name, size_hint_y=None, height=50, outline_width=1))
 
                             for mission in categories[category]:
+                                if (len(self.ctx.mission_req_table[mission]) > 6
+                                    and MissionInfoUiFlags.PrependSpacer in MissionInfoUiFlags(self.ctx.mission_req_table[mission].ui_flags)
+                                ):
+                                    column_spacer = Label(text='', size_hint_y=None, height=50)
+                                    category_panel.add_widget(column_spacer)
+
                                 text: str = mission
                                 tooltip: str = ""
                                 mission_id: int = self.ctx.mission_req_table[mission].id

--- a/worlds/sc2wol/Client.py
+++ b/worlds/sc2wol/Client.py
@@ -34,6 +34,7 @@ from worlds.sc2wol import SC2WoLWorld
 from worlds.sc2wol.Items import lookup_id_to_name, get_full_item_list, ItemData, type_flaggroups, upgrade_numbers
 from worlds.sc2wol.Locations import SC2WOL_LOC_ID_OFFSET
 from worlds.sc2wol.MissionTables import lookup_id_to_mission
+from worlds.sc2wol import Options
 from worlds.sc2wol.Regions import MissionInfo
 
 import colorama
@@ -936,7 +937,7 @@ def calc_available_missions(ctx: SC2Context, unlocks=None):
     return available_missions
 
 
-def mission_reqs_completed(ctx: SC2Context, mission_name: str, missions_complete: int):
+def mission_reqs_completed(ctx: SC2Context, mission_name: str, missions_complete: int) -> bool:
     """Returns a bool signifying if the mission has all requirements complete and can be done
 
     Arguments:
@@ -962,7 +963,11 @@ def mission_reqs_completed(ctx: SC2Context, mission_name: str, missions_complete
                     req_success = False
 
             # Grid-specific logic (to avoid long path checks and infinite recursion)
-            if ctx.mission_order in (3, 4):
+            if ctx.mission_order in (
+                Options.MissionOrder.option_medium_grid,
+                Options.MissionOrder.option_mini_grid,
+                Options.MissionOrder.option_grid,
+            ):
                 if req_success:
                     return True
                 else:
@@ -1137,7 +1142,7 @@ class DllDirectory:
         return False
 
 
-def download_latest_release_zip(owner: str, repo: str, api_version: str, metadata: str = None, force_download=False) -> (str, str):
+def download_latest_release_zip(owner: str, repo: str, api_version: str, metadata: str = None, force_download=False) -> typing.Tuple[str, str]:
     """Downloads the latest release of a GitHub repo to the current directory as a .zip file."""
     import requests
 

--- a/worlds/sc2wol/Locations.py
+++ b/worlds/sc2wol/Locations.py
@@ -4,6 +4,7 @@ from BaseClasses import MultiWorld
 from .Options import get_option_value
 
 from BaseClasses import Location
+from .PoolFilter import ValidInventory
 
 SC2WOL_LOC_ID_OFFSET = 1000
 
@@ -24,7 +25,7 @@ class LocationData(NamedTuple):
     name: str
     code: Optional[int]
     type: LocationType
-    rule: Callable = lambda state: True
+    rule: Callable[[ValidInventory], bool] = lambda state: True
 
 
 def get_locations(multiworld: Optional[MultiWorld], player: Optional[int]) -> Tuple[LocationData, ...]:

--- a/worlds/sc2wol/MissionTables.py
+++ b/worlds/sc2wol/MissionTables.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Dict, List
+from typing import NamedTuple, Dict, List, Union
 from enum import IntEnum, Flag, auto
 
 
@@ -26,9 +26,12 @@ class MissionPools(IntEnum):
     FINAL = 4
 
 
+mission_pool_names = ['Starter', 'Easy', 'Medium', 'Hard', 'Final']
+
+
 class MissionInfo(NamedTuple):
     id: int
-    required_world: List[int]
+    required_world: Union[List[int], List[str]]
     category: str
     number: int = 0  # number of worlds need beaten
     completion_critical: bool = False  # missions needed to beat game

--- a/worlds/sc2wol/MissionTables.py
+++ b/worlds/sc2wol/MissionTables.py
@@ -262,7 +262,7 @@ mission_tags = {
     "Whispers of Doom":         MissionTags.Prophecy | MissionTags.VsZerg | MissionTags.NoBuild,
     "A Sinister Turn":          MissionTags.Prophecy | MissionTags.VsProtoss,
     "Echoes of the Future":     MissionTags.Prophecy | MissionTags.VsZerg | MissionTags.Hero,
-    "In Utter Darkness":        MissionTags.Prophecy | MissionTags.VsZerg | MissionTags.Hero,
+    "In Utter Darkness":        MissionTags.Prophecy | MissionTags.VsZerg | MissionTags.Hero | MissionTags.TimedDefense,
     "Gates of Hell":            MissionTags.Char | MissionTags.VsZerg,
     "Belly of the Beast":       MissionTags.Char | MissionTags.VsZerg | MissionTags.NoBuild | MissionTags.Hero,
     "Shatter the Sky":          MissionTags.Char | MissionTags.VsZerg,

--- a/worlds/sc2wol/MissionTables.py
+++ b/worlds/sc2wol/MissionTables.py
@@ -1,14 +1,21 @@
 from typing import NamedTuple, Dict, List
-from enum import IntEnum
+from enum import IntEnum, Flag, auto
 
-no_build_regions_list = ["Liberation Day", "Breakout", "Ghost of a Chance", "Piercing the Shroud", "Whispers of Doom",
-                         "Belly of the Beast"]
-easy_regions_list = ["The Outlaws", "Zero Hour", "Evacuation", "Outbreak", "Smash and Grab", "Devil's Playground"]
-medium_regions_list = ["Safe Haven", "Haven's Fall", "The Dig", "The Moebius Factor", "Supernova",
-                       "Welcome to the Jungle", "The Great Train Robbery", "Cutthroat", "Media Blitz",
-                       "A Sinister Turn", "Echoes of the Future"]
-hard_regions_list = ["Maw of the Void", "Engine of Destruction", "In Utter Darkness", "Gates of Hell",
-                     "Shatter the Sky"]
+
+class MissionTags(Flag):
+    MarSara = auto()
+    Colonist = auto()
+    Artifact = auto()
+    Covert = auto()
+    Rebellion = auto()
+    Prophecy = auto()
+    Char = auto()
+    NoBuild = auto()
+    Hero = auto()
+    TimedDefense = auto()
+    VsTerran = auto()
+    VsZerg = auto()
+    VsProtoss = auto()
 
 
 class MissionPools(IntEnum):
@@ -167,7 +174,7 @@ mission_orders = [
     blitz_order,
     gauntlet_order,
     mini_gauntlet_order,
-    tiny_grid_order
+    tiny_grid_order,
 ]
 
 
@@ -228,3 +235,37 @@ alt_final_mission_locations = {
     "Gates of Hell": "Gates of Hell: Victory",
     "Shatter the Sky": "Shatter the Sky: Victory"
 }
+
+
+mission_tags = {
+    "Liberation Day":           MissionTags.MarSara | MissionTags.VsTerran | MissionTags.NoBuild | MissionTags.Hero,
+    "The Outlaws":              MissionTags.MarSara | MissionTags.VsTerran,
+    "Zero Hour":                MissionTags.MarSara | MissionTags.VsZerg | MissionTags.TimedDefense,
+    "Evacuation":               MissionTags.Colonist | MissionTags.VsZerg,
+    "Outbreak":                 MissionTags.Colonist | MissionTags.VsZerg,
+    "Safe Haven":               MissionTags.Colonist | MissionTags.VsProtoss,
+    "Haven's Fall":             MissionTags.Colonist | MissionTags.VsZerg,
+    "Smash and Grab":           MissionTags.Artifact | MissionTags.VsZerg | MissionTags.VsProtoss,
+    "The Dig":                  MissionTags.Artifact | MissionTags.VsProtoss | MissionTags.TimedDefense,
+    "The Moebius Factor":       MissionTags.Artifact | MissionTags.VsZerg,
+    "Supernova":                MissionTags.Artifact | MissionTags.VsProtoss,
+    "Maw of the Void":          MissionTags.Artifact | MissionTags.VsProtoss,
+    "Devil's Playground":       MissionTags.Covert | MissionTags.VsZerg,
+    "Welcome to the Jungle":    MissionTags.Covert | MissionTags.VsProtoss,
+    "Breakout":                 MissionTags.Covert | MissionTags.VsTerran | MissionTags.NoBuild | MissionTags.Hero,
+    "Ghost of a Chance":        MissionTags.Covert | MissionTags.VsTerran | MissionTags.NoBuild | MissionTags.Hero,
+    "The Great Train Robbery":  MissionTags.Rebellion | MissionTags.VsTerran,
+    "Cutthroat":                MissionTags.Rebellion | MissionTags.VsTerran,
+    "Engine of Destruction":    MissionTags.Rebellion | MissionTags.VsTerran,
+    "Media Blitz":              MissionTags.Rebellion | MissionTags.VsTerran | MissionTags.Hero,
+    "Piercing the Shroud":      MissionTags.Rebellion | MissionTags.VsTerran | MissionTags.VsZerg | MissionTags.VsProtoss | MissionTags.NoBuild | MissionTags.Hero,
+    "Whispers of Doom":         MissionTags.Prophecy | MissionTags.VsZerg | MissionTags.NoBuild,
+    "A Sinister Turn":          MissionTags.Prophecy | MissionTags.VsProtoss,
+    "Echoes of the Future":     MissionTags.Prophecy | MissionTags.VsZerg | MissionTags.Hero,
+    "In Utter Darkness":        MissionTags.Prophecy | MissionTags.VsZerg | MissionTags.Hero,
+    "Gates of Hell":            MissionTags.Char | MissionTags.VsZerg,
+    "Belly of the Beast":       MissionTags.Char | MissionTags.VsZerg | MissionTags.NoBuild | MissionTags.Hero,
+    "Shatter the Sky":          MissionTags.Char | MissionTags.VsZerg,
+    "All-In":                   MissionTags.Char | MissionTags.VsZerg | MissionTags.TimedDefense,
+}
+

--- a/worlds/sc2wol/MissionTables.py
+++ b/worlds/sc2wol/MissionTables.py
@@ -29,6 +29,10 @@ class MissionPools(IntEnum):
 mission_pool_names = ['Starter', 'Easy', 'Medium', 'Hard', 'Final']
 
 
+class MissionInfoUiFlags(Flag):
+    PrependSpacer = auto()
+
+
 class MissionInfo(NamedTuple):
     id: int
     required_world: Union[List[int], List[str]]
@@ -36,6 +40,7 @@ class MissionInfo(NamedTuple):
     number: int = 0  # number of worlds need beaten
     completion_critical: bool = False  # missions needed to beat game
     or_requirements: bool = False  # true if the requirements should be or-ed instead of and-ed
+    ui_flags: int = 0  # for sending flags to the UI. Uses MissionInfoUiFlags, but stored as an int so pickling works
 
 
 class FillMission(NamedTuple):

--- a/worlds/sc2wol/Options.py
+++ b/worlds/sc2wol/Options.py
@@ -1,4 +1,4 @@
-from typing import Dict, FrozenSet, Union
+from typing import Dict, FrozenSet, Union, Optional
 from BaseClasses import MultiWorld
 from Options import Choice, Option, Toggle, DefaultOnToggle, ItemSet, OptionSet, Range
 from .MissionTables import vanilla_mission_req_table
@@ -60,23 +60,25 @@ class MissionOrder(Choice):
     Vanilla (29): Keeps the standard mission order and branching from the WoL Campaign.
     Vanilla Shuffled (29): Keeps same branching paths from the WoL Campaign but randomizes the order of missions within.
     Mini Campaign (15): Shorter version of the campaign with randomized missions and optional branches.
-    Grid (16):  A 4x4 grid of random missions.  Start at the top-left and forge a path towards bottom-right mission to win.
+    Medium Grid (16):  A 4x4 grid of random missions.  Start at the top-left and forge a path towards bottom-right mission to win.
     Mini Grid (9):  A 3x3 version of Grid.  Complete the bottom-right mission to win.
     Blitz (12):  12 random missions that open up very quickly.  Complete the bottom-right mission to win.
     Gauntlet (7): Linear series of 7 random missions to complete the campaign.
     Mini Gauntlet (4): Linear series of 4 random missions to complete the campaign.
     Tiny Grid (4): A 2x2 version of Grid.  Complete the bottom-right mission to win.
+    Grid (variable): A grid that will resize to use all non-excluded missions.  Corners may be omitted to make the grid more square.  Complete the bottom-right mission to win.
     """
     display_name = "Mission Order"
     option_vanilla = 0
     option_vanilla_shuffled = 1
     option_mini_campaign = 2
-    option_grid = 3
+    option_medium_grid = 3
     option_mini_grid = 4
     option_blitz = 5
     option_gauntlet = 6
     option_mini_gauntlet = 7
     option_tiny_grid = 8
+    option_grid = 9
 
 
 class PlayerColor(Choice):
@@ -353,7 +355,7 @@ sc2wol_options: Dict[str, Option] = {
 }
 
 
-def get_option_value(multiworld: MultiWorld, player: int, name: str) -> Union[int,  FrozenSet]:
+def get_option_value(multiworld: Optional[MultiWorld], player: int, name: str) -> Union[int,  FrozenSet]:
     if multiworld is None:
         return sc2wol_options[name].default
 

--- a/worlds/sc2wol/Options.py
+++ b/worlds/sc2wol/Options.py
@@ -81,6 +81,26 @@ class MissionOrder(Choice):
     option_grid = 9
 
 
+class MaximumCampaignSize(Range):
+    """
+    Sets an upper bound on how many missions to include when a variable-size mission order is selected.
+    If a set-size mission order is selected, does nothing.
+    """
+    display_name = "Maximum Campaign Size"
+    range_start = 4
+    range_end = 29
+    default = 29
+
+
+class GridTwoStartPositions(Toggle):
+    """
+    If turned on and 'grid' mission order is selected, removes a mission from the starting
+    corner sets the adjacent two missions as the starter missions.
+    """
+    display_name = "Start with two unlocked missions on grid"
+    default = Toggle.option_false
+
+
 class PlayerColor(Choice):
     """Determines in-game team color."""
     display_name = "Player Color"
@@ -332,6 +352,8 @@ sc2wol_options: Dict[str, Option] = {
     "all_in_map": AllInMap,
     "final_map": FinalMap,
     "mission_order": MissionOrder,
+    "maximum_campaign_size": MaximumCampaignSize,
+    "grid_two_start_positions": GridTwoStartPositions,
     "player_color": PlayerColor,
     "shuffle_protoss": ShuffleProtoss,
     "shuffle_no_build": ShuffleNoBuild,

--- a/worlds/sc2wol/PoolFilter.py
+++ b/worlds/sc2wol/PoolFilter.py
@@ -1,9 +1,9 @@
 from typing import Callable, Dict, List, Set
 from BaseClasses import MultiWorld, ItemClassification, Item, Location
-from .Items import get_full_item_list, spider_mine_sources, second_pass_placeable_items, filler_items
-from .MissionTables import no_build_regions_list, easy_regions_list, medium_regions_list, hard_regions_list,\
-    mission_orders, MissionInfo, alt_final_mission_locations, MissionPools
-from .Options import get_option_value, MissionOrder, FinalMap, MissionProgressLocations, LocationInclusion
+from .Items import get_full_item_list, spider_mine_sources, second_pass_placeable_items
+from .MissionTables import (
+    mission_orders, MissionInfo, alt_final_mission_locations, MissionPools, mission_tags, MissionTags)
+from .Options import get_option_value, MissionOrder, FinalMap
 from .LogicMixin import SC2WoLLogic
 
 # Items with associated upgrades
@@ -18,7 +18,14 @@ BARRACKS_UNITS = {"Marine", "Medic", "Firebat", "Marauder", "Reaper", "Ghost", "
 FACTORY_UNITS = {"Hellion", "Vulture", "Goliath", "Diamondback", "Siege Tank", "Thor", "Predator", "Widow Mine"}
 STARPORT_UNITS = {"Medivac", "Wraith", "Viking", "Banshee", "Battlecruiser", "Hercules", "Science Vessel", "Raven", "Liberator", "Valkyrie"}
 
-PROTOSS_REGIONS = {"A Sinister Turn", "Echoes of the Future", "In Utter Darkness"}
+PROTOSS_REGIONS = set(region_name for region_name in mission_tags if MissionTags.Prophecy in mission_tags[region_name])
+no_build_regions_list = [region_name for region_name in mission_tags if MissionTags.NoBuild in mission_tags[region_name]]
+easy_regions_list = ["The Outlaws", "Zero Hour", "Evacuation", "Outbreak", "Smash and Grab", "Devil's Playground"]
+medium_regions_list = ["Safe Haven", "Haven's Fall", "The Dig", "The Moebius Factor", "Supernova",
+                       "Welcome to the Jungle", "The Great Train Robbery", "Cutthroat", "Media Blitz",
+                       "A Sinister Turn", "Echoes of the Future"]
+hard_regions_list = ["Maw of the Void", "Engine of Destruction", "In Utter Darkness", "Gates of Hell",
+                     "Shatter the Sky"]
 
 
 def filter_missions(multiworld: MultiWorld, player: int) -> Dict[int, List[str]]:

--- a/worlds/sc2wol/PoolFilter.py
+++ b/worlds/sc2wol/PoolFilter.py
@@ -128,6 +128,15 @@ def copy_item(item: Item):
     return Item(item.name, item.classification, item.code, item.player)
 
 
+def num_missions(multiworld: MultiWorld, player: int) -> int:
+    mission_order_type = multiworld.mission_order[player]
+    if mission_order_type < MissionOrder.option_grid:
+        return len(mission_orders[mission_order_type]) - 1
+    else:
+        mission_pools = filter_missions(multiworld, player)
+        return sum(len(pool) for _, pool in mission_pools.items())
+
+
 class ValidInventory:
 
     def has(self, item: str, player: int):
@@ -337,8 +346,7 @@ class ValidInventory:
         self.item_pool = []
         item_quantities: dict[str, int] = dict()
         # Inventory restrictiveness based on number of missions with checks
-        mission_order_type = get_option_value(self.multiworld, self.player, "mission_order")
-        mission_count = len(mission_orders[mission_order_type]) - 1
+        mission_count = num_missions(multiworld, player)
         self.min_units_per_structure = int(mission_count / 7)
         min_upgrades = 1 if mission_count < 10 else 2
         for item in item_pool:

--- a/worlds/sc2wol/Regions.py
+++ b/worlds/sc2wol/Regions.py
@@ -474,10 +474,10 @@ def get_factors(number: int) -> Tuple[int, int]:
     Factor order is such that x <= y.
     """
     assert number > 0
-    for divisor in range(math.floor(math.sqrt(number) + 1), 1, -1):
+    for divisor in range(math.floor(math.sqrt(number)), 1, -1):
         quotient = number // divisor
         if quotient * divisor == number:
-            return (quotient, divisor)
+            return (divisor, quotient)
     return (1, number)
 
 
@@ -490,7 +490,7 @@ def get_grid_dimensions(size: int) -> Tuple[int, int, int]:
     * If multiple options of the same rating are possible, the one with the larger error is chosen,
     as it will appear more square. Compare 3x11 to 5x7-2 for an example of this.
     """
-    dimension_candidates = [(*get_factors(size+x), x) for x in range(2, -1, -1)]
+    dimension_candidates = [(*get_factors(size+x), x) for x in (2, 1, 0)]
     best_dimension = min(dimension_candidates, key=sum)
     return best_dimension
 

--- a/worlds/sc2wol/Regions.py
+++ b/worlds/sc2wol/Regions.py
@@ -8,9 +8,14 @@ from .MissionTables import (MissionInfo, MissionInfoUiFlags, mission_orders,
     MissionPools, mission_pool_names, vanilla_shuffle_order)
 from .PoolFilter import filter_missions
 
+# Allows for backward compatibility.
+# Can be changed independently of the Archipelago version for asynchronous release
+MISSION_GENERATOR_VERSION = 1
+
 PROPHECY_CHAIN_MISSION_COUNT = 4
 
 VANILLA_SHUFFLED_FIRST_PROPHECY_MISSION = 21
+
 
 def create_regions(
     multiworld: MultiWorld,

--- a/worlds/sc2wol/Regions.py
+++ b/worlds/sc2wol/Regions.py
@@ -164,9 +164,9 @@ def create_grid_regions(
         diagonal_length = min(diagonal + 1, num_diagonals - diagonal, grid_size_x, grid_size_y)
         if len(missions_to_add) < diagonal_length:
             raise Exception(f"There are not enough {mission_pool_names[diagonal_difficulty]} missions to fill the campaign.  Please exclude fewer missions.")
-        for i in range(diagonal_length-1, -1, -1):
-            # (0,0) + (1,0)*diagonal + (-1,1)*i + (-1,1)*max(diagonal - grid_size_x + 1, 0)
-            grid_coords = (diagonal - i - max(diagonal - grid_size_x + 1, 0), i + max(diagonal - grid_size_x + 1, 0))
+        for i in range(diagonal_length):
+            # (0,0) + (0,1)*diagonal + (1,-1)*i + (1,-1)*max(diagonal - grid_size_y + 1, 0)
+            grid_coords = (i + max(diagonal - grid_size_y + 1, 0), diagonal - i - max(diagonal - grid_size_y + 1, 0))
             if grid_coords == (grid_size_x - 1, 0) and num_corners_to_remove >= 2:
                 missions[grid_coords] = ''
             elif grid_coords == (0, grid_size_y - 1) and num_corners_to_remove >= 1:

--- a/worlds/sc2wol/Regions.py
+++ b/worlds/sc2wol/Regions.py
@@ -3,8 +3,9 @@ import math
 from BaseClasses import MultiWorld, Region, Entrance, Location, CollectionState
 from .Locations import LocationData
 from .Options import get_option_value, MissionOrder
-from .MissionTables import MissionInfo, mission_orders, vanilla_mission_req_table, alt_final_mission_locations, \
-    MissionPools, mission_pool_names, vanilla_shuffle_order
+from .MissionTables import (MissionInfo, MissionInfoUiFlags, mission_orders,
+    vanilla_mission_req_table, alt_final_mission_locations,
+    MissionPools, mission_pool_names, vanilla_shuffle_order)
 from .PoolFilter import filter_missions
 
 PROPHECY_CHAIN_MISSION_COUNT = 4
@@ -180,6 +181,7 @@ def create_grid_regions(
 
     mission_req_table: Dict[str, MissionInfo] = {}
     for coords, mission in missions.items():
+        ui_flags: MissionInfoUiFlags = MissionInfoUiFlags(0)
         if not mission:
             continue
         connections: List[str] = []
@@ -194,11 +196,14 @@ def create_grid_regions(
                     connect(multiworld, player, names, missions[connected_coords], mission,
                         make_grid_connect_rule(missions, connected_coords, player),
                     )
+        if len(connections) == 2 and coords[1] == 1:
+            ui_flags |= MissionInfoUiFlags.PrependSpacer
         mission_req_table[mission] = MissionInfo(
             vanilla_mission_req_table[mission].id,
             connections,
             category=f'{coords[0] + 1}',
             or_requirements=True,
+            ui_flags=ui_flags.value,
         )
 
     final_mission_id = vanilla_mission_req_table[final_mission].id

--- a/worlds/sc2wol/Regions.py
+++ b/worlds/sc2wol/Regions.py
@@ -474,20 +474,20 @@ def get_factors(number: int) -> Tuple[int, int]:
     Factor order is such that x <= y.
     """
     assert number > 0
-    for divisor in range(math.floor(math.sqrt(number) + 1), 0, -1):
+    for divisor in range(math.floor(math.sqrt(number) + 1), 1, -1):
         quotient = number // divisor
         if quotient * divisor == number:
-            return (divisor, quotient)
-    raise Exception('Expected to return before exiting loop')
+            return (quotient, divisor)
+    return (1, number)
 
 
 def get_grid_dimensions(size: int) -> Tuple[int, int, int]:
     """
     Get the dimensions of a grid mission order from the number of missions, int the format (x, y, error).
-    Error will always be 0, 1, or 2, so the missions can be removed from the corners that aren't the start or end.
-    Dimensions are chosen such that x <= y, as buttons in the UI are wider than they are tall.
-    Dimensions are chosen to be maximally square. That is, x + y + error is minimized.
-    If multiple options of the same rating are possible, the one with the larger error is chosen,
+    * Error will always be 0, 1, or 2, so the missions can be removed from the corners that aren't the start or end.
+    * Dimensions are chosen such that x <= y, as buttons in the UI are wider than they are tall.
+    * Dimensions are chosen to be maximally square. That is, x + y + error is minimized.
+    * If multiple options of the same rating are possible, the one with the larger error is chosen,
     as it will appear more square. Compare 3x11 to 5x7-2 for an example of this.
     """
     dimension_candidates = [(*get_factors(size+x), x) for x in range(2, -1, -1)]

--- a/worlds/sc2wol/Regions.py
+++ b/worlds/sc2wol/Regions.py
@@ -1,5 +1,5 @@
 from typing import List, Set, Dict, Tuple, Optional, Callable
-from BaseClasses import MultiWorld, Region, Entrance, Location
+from BaseClasses import MultiWorld, Region, Entrance, Location, CollectionState
 from .Locations import LocationData
 from .Options import get_option_value, MissionOrder
 from .MissionTables import MissionInfo, mission_orders, vanilla_mission_req_table, alt_final_mission_locations, \
@@ -10,252 +10,315 @@ PROPHECY_CHAIN_MISSION_COUNT = 4
 
 VANILLA_SHUFFLED_FIRST_PROPHECY_MISSION = 21
 
-def create_regions(multiworld: MultiWorld, player: int, locations: Tuple[LocationData, ...], location_cache: List[Location])\
-        -> Tuple[Dict[str, MissionInfo], int, str]:
-    locations_per_region = get_locations_per_region(locations)
-
-    mission_order_type = get_option_value(multiworld, player, "mission_order")
-    mission_order = mission_orders[mission_order_type]
-
-    mission_pools = filter_missions(multiworld, player)
-
-    regions = [create_region(multiworld, player, locations_per_region, location_cache, "Menu")]
-
-    names: Dict[str, int] = {}
+def create_regions(
+    multiworld: MultiWorld,
+    player: int,
+    locations: Tuple[LocationData, ...],
+    location_cache: List[Location]
+) -> Tuple[Dict[str, MissionInfo], int, str]:
+    """
+    Creates region connections by calling the multiworld's `connect()` methods
+    Returns a 3-tuple containing:
+    * dict[str, MissionInfo] mapping a mission name to its data
+    * int The number of missions in the world
+    * str The name of the goal location
+    """
+    mission_order_type: int = multiworld.mission_order[player]
 
     if mission_order_type == MissionOrder.option_vanilla:
-
-        # Generating all regions and locations
-        for region_name in vanilla_mission_req_table.keys():
-            regions.append(create_region(multiworld, player, locations_per_region, location_cache, region_name))
-        multiworld.regions += regions
-
-        connect(multiworld, player, names, 'Menu', 'Liberation Day'),
-        connect(multiworld, player, names, 'Liberation Day', 'The Outlaws',
-                lambda state: state.has("Beat Liberation Day", player)),
-        connect(multiworld, player, names, 'The Outlaws', 'Zero Hour',
-                lambda state: state.has("Beat The Outlaws", player)),
-        connect(multiworld, player, names, 'Zero Hour', 'Evacuation',
-                lambda state: state.has("Beat Zero Hour", player)),
-        connect(multiworld, player, names, 'Evacuation', 'Outbreak',
-                lambda state: state.has("Beat Evacuation", player)),
-        connect(multiworld, player, names, "Outbreak", "Safe Haven",
-                lambda state: state._sc2wol_cleared_missions(multiworld, player, 7) and
-                              state.has("Beat Outbreak", player)),
-        connect(multiworld, player, names, "Outbreak", "Haven's Fall",
-                lambda state: state._sc2wol_cleared_missions(multiworld, player, 7) and
-                              state.has("Beat Outbreak", player)),
-        connect(multiworld, player, names, 'Zero Hour', 'Smash and Grab',
-                lambda state: state.has("Beat Zero Hour", player)),
-        connect(multiworld, player, names, 'Smash and Grab', 'The Dig',
-                lambda state: state._sc2wol_cleared_missions(multiworld, player, 8) and
-                              state.has("Beat Smash and Grab", player)),
-        connect(multiworld, player, names, 'The Dig', 'The Moebius Factor',
-                lambda state: state._sc2wol_cleared_missions(multiworld, player, 11) and
-                              state.has("Beat The Dig", player)),
-        connect(multiworld, player, names, 'The Moebius Factor', 'Supernova',
-                lambda state: state._sc2wol_cleared_missions(multiworld, player, 14) and
-                              state.has("Beat The Moebius Factor", player)),
-        connect(multiworld, player, names, 'Supernova', 'Maw of the Void',
-                lambda state: state.has("Beat Supernova", player)),
-        connect(multiworld, player, names, 'Zero Hour', "Devil's Playground",
-                lambda state: state._sc2wol_cleared_missions(multiworld, player, 4) and
-                              state.has("Beat Zero Hour", player)),
-        connect(multiworld, player, names, "Devil's Playground", 'Welcome to the Jungle',
-                lambda state: state.has("Beat Devil's Playground", player)),
-        connect(multiworld, player, names, "Welcome to the Jungle", 'Breakout',
-                lambda state: state._sc2wol_cleared_missions(multiworld, player, 8) and
-                              state.has("Beat Welcome to the Jungle", player)),
-        connect(multiworld, player, names, "Welcome to the Jungle", 'Ghost of a Chance',
-                lambda state: state._sc2wol_cleared_missions(multiworld, player, 8) and
-                              state.has("Beat Welcome to the Jungle", player)),
-        connect(multiworld, player, names, "Zero Hour", 'The Great Train Robbery',
-                lambda state: state._sc2wol_cleared_missions(multiworld, player, 6) and
-                              state.has("Beat Zero Hour", player)),
-        connect(multiworld, player, names, 'The Great Train Robbery', 'Cutthroat',
-                lambda state: state.has("Beat The Great Train Robbery", player)),
-        connect(multiworld, player, names, 'Cutthroat', 'Engine of Destruction',
-                lambda state: state.has("Beat Cutthroat", player)),
-        connect(multiworld, player, names, 'Engine of Destruction', 'Media Blitz',
-                lambda state: state.has("Beat Engine of Destruction", player)),
-        connect(multiworld, player, names, 'Media Blitz', 'Piercing the Shroud',
-                lambda state: state.has("Beat Media Blitz", player)),
-        connect(multiworld, player, names, 'The Dig', 'Whispers of Doom',
-                lambda state: state.has("Beat The Dig", player)),
-        connect(multiworld, player, names, 'Whispers of Doom', 'A Sinister Turn',
-                lambda state: state.has("Beat Whispers of Doom", player)),
-        connect(multiworld, player, names, 'A Sinister Turn', 'Echoes of the Future',
-                lambda state: state.has("Beat A Sinister Turn", player)),
-        connect(multiworld, player, names, 'Echoes of the Future', 'In Utter Darkness',
-                lambda state: state.has("Beat Echoes of the Future", player)),
-        connect(multiworld, player, names, 'Maw of the Void', 'Gates of Hell',
-                lambda state: state.has("Beat Maw of the Void", player)),
-        connect(multiworld, player, names, 'Gates of Hell', 'Belly of the Beast',
-                lambda state: state.has("Beat Gates of Hell", player)),
-        connect(multiworld, player, names, 'Gates of Hell', 'Shatter the Sky',
-                lambda state: state.has("Beat Gates of Hell", player)),
-        connect(multiworld, player, names, 'Gates of Hell', 'All-In',
-                lambda state: state.has('Beat Gates of Hell', player) and (
-                        state.has('Beat Shatter the Sky', player) or state.has('Beat Belly of the Beast', player)))
-
-        return vanilla_mission_req_table, 29, 'All-In: Victory'
-
+        return create_vanilla_regions(multiworld, player, locations, location_cache)
+    elif mission_order_type == MissionOrder.option_grid:
+        return create_grid_regions(multiworld, player, locations, location_cache)
     else:
-        missions = []
+        return create_structured_regions(multiworld, player, locations, location_cache, mission_order_type)
 
-        remove_prophecy = mission_order_type == 1 and not get_option_value(multiworld, player, "shuffle_protoss")
 
-        final_mission = mission_pools[MissionPools.FINAL][0]
+def create_vanilla_regions(
+    multiworld: MultiWorld,
+    player: int,
+    locations: Tuple[LocationData, ...],
+    location_cache: List[Location],
+) -> Tuple[Dict[str, MissionInfo], int, str]:
+    
+    locations_per_region = initialize_locations_per_region(locations)
+    regions = [create_region(multiworld, player, locations_per_region, location_cache, "Menu")]
 
-        # Determining if missions must be removed
-        mission_pool_size = sum(len(mission_pool) for mission_pool in mission_pools.values())
-        removals = len(mission_order) - mission_pool_size
-        # Removing entire Prophecy chain on vanilla shuffled when not shuffling protoss
-        if remove_prophecy:
-            removals -= PROPHECY_CHAIN_MISSION_COUNT
+    # Generating all regions and locations
+    names: Dict[str, int] = {}
+    for region_name in vanilla_mission_req_table.keys():
+        regions.append(create_region(multiworld, player, locations_per_region, location_cache, region_name))
+    multiworld.regions += regions
 
-        # Initial fill out of mission list and marking all-in mission
-        for mission in mission_order:
-            # Removing extra missions if mission pool is too small
-            # Also handle lower removal priority than Prophecy
-            if 0 < mission.removal_priority <= removals or mission.category == 'Prophecy' and remove_prophecy \
-                    or (remove_prophecy and mission_order_type == MissionOrder.option_vanilla_shuffled
-                        and mission.removal_priority > vanilla_shuffle_order[
-                            VANILLA_SHUFFLED_FIRST_PROPHECY_MISSION].removal_priority
-                        and 0 < mission.removal_priority <= removals + PROPHECY_CHAIN_MISSION_COUNT):
-                missions.append(None)
-            elif mission.type == MissionPools.FINAL:
-                missions.append(final_mission)
-            else:
-                missions.append(mission.type)
+    connect(multiworld, player, names, 'Menu', 'Liberation Day'),
+    connect(multiworld, player, names, 'Liberation Day', 'The Outlaws',
+            lambda state: state.has("Beat Liberation Day", player)),
+    connect(multiworld, player, names, 'The Outlaws', 'Zero Hour',
+            lambda state: state.has("Beat The Outlaws", player)),
+    connect(multiworld, player, names, 'Zero Hour', 'Evacuation',
+            lambda state: state.has("Beat Zero Hour", player)),
+    connect(multiworld, player, names, 'Evacuation', 'Outbreak',
+            lambda state: state.has("Beat Evacuation", player)),
+    connect(multiworld, player, names, "Outbreak", "Safe Haven",
+            lambda state: state._sc2wol_cleared_missions(multiworld, player, 7) and
+                            state.has("Beat Outbreak", player)),
+    connect(multiworld, player, names, "Outbreak", "Haven's Fall",
+            lambda state: state._sc2wol_cleared_missions(multiworld, player, 7) and
+                            state.has("Beat Outbreak", player)),
+    connect(multiworld, player, names, 'Zero Hour', 'Smash and Grab',
+            lambda state: state.has("Beat Zero Hour", player)),
+    connect(multiworld, player, names, 'Smash and Grab', 'The Dig',
+            lambda state: state._sc2wol_cleared_missions(multiworld, player, 8) and
+                            state.has("Beat Smash and Grab", player)),
+    connect(multiworld, player, names, 'The Dig', 'The Moebius Factor',
+            lambda state: state._sc2wol_cleared_missions(multiworld, player, 11) and
+                            state.has("Beat The Dig", player)),
+    connect(multiworld, player, names, 'The Moebius Factor', 'Supernova',
+            lambda state: state._sc2wol_cleared_missions(multiworld, player, 14) and
+                            state.has("Beat The Moebius Factor", player)),
+    connect(multiworld, player, names, 'Supernova', 'Maw of the Void',
+            lambda state: state.has("Beat Supernova", player)),
+    connect(multiworld, player, names, 'Zero Hour', "Devil's Playground",
+            lambda state: state._sc2wol_cleared_missions(multiworld, player, 4) and
+                            state.has("Beat Zero Hour", player)),
+    connect(multiworld, player, names, "Devil's Playground", 'Welcome to the Jungle',
+            lambda state: state.has("Beat Devil's Playground", player)),
+    connect(multiworld, player, names, "Welcome to the Jungle", 'Breakout',
+            lambda state: state._sc2wol_cleared_missions(multiworld, player, 8) and
+                            state.has("Beat Welcome to the Jungle", player)),
+    connect(multiworld, player, names, "Welcome to the Jungle", 'Ghost of a Chance',
+            lambda state: state._sc2wol_cleared_missions(multiworld, player, 8) and
+                            state.has("Beat Welcome to the Jungle", player)),
+    connect(multiworld, player, names, "Zero Hour", 'The Great Train Robbery',
+            lambda state: state._sc2wol_cleared_missions(multiworld, player, 6) and
+                            state.has("Beat Zero Hour", player)),
+    connect(multiworld, player, names, 'The Great Train Robbery', 'Cutthroat',
+            lambda state: state.has("Beat The Great Train Robbery", player)),
+    connect(multiworld, player, names, 'Cutthroat', 'Engine of Destruction',
+            lambda state: state.has("Beat Cutthroat", player)),
+    connect(multiworld, player, names, 'Engine of Destruction', 'Media Blitz',
+            lambda state: state.has("Beat Engine of Destruction", player)),
+    connect(multiworld, player, names, 'Media Blitz', 'Piercing the Shroud',
+            lambda state: state.has("Beat Media Blitz", player)),
+    connect(multiworld, player, names, 'The Dig', 'Whispers of Doom',
+            lambda state: state.has("Beat The Dig", player)),
+    connect(multiworld, player, names, 'Whispers of Doom', 'A Sinister Turn',
+            lambda state: state.has("Beat Whispers of Doom", player)),
+    connect(multiworld, player, names, 'A Sinister Turn', 'Echoes of the Future',
+            lambda state: state.has("Beat A Sinister Turn", player)),
+    connect(multiworld, player, names, 'Echoes of the Future', 'In Utter Darkness',
+            lambda state: state.has("Beat Echoes of the Future", player)),
+    connect(multiworld, player, names, 'Maw of the Void', 'Gates of Hell',
+            lambda state: state.has("Beat Maw of the Void", player)),
+    connect(multiworld, player, names, 'Gates of Hell', 'Belly of the Beast',
+            lambda state: state.has("Beat Gates of Hell", player)),
+    connect(multiworld, player, names, 'Gates of Hell', 'Shatter the Sky',
+            lambda state: state.has("Beat Gates of Hell", player)),
+    connect(multiworld, player, names, 'Gates of Hell', 'All-In',
+            lambda state: state.has('Beat Gates of Hell', player) and (
+                    state.has('Beat Shatter the Sky', player) or state.has('Beat Belly of the Beast', player)))
 
-        no_build_slots = []
-        easy_slots = []
-        medium_slots = []
-        hard_slots = []
+    return vanilla_mission_req_table, 29, 'All-In: Victory'
 
-        # Search through missions to find slots needed to fill
-        for i in range(len(missions)):
-            if missions[i] is None:
-                continue
-            if missions[i] == MissionPools.STARTER:
-                no_build_slots.append(i)
-            elif missions[i] == MissionPools.EASY:
-                easy_slots.append(i)
-            elif missions[i] == MissionPools.MEDIUM:
-                medium_slots.append(i)
-            elif missions[i] == MissionPools.HARD:
-                hard_slots.append(i)
 
-        # Add no_build missions to the pool and fill in no_build slots
-        missions_to_add = mission_pools[MissionPools.STARTER]
-        if len(no_build_slots) > len(missions_to_add):
-            raise Exception("There are no valid No-Build missions.  Please exclude fewer missions.")
-        for slot in no_build_slots:
-            filler = multiworld.random.randint(0, len(missions_to_add) - 1)
+def create_grid_regions(
+    multiworld: MultiWorld,
+    player: int,
+    locations: Tuple[LocationData, ...],
+    location_cache: List[Location],
+) -> Tuple[Dict[str, MissionInfo], int, str]:
+    
+    locations_per_region = initialize_locations_per_region(locations)
+    regions = [create_region(multiworld, player, locations_per_region, location_cache, "Menu")]
 
-            missions[slot] = missions_to_add.pop(filler)
+    # Generating all regions and locations
+    names: Dict[str, int] = {}
+    raise NotImplementedError('Variable-size grid is work-in-progress')
 
-        # Add easy missions into pool and fill in easy slots
-        missions_to_add = missions_to_add + mission_pools[MissionPools.EASY]
-        if len(easy_slots) > len(missions_to_add):
-            raise Exception("There are not enough Easy missions to fill the campaign.  Please exclude fewer missions.")
-        for slot in easy_slots:
-            filler = multiworld.random.randint(0, len(missions_to_add) - 1)
 
-            missions[slot] = missions_to_add.pop(filler)
+def create_structured_regions(
+    multiworld: MultiWorld,
+    player: int,
+    locations: Tuple[LocationData, ...],
+    location_cache: List[Location],
+    mission_order_type: int,
+) -> Tuple[Dict[str, MissionInfo], int, str]:
+    locations_per_region = initialize_locations_per_region(locations)
+    regions = [create_region(multiworld, player, locations_per_region, location_cache, "Menu")]
+    mission_pools = filter_missions(multiworld, player)
 
-        # Add medium missions into pool and fill in medium slots
-        missions_to_add = missions_to_add + mission_pools[MissionPools.MEDIUM]
-        if len(medium_slots) > len(missions_to_add):
-            raise Exception("There are not enough Easy and Medium missions to fill the campaign.  Please exclude fewer missions.")
-        for slot in medium_slots:
-            filler = multiworld.random.randint(0, len(missions_to_add) - 1)
+    names: Dict[str, int] = {}
+    mission_order = mission_orders[mission_order_type]
+    missions = []
 
-            missions[slot] = missions_to_add.pop(filler)
+    remove_prophecy = mission_order_type == 1 and not get_option_value(multiworld, player, "shuffle_protoss")
 
-        # Add hard missions into pool and fill in hard slots
-        missions_to_add = missions_to_add + mission_pools[MissionPools.HARD]
-        if len(hard_slots) > len(missions_to_add):
-            raise Exception("There are not enough missions to fill the campaign.  Please exclude fewer missions.")
-        for slot in hard_slots:
-            filler = multiworld.random.randint(0, len(missions_to_add) - 1)
+    final_mission = mission_pools[MissionPools.FINAL][0]
 
-            missions[slot] = missions_to_add.pop(filler)
+    # Determining if missions must be removed
+    mission_pool_size = sum(len(mission_pool) for mission_pool in mission_pools.values())
+    removals = len(mission_order) - mission_pool_size
+    # Removing entire Prophecy chain on vanilla shuffled when not shuffling protoss
+    if remove_prophecy:
+        removals -= PROPHECY_CHAIN_MISSION_COUNT
 
-        # Generating regions and locations from selected missions
-        for region_name in missions:
-            regions.append(create_region(multiworld, player, locations_per_region, location_cache, region_name))
-        multiworld.regions += regions
-
-        # Mapping original mission slots to shifted mission slots when missions are removed
-        slot_map = []
-        slot_offset = 0
-        for position, mission in enumerate(missions):
-            slot_map.append(position - slot_offset + 1)
-            if mission is None:
-                slot_offset += 1
-
-        # Loop through missions to create requirements table and connect regions
-        # TODO: Handle 'and' connections
-        mission_req_table = {}
-
-        def build_connection_rule(mission_names: List[str], missions_req: int) -> Callable:
-            if len(mission_names) > 1:
-                return lambda state: state.has_all({f"Beat {name}" for name in mission_names}, player) and \
-                                     state._sc2wol_cleared_missions(multiworld, player, missions_req)
-            else:
-                return lambda state: state.has(f"Beat {mission_names[0]}", player) and \
-                                     state._sc2wol_cleared_missions(multiworld, player, missions_req)
-
-        for i, mission in enumerate(missions):
-            if mission is None:
-                continue
-            connections = []
-            all_connections = []
-            for connection in mission_order[i].connect_to:
-                if connection == -1:
-                    continue
-                while missions[connection] is None:
-                    connection -= 1
-                all_connections.append(missions[connection])
-            for connection in mission_order[i].connect_to:
-                required_mission = missions[connection]
-                if connection == -1:
-                    connect(multiworld, player, names, "Menu", mission)
-                else:
-                    if required_mission is None and not mission_order[i].completion_critical:  # Drop non-critical null slots
-                        continue
-                    while required_mission is None:  # Substituting null slot with prior slot
-                        connection -= 1
-                        required_mission = missions[connection]
-                    required_missions = [required_mission] if mission_order[i].or_requirements else all_connections
-                    connect(multiworld, player, names, required_mission, mission,
-                            build_connection_rule(required_missions, mission_order[i].number))
-                    connections.append(slot_map[connection])
-
-            mission_req_table.update({mission: MissionInfo(
-                vanilla_mission_req_table[mission].id, connections, mission_order[i].category,
-                number=mission_order[i].number,
-                completion_critical=mission_order[i].completion_critical,
-                or_requirements=mission_order[i].or_requirements)})
-
-        final_mission_id = vanilla_mission_req_table[final_mission].id
-
-        # Changing the completion condition for alternate final missions into an event
-        if final_mission != 'All-In':
-            final_location = alt_final_mission_locations[final_mission]
-            # Final location should be near the end of the cache
-            for i in range(len(location_cache) - 1, -1, -1):
-                if location_cache[i].name == final_location:
-                    location_cache[i].locked = True
-                    location_cache[i].event = True
-                    location_cache[i].address = None
-                    break
+    # Initial fill out of mission list and marking all-in mission
+    for mission in mission_order:
+        # Removing extra missions if mission pool is too small
+        # Also handle lower removal priority than Prophecy
+        if 0 < mission.removal_priority <= removals or mission.category == 'Prophecy' and remove_prophecy \
+                or (remove_prophecy and mission_order_type == MissionOrder.option_vanilla_shuffled
+                    and mission.removal_priority > vanilla_shuffle_order[
+                        VANILLA_SHUFFLED_FIRST_PROPHECY_MISSION].removal_priority
+                    and 0 < mission.removal_priority <= removals + PROPHECY_CHAIN_MISSION_COUNT):
+            missions.append(None)
+        elif mission.type == MissionPools.FINAL:
+            missions.append(final_mission)
         else:
-            final_location = 'All-In: Victory'
+            missions.append(mission.type)
 
-        return mission_req_table, final_mission_id, final_location
+    no_build_slots = []
+    easy_slots = []
+    medium_slots = []
+    hard_slots = []
+
+    # Search through missions to find slots needed to fill
+    for i in range(len(missions)):
+        if missions[i] is None:
+            continue
+        if missions[i] == MissionPools.STARTER:
+            no_build_slots.append(i)
+        elif missions[i] == MissionPools.EASY:
+            easy_slots.append(i)
+        elif missions[i] == MissionPools.MEDIUM:
+            medium_slots.append(i)
+        elif missions[i] == MissionPools.HARD:
+            hard_slots.append(i)
+
+    # Add no_build missions to the pool and fill in no_build slots
+    missions_to_add = mission_pools[MissionPools.STARTER]
+    if len(no_build_slots) > len(missions_to_add):
+        raise Exception("There are no valid No-Build missions.  Please exclude fewer missions.")
+    for slot in no_build_slots:
+        filler = multiworld.random.randint(0, len(missions_to_add) - 1)
+
+        missions[slot] = missions_to_add.pop(filler)
+
+    # Add easy missions into pool and fill in easy slots
+    missions_to_add = missions_to_add + mission_pools[MissionPools.EASY]
+    if len(easy_slots) > len(missions_to_add):
+        raise Exception("There are not enough Easy missions to fill the campaign.  Please exclude fewer missions.")
+    for slot in easy_slots:
+        filler = multiworld.random.randint(0, len(missions_to_add) - 1)
+
+        missions[slot] = missions_to_add.pop(filler)
+
+    # Add medium missions into pool and fill in medium slots
+    missions_to_add = missions_to_add + mission_pools[MissionPools.MEDIUM]
+    if len(medium_slots) > len(missions_to_add):
+        raise Exception("There are not enough Easy and Medium missions to fill the campaign.  Please exclude fewer missions.")
+    for slot in medium_slots:
+        filler = multiworld.random.randint(0, len(missions_to_add) - 1)
+
+        missions[slot] = missions_to_add.pop(filler)
+
+    # Add hard missions into pool and fill in hard slots
+    missions_to_add = missions_to_add + mission_pools[MissionPools.HARD]
+    if len(hard_slots) > len(missions_to_add):
+        raise Exception("There are not enough missions to fill the campaign.  Please exclude fewer missions.")
+    for slot in hard_slots:
+        filler = multiworld.random.randint(0, len(missions_to_add) - 1)
+
+        missions[slot] = missions_to_add.pop(filler)
+
+    # Generating regions and locations from selected missions
+    for region_name in missions:
+        regions.append(create_region(multiworld, player, locations_per_region, location_cache, region_name))
+    multiworld.regions += regions
+
+    # Mapping original mission slots to shifted mission slots when missions are removed
+    slot_map = []
+    slot_offset = 0
+    for position, mission in enumerate(missions):
+        slot_map.append(position - slot_offset + 1)
+        if mission is None:
+            slot_offset += 1
+
+    # Loop through missions to create requirements table and connect regions
+    # TODO: Handle 'and' connections
+    mission_req_table: Dict[str, MissionInfo] = {}
+
+    def build_connection_rule(mission_names: List[str], missions_req: int) -> Callable:
+        if len(mission_names) > 1:
+            return lambda state: state.has_all({f"Beat {name}" for name in mission_names}, player) and \
+                                    state._sc2wol_cleared_missions(multiworld, player, missions_req)
+        else:
+            return lambda state: state.has(f"Beat {mission_names[0]}", player) and \
+                                    state._sc2wol_cleared_missions(multiworld, player, missions_req)
+
+    for i, mission in enumerate(missions):
+        if mission is None:
+            continue
+        connections = []
+        all_connections = []
+        for connection in mission_order[i].connect_to:
+            if connection == -1:
+                continue
+            while missions[connection] is None:
+                connection -= 1
+            all_connections.append(missions[connection])
+        for connection in mission_order[i].connect_to:
+            required_mission = missions[connection]
+            if connection == -1:
+                connect(multiworld, player, names, "Menu", mission)
+            else:
+                if required_mission is None and not mission_order[i].completion_critical:  # Drop non-critical null slots
+                    continue
+                while required_mission is None:  # Substituting null slot with prior slot
+                    connection -= 1
+                    required_mission = missions[connection]
+                required_missions = [required_mission] if mission_order[i].or_requirements else all_connections
+                connect(multiworld, player, names, required_mission, mission,
+                        build_connection_rule(required_missions, mission_order[i].number))
+                connections.append(slot_map[connection])
+
+        mission_req_table.update({mission: MissionInfo(
+            vanilla_mission_req_table[mission].id, connections, mission_order[i].category,
+            number=mission_order[i].number,
+            completion_critical=mission_order[i].completion_critical,
+            or_requirements=mission_order[i].or_requirements)})
+
+    final_mission_id = vanilla_mission_req_table[final_mission].id
+
+    # Changing the completion condition for alternate final missions into an event
+    if final_mission != 'All-In':
+        final_location = alt_final_mission_locations[final_mission]
+        # Final location should be near the end of the cache
+        for i in range(len(location_cache) - 1, -1, -1):
+            if location_cache[i].name == final_location:
+                location_cache[i].locked = True
+                location_cache[i].event = True
+                location_cache[i].address = None
+                break
+    else:
+        final_location = 'All-In: Victory'
+
+    return mission_req_table, final_mission_id, final_location
+
+
+# ===== Private helper methods =====
+
+
+def create_region(multiworld: MultiWorld, player: int, locations_per_region: Dict[str, List[LocationData]],
+                  location_cache: List[Location], name: str) -> Region:
+    region = Region(name, player, multiworld)
+
+    if name in locations_per_region:
+        for location_data in locations_per_region[name]:
+            location = create_location(player, location_data, region, location_cache)
+            region.locations.append(location)
+
+    return region
+
 
 def create_location(player: int, location_data: LocationData, region: Region,
                     location_cache: List[Location]) -> Location:
@@ -271,20 +334,8 @@ def create_location(player: int, location_data: LocationData, region: Region,
     return location
 
 
-def create_region(multiworld: MultiWorld, player: int, locations_per_region: Dict[str, List[LocationData]],
-                  location_cache: List[Location], name: str) -> Region:
-    region = Region(name, player, multiworld)
-
-    if name in locations_per_region:
-        for location_data in locations_per_region[name]:
-            location = create_location(player, location_data, region, location_cache)
-            region.locations.append(location)
-
-    return region
-
-
 def connect(world: MultiWorld, player: int, used_names: Dict[str, int], source: str, target: str,
-            rule: Optional[Callable] = None):
+            rule: Optional[Callable[[CollectionState], bool]] = None):
     sourceRegion = world.get_region(source, player)
     targetRegion = world.get_region(target, player)
 
@@ -304,10 +355,11 @@ def connect(world: MultiWorld, player: int, used_names: Dict[str, int], source: 
     connection.connect(targetRegion)
 
 
-def get_locations_per_region(locations: Tuple[LocationData, ...]) -> Dict[str, List[LocationData]]:
+def initialize_locations_per_region(locations: Tuple[LocationData, ...]) -> Dict[str, List[LocationData]]:
     per_region: Dict[str, List[LocationData]] = {}
 
     for location in locations:
         per_region.setdefault(location.region, []).append(location)
 
     return per_region
+

--- a/worlds/sc2wol/Regions.py
+++ b/worlds/sc2wol/Regions.py
@@ -205,7 +205,7 @@ def create_grid_regions(
                     connect(multiworld, player, names, missions[connected_coords], mission,
                         make_grid_connect_rule(missions, connected_coords, player),
                     )
-        if coords[1] == 1 and (coords[0], 0) not in missions:
+        if coords[1] == 1 and not missions.get((coords[0], 0)):
             ui_flags |= MissionInfoUiFlags.PrependSpacer
         mission_req_table[mission] = MissionInfo(
             vanilla_mission_req_table[mission].id,

--- a/worlds/sc2wol/__init__.py
+++ b/worlds/sc2wol/__init__.py
@@ -9,7 +9,7 @@ from .Locations import get_locations, LocationType
 from .Regions import create_regions
 from .Options import sc2wol_options, get_option_value, LocationInclusion
 from .LogicMixin import SC2WoLLogic
-from .PoolFilter import filter_missions, filter_items, get_item_upgrades
+from .PoolFilter import filter_items, get_item_upgrades
 from .MissionTables import starting_mission_locations, MissionInfo
 
 
@@ -163,7 +163,7 @@ def get_item_pool(multiworld: MultiWorld, player: int, mission_req_table: Dict[s
     pool: List[Item] = []
 
     # For the future: goal items like Artifact Shards go here
-    locked_items = []
+    locked_items: List[Item] = []
 
     # YAML items
     yaml_locked_items = get_option_value(multiworld, player, 'locked_items')
@@ -232,7 +232,7 @@ def create_item_with_correct_settings(player: int, name: str) -> Item:
     return item
 
 
-def pool_contains_parent(item: Item, pool: [Item]):
+def pool_contains_parent(item: Item, pool: List[Item]):
     item_data = get_full_item_list().get(item.name)
     if item_data.parent_item is None:
         # The item has not associated parent, the item is valid

--- a/worlds/sc2wol/__init__.py
+++ b/worlds/sc2wol/__init__.py
@@ -1,12 +1,12 @@
 import typing
 
-from typing import List, Set, Tuple, Dict
+from typing import List, Set, Tuple, Dict, Any
 from BaseClasses import Item, MultiWorld, Location, Tutorial, ItemClassification
 from worlds.AutoWorld import WebWorld, World
 from .Items import StarcraftWoLItem, filler_items, item_name_groups, get_item_table, get_full_item_list, \
     get_basic_units, ItemData, upgrade_included_names, progressive_if_nco
 from .Locations import get_locations, LocationType
-from .Regions import create_regions
+from .Regions import create_regions, MISSION_GENERATOR_VERSION
 from .Options import sc2wol_options, get_option_value, LocationInclusion
 from .LogicMixin import SC2WoLLogic
 from .PoolFilter import filter_items, get_item_upgrades
@@ -83,7 +83,7 @@ class SC2WoLWorld(World):
     def get_filler_item_name(self) -> str:
         return self.multiworld.random.choice(filler_items)
 
-    def fill_slot_data(self):
+    def fill_slot_data(self) -> Dict[str, Any]:
         slot_data = {}
         for option_name in sc2wol_options:
             option = getattr(self.multiworld, option_name)[self.player]
@@ -93,6 +93,7 @@ class SC2WoLWorld(World):
         for mission in self.mission_req_table:
             slot_req_table[mission] = self.mission_req_table[mission]._asdict()
 
+        slot_data["mission_generator_version"] = MISSION_GENERATOR_VERSION
         slot_data["mission_req"] = slot_req_table
         slot_data["final_mission"] = self.final_mission_id
         return slot_data

--- a/worlds/sc2wol/tests/region_tests.py
+++ b/worlds/sc2wol/tests/region_tests.py
@@ -1,0 +1,21 @@
+
+import unittest
+from ...sc2wol import Regions
+
+class genntypes_tests(unittest.TestCase):
+    def test_grid_sizes_meet_specs(self):
+        self.assertEqual((2, 4, 1), Regions.get_grid_dimensions(7))
+        self.assertEqual((2, 4, 0), Regions.get_grid_dimensions(8))
+        self.assertEqual((3, 3, 0), Regions.get_grid_dimensions(9))
+        self.assertEqual((2, 5, 0), Regions.get_grid_dimensions(10))
+        self.assertEqual((3, 4, 1), Regions.get_grid_dimensions(11))
+        self.assertEqual((3, 4, 0), Regions.get_grid_dimensions(12))
+        self.assertEqual((3, 5, 0), Regions.get_grid_dimensions(15))
+        self.assertEqual((4, 4, 0), Regions.get_grid_dimensions(16))
+        self.assertEqual((4, 6, 0), Regions.get_grid_dimensions(24))
+        self.assertEqual((5, 5, 0), Regions.get_grid_dimensions(25))
+        self.assertEqual((5, 6, 1), Regions.get_grid_dimensions(29))
+        self.assertEqual((5, 7, 2), Regions.get_grid_dimensions(33))
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What is this fixing or adding?
### New mission order
This adds a new variable-size grid mission order. Currently it always tries to make the largest grid it can with the non-excluded missions it has. The dimensions are determined by the following rules:
* size = x * y - error
* x <= y -- this is because the UI buttons are wider than they are tall
* error is 0, 1, or 2 -- these missions are removed from the corners that aren't the start or end
* "Squareness" is maximized; that is, x + y + error is minimized
* If there are tied candidates, the option with the greater error is chosen, as that tends to be more square
  * Consider 33 = `3 * 11` vs `5 * 7 - 2` as an example

### Mission removal adjustments
The existing logic to adjust mission difficulty ratings for no-build configurations was brittle to missions exclusions without setting `shuffle_no_build` to false. I've adjusted the logic so it should behave the same no matter what method is used to exclude missions, while also spreading out the adjustments in case only a few missions are excluded. Additionally, made some of the adjustments only occur if either an early unit is enabled or a tactics level with some logic is enabled, as it was agreed missions like Evacuation and Trains weren't particularly doable without some logic / early unit to help you out.

### Code cleanup
I mostly added and fixed a lot of typehints as I came across issues while working. Additionally, allowed mission requirements in `MissionInfo` structs to reference by name rather than integer ID, as that integer ID depended on dict ordering which I found was quite brittle.

## How was this tested?
I generated several worlds and hosted the games locally before connecting on the client. Old mission orders were not broken in the client, and 

I expect this PR will stay open for a while, and that I will play several local games on it in the meantime with different settings.

## If this makes graphical changes, please attach screenshots.
A world example with no-builds excluded, with the grid setting error to 2:
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/30ef665b-932a-4f20-9f48-74fd1286eefb)

Example with maximum grid size set to 19, and with 2 starting missions enabled (and also when I remembered to add the underscores back to the column names):
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/dda99f99-424a-4cee-9dfb-5b8bfb703536)

