### PR TITLE
Type annotations and separate GUI

### DIFF
--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -149,6 +149,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         if color:
             if color.lower() not in match_colors:
                 self.output(color + " is not a valid color.  Available colors: " + ', '.join(player_colors))
+                return
             if color.lower() == "random":
                 color = random.choice(player_colors[:16])
             self.ctx.player_color = match_colors.index(color.lower())

--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -25,7 +25,6 @@ class HoverableButton(HoverBehavior, Button):
 
 class MissionButton(HoverableButton):
     tooltip_text = StringProperty("Test")
-    # ctx: SC2Context
 
     def __init__(self, *args, **kwargs):
         super(HoverableButton, self).__init__(*args, **kwargs)

--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -1,0 +1,231 @@
+from typing import *
+import asyncio
+
+from kvui import GameManager, HoverBehavior, ServerToolTip
+from kivy.app import App
+from kivy.clock import Clock
+from kivy.uix.tabbedpanel import TabbedPanelItem
+from kivy.uix.gridlayout import GridLayout
+from kivy.lang import Builder
+from kivy.uix.label import Label
+from kivy.uix.button import Button
+from kivy.uix.floatlayout import FloatLayout
+from kivy.uix.scrollview import ScrollView
+from kivy.properties import StringProperty
+
+from CommonClient import CommonContext
+from worlds.sc2.Client import SC2Context, calc_unfinished_missions, parse_unlock
+from worlds.sc2.MissionTables import lookup_id_to_mission, lookup_name_to_mission
+from worlds.sc2 import SC2World
+
+
+class HoverableButton(HoverBehavior, Button):
+    pass
+
+
+class MissionButton(HoverableButton):
+    tooltip_text = StringProperty("Test")
+    ctx: SC2Context
+
+    def __init__(self, *args, **kwargs):
+        super(HoverableButton, self).__init__(*args, **kwargs)
+        self.layout = FloatLayout()
+        self.popuplabel = ServerToolTip(text=self.text)
+        self.layout.add_widget(self.popuplabel)
+
+    def on_enter(self):
+        self.popuplabel.text = self.tooltip_text
+
+        if self.ctx.current_tooltip:
+            App.get_running_app().root.remove_widget(self.ctx.current_tooltip)
+
+        if self.tooltip_text == "":
+            self.ctx.current_tooltip = None
+        else:
+            App.get_running_app().root.add_widget(self.layout)
+            self.ctx.current_tooltip = self.layout
+
+    def on_leave(self):
+        self.ctx.ui.clear_tooltip()
+
+    @property
+    def ctx(self) -> CommonContext:
+        return App.get_running_app().ctx
+
+class CampaignScroll(ScrollView):
+    pass
+
+class MultiCampaignLayout(GridLayout):
+    pass
+
+class CampaignLayout(GridLayout):
+    pass
+
+class MissionLayout(GridLayout):
+    pass
+
+class MissionCategory(GridLayout):
+    pass
+
+class SC2Manager(GameManager):
+    logging_pairs = [
+        ("Client", "Archipelago"),
+        ("Starcraft2", "Starcraft2"),
+    ]
+    base_title = "Archipelago Starcraft 2 Client"
+
+    campaign_panel = None
+    last_checked_locations = {}
+    mission_id_to_button = {}
+    launching: Union[bool, int] = False  # if int -> mission ID
+    refresh_from_launching = True
+    first_check = True
+    ctx: SC2Context
+
+    def __init__(self, ctx) -> None:
+        super().__init__(ctx)
+
+    def clear_tooltip(self) -> None:
+        if self.ctx.current_tooltip:
+            App.get_running_app().root.remove_widget(self.ctx.current_tooltip)
+
+        self.ctx.current_tooltip = None
+
+    def build(self):
+        container = super().build()
+
+        panel = TabbedPanelItem(text="Starcraft 2 Launcher")
+        panel.content = CampaignScroll()
+        self.campaign_panel = MultiCampaignLayout()
+        panel.content.add_widget(self.campaign_panel)
+
+        self.tabs.add_widget(panel)
+
+        Clock.schedule_interval(self.build_mission_table, 0.5)
+
+        return container
+
+    def build_mission_table(self, dt):
+        if (not self.launching and (not self.last_checked_locations == self.ctx.checked_locations or
+                                    not self.refresh_from_launching)) or self.first_check:
+            self.refresh_from_launching = True
+
+            self.campaign_panel.clear_widgets()
+            if self.ctx.mission_req_table:
+                self.last_checked_locations = self.ctx.checked_locations.copy()
+                self.first_check = False
+
+                self.mission_id_to_button = {}
+
+                available_missions, unfinished_missions = calc_unfinished_missions(self.ctx)
+
+                multi_campaign_layout_height = 0
+
+                for campaign, missions in self.ctx.mission_req_table.items():
+                    categories = {}
+
+                    # separate missions into categories
+                    for mission_index in missions:
+                        mission = self.ctx.mission_req_table[campaign][mission_index]
+                        if mission.category not in categories:
+                            categories[mission.category] = []
+
+                        categories[mission.category].append(mission_index)
+
+                    max_mission_count = max(len(categories[category]) for category in categories)
+                    campaign_layout_height = (max_mission_count + 2) * 50
+                    multi_campaign_layout_height += campaign_layout_height
+                    campaign_layout = CampaignLayout(size_hint_y=None, height=campaign_layout_height)
+                    campaign_layout.add_widget(
+                        Label(text=campaign.campaign_name, size_hint_y=None, height=25, outline_width=1)
+                    )
+                    mission_layout = MissionLayout()
+
+                    for category in categories:
+                        category_panel = MissionCategory()
+                        if category.startswith('_'):
+                            category_display_name = ''
+                        else:
+                            category_display_name = category
+                        category_panel.add_widget(
+                            Label(text=category_display_name, size_hint_y=None, height=25, outline_width=1))
+
+                        for mission in categories[category]:
+                            text: str = mission
+                            tooltip: str = ""
+                            mission_id: int = lookup_name_to_mission[mission].id
+                            mission_data = self.ctx.mission_req_table[campaign][mission]
+                            # Map has uncollected locations
+                            if mission in unfinished_missions:
+                                text = f"[color=6495ED]{text}[/color]"
+                            elif mission in available_missions:
+                                text = f"[color=FFFFFF]{text}[/color]"
+                            # Map requirements not met
+                            else:
+                                text = f"[color=a9a9a9]{text}[/color]"
+                                tooltip = f"Requires: "
+                                if mission_data.required_world:
+                                    tooltip += ", ".join(list(self.ctx.mission_req_table[parse_unlock(req_mission).campaign])[parse_unlock(req_mission).connect_to - 1] for
+                                                            req_mission in
+                                                            mission_data.required_world)
+
+                                    if mission_data.number:
+                                        tooltip += " and "
+                                if mission_data.number:
+                                    tooltip += f"{self.ctx.mission_req_table[campaign][mission].number} missions completed"
+                            remaining_location_names: List[str] = [
+                                self.ctx.location_names[loc] for loc in self.ctx.locations_for_mission(mission)
+                                if loc in self.ctx.missing_locations]
+
+                            if mission_id == self.ctx.final_mission:
+                                if mission in available_missions:
+                                    text = f"[color=FFBC95]{mission}[/color]"
+                                else:
+                                    text = f"[color=D0C0BE]{mission}[/color]"
+                                if tooltip:
+                                    tooltip += "\n"
+                                tooltip += "Final Mission"
+
+                            if remaining_location_names:
+                                if tooltip:
+                                    tooltip += "\n"
+                                tooltip += f"Uncollected locations:\n"
+                                tooltip += "\n".join(remaining_location_names)
+
+                            mission_button = MissionButton(text=text, size_hint_y=None, height=50)
+                            mission_button.tooltip_text = tooltip
+                            mission_button.bind(on_press=self.mission_callback)
+                            self.mission_id_to_button[mission_id] = mission_button
+                            category_panel.add_widget(mission_button)
+
+                        category_panel.add_widget(Label(text=""))
+                        mission_layout.add_widget(category_panel)
+                    campaign_layout.add_widget(mission_layout)
+                    self.campaign_panel.add_widget(campaign_layout)
+                self.campaign_panel.height = multi_campaign_layout_height
+
+        elif self.launching:
+            self.refresh_from_launching = False
+
+            self.campaign_panel.clear_widgets()
+            self.campaign_panel.add_widget(Label(text="Launching Mission: " +
+                                                        lookup_id_to_mission[self.launching].mission_name))
+            if self.ctx.ui:
+                self.ctx.ui.clear_tooltip()
+
+    def mission_callback(self, button):
+        if not self.launching:
+            mission_id: int = next(k for k, v in self.mission_id_to_button.items() if v == button)
+            if self.ctx.play_mission(mission_id):
+                self.launching = mission_id
+                Clock.schedule_once(self.finish_launching, 10)
+
+    def finish_launching(self, dt):
+        self.launching = False
+
+def start_gui(context: SC2Context):
+    context.ui = SC2Manager(context)
+    context.ui_task = asyncio.create_task(context.ui.async_run(), name="UI")
+    import pkgutil
+    data = pkgutil.get_data(SC2World.__module__, "Starcraft2.kv").decode()
+    Builder.load_string(data)

