### PR TITLE
sc2: Fix kivy deprecation warning for padding_x

### DIFF
--- a/worlds/sc2/Starcraft2.kv
+++ b/worlds/sc2/Starcraft2.kv
@@ -23,6 +23,6 @@
     markup: True
     halign: 'center'
     valign: 'middle'
-    padding_x: 5
+    padding: [5,0,5,0]
     markup: True
     outline_width: 1


### PR DESCRIPTION
## What is this fixing or adding?
Berserker brought up the kivy warning I think we've all been ignoring:
```
Deprecated property "<NumericProperty name=padding_x>" of object "<worlds.sc2wol.Client.SC2Context.run_gui.<locals>.MissionButton object at 0x00000292AF91B770>" was accessed, it will be removed in a future version
```
Getting rid of that

## How was this tested?
Opened the client with these changes, verified the warning was not there.


## If this makes graphical changes, please attach screenshots.
The UI looked the same to me
