### PR TITLE
sc2: Fixed launcher not updating when connecting to a different slot

### DIFF
--- a/worlds/sc2wol/Client.py
+++ b/worlds/sc2wol/Client.py
@@ -285,6 +285,8 @@ class SC2Context(CommonContext):
             await super(SC2Context, self).server_auth(password_requested)
         await self.get_username()
         await self.send_connect()
+        if self.ui:
+            self.ui.first_check = True
 
     def on_package(self, cmd: str, args: dict):
         if cmd in {"Connected"}:


### PR DESCRIPTION
## What is this fixing or adding?

This came up a lot in the Starcraft async today. Disconnecting and reconnecting as a different slot without closing the client would leave the launcher unupdated, so it would display the mission order of the initial slot. It seems the condition to rebuild the mission panel just didn't account for this condition. Setting the `first_check` flag fixed it, as that is one flag that will cause a rebuild of the panel.

## How was this tested?
I reconnected as a different slot and successfully saw the new mission order