--- a/worlds/sc2/Items.py
+++ b/worlds/sc2/Items.py
@@ -7,12 +7,12 @@ from .MissionTables import SC2Mission, SC2Race, SC2Campaign, campaign_mission_ta
 
 class ItemData(typing.NamedTuple):
     code: typing.Optional[int]
-    type: typing.Optional[str]
-    number: typing.Optional[int]
+    type: str
+    number: int
     race: SC2Race
     classification: ItemClassification = ItemClassification.useful
     quantity: int = 1
-    parent_item: str = None
+    parent_item: typing.Optional[str] = None
     origin: typing.Set[str] = {"wol"}
 
 
@@ -414,7 +414,7 @@ item_name_group_names = {
     # HotS
     "Ability", "Strain", "Mutation"
 }
-item_name_groups = {}
+item_name_groups: typing.Dict[str, typing.List[str]] = {}
 for item, data in get_full_item_list().items():
     item_name_groups.setdefault(data.type, []).append(item)
     if data.type in item_name_group_names and '(' in item:

--- a/worlds/sc2/Items.py
+++ b/worlds/sc2/Items.py
@@ -501,7 +501,7 @@ progressive_if_nco = {
     "Progressive Regenerative Bio-Steel"
 }
 
-kerrigan_actives = [
+kerrigan_actives: typing.List[typing.Set[str]] = [
     {'Kinetic Blast (Kerrigan Tier 1)', 'Leaping Strike (Kerrigan Tier 1)'},
     {'Crushing Grip (Kerrigan Tier 2)', 'Psionic Shift (Kerrigan Tier 2)'},
     set(),
@@ -511,7 +511,7 @@ kerrigan_actives = [
     {'Apocalypse (Kerrigan Tier 7)', 'Spawn Leviathan (Kerrigan Tier 7)', 'Drop-Pods (Kerrigan Tier 7)'},
 ]
 
-kerrigan_passives = [
+kerrigan_passives: typing.List[typing.Set[str]] = [
     {"Heroic Fortitude (Kerrigan Tier 1)"},
     {"Chain Reaction (Kerrigan Tier 2)"},
     {"Zergling Reconstitution (Kerrigan Tier 3)", "Improved Overlords (Kerrigan Tier 3)", "Automated Extractors (Kerrigan Tier 3)"},

--- a/worlds/sc2/MissionTables.py
+++ b/worlds/sc2/MissionTables.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Dict, List, Set
+from typing import NamedTuple, Dict, List, Set, Union, Literal, Iterable
 from enum import IntEnum, Enum
 
 
@@ -138,7 +138,7 @@ class MissionConnection:
 
 class MissionInfo(NamedTuple):
     mission: SC2Mission
-    required_world: List[MissionConnection]
+    required_world: List[Union[MissionConnection, Dict[Literal["campaign", "connect_to"], int]]]
     category: str
     number: int = 0  # number of worlds need beaten
     completion_critical: bool = False  # missions needed to beat game
@@ -424,21 +424,19 @@ for mission in SC2Mission:
     campaign_mission_table[mission.campaign].add(mission)
 
 
-def get_campaign_difficulty(campaign: SC2Campaign, excluded_missions: Set[SC2Mission] = None) -> MissionPools:
+def get_campaign_difficulty(campaign: SC2Campaign, excluded_missions: Iterable[SC2Mission] = ()) -> MissionPools:
     """
 
     :param campaign:
     :param excluded_missions:
     :return: Campaign's the most difficult non-excluded mission
     """
-    if excluded_missions is None:
-        excluded_missions = []
     excluded_mission_set = set(excluded_missions)
     included_missions = campaign_mission_table[campaign].difference(excluded_mission_set)
     return max([mission.pool for mission in included_missions])
 
 
-def get_campaign_goal_priority(campaign: SC2Campaign, excluded_missions: Set[SC2Mission] | frozenset[SC2Mission] = None) -> SC2CampaignGoalPriority:
+def get_campaign_goal_priority(campaign: SC2Campaign, excluded_missions: Iterable[SC2Mission] = ()) -> SC2CampaignGoalPriority:
     """
     Gets a modified campaign goal priority.
     If all the campaign's goal missions are excluded, it's ineligible to have the goal

--- a/worlds/sc2/MissionTables.py
+++ b/worlds/sc2/MissionTables.py
@@ -41,7 +41,7 @@ class SC2Campaign(Enum):
         self.id = campaign_id
         self.campaign_name = name
         self.goal_priority = goal_priority
-        race: race
+        self.race = race
 
     GLOBAL = 0, "Global", SC2CampaignGoalPriority.NONE, SC2Race.ANY
     WOL = 1, "Wings of Liberty", SC2CampaignGoalPriority.VERY_HARD, SC2Race.TERRAN


### PR DESCRIPTION
## What is this fixing or adding?
This is the start of my code quality refactors for sc2. Included so far:
* Moved sc2 client GUI to a separate file, ClientGui.py
* Added and fixed a lot of type annotations in Client.py and ClientGui.py

## How was this tested?
I generated, spun up a local server, and connected to that server with the client. I ran `/download_data` and started a mission. I also connected to an existing world by temporarily changing the game name back to `Starcraft 2 Wings of Liberty`.

The client worked fine, but in all cases the mission crashed on load. I reverted my changes, and the mission still crashed; it seems this instability is unrelated to my changes.

## Results
I checked the improvements of the type annotations by running `mypy` locally with fairly strict settings. Before my settings, mypy found 27 issues in Client.py. There were also a lot of variables, especially those initialized as empty lists or dictionaries, which the IDE couldn't deduce the types of. There were a handful of places where the type annotations were incorrect.

After my changes, mypy only found 6 problems. Many of these problems have to do with mypy not finding type annotations for third party libraries, or not properly detecting imports through `_sc2common.bot`, which I elected not to fix. The remaining issues are:
* line 30: `import nest_asyncio`; mypy is complaining I didn't pip install library stubs
* line 41: `import colorama`; mypy is complaining I didn't pip install library stubs
* line 287: `self.raw_text_parser = SC2JSONtoTextParser(self)`, mypy complains about the types. I think it's just getting confused by the `@cached_property` decorator in CommonClient.py
* line 560: mypy complains `Race.Terran` isn't a member of `Race`; this is probably because it doesn't understand the race enum descriptor magic happening in common_pv2.py
* line 936: `Path(bot.paths.USERPATH[bot.paths.PF])`; mypy is complaining that `USERPATH` can contain a `None`
* line 1064: `import requests`; mypy is complaining I didn't pip install `types-requests`

There are some lingering issues in ClientGui.py as well, 13 of them:
* 10 are just mypy being unable to find my kivy imports
* 2 relate to `CommonContext.ui` being set to `None` without a typehint; fixing that requires touching core which I don't want to do (lines 229, 230)
* line 232: The last one is `pkgutil.get_data()` being able to return `None` and not being checked. I think it's reasonable to leave that in there

I got __init__.py down from 29 issues to just 6. 3 are problems coming in from core. The last 3 are around lines 128~133, where mypy complains `set(get_option_value())` doesn't check that `get_option_value()` isn't returning an `int`. I don't think it's worth messing up the existing type annotations to cram an extra type assertion in there.