### PR TITLE
SC2: Add location type tracking to client UI

### DIFF
--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -19,7 +19,8 @@ from pathlib import Path
 from CommonClient import CommonContext, server_loop, ClientCommandProcessor, gui_enabled, get_base_parser
 from Utils import init_logging, is_windows
 from worlds.sc2.Options import MissionOrder, KerriganPrimalStatus, kerrigan_unit_available, Kerriganless, GameSpeed, \
-    GenericUpgradeItems, GenericUpgradeResearch, ColorChoice, GenericUpgradeMissions, KerriganCheckLevelPackSize, KerriganChecksPerLevelPack
+    GenericUpgradeItems, GenericUpgradeResearch, ColorChoice, GenericUpgradeMissions, KerriganCheckLevelPackSize, KerriganChecksPerLevelPack, \
+    LocationInclusion, MissionProgressLocations, OptionalBossLocations, ChallengeLocations, BonusLocations
 
 if __name__ == "__main__":
     init_logging("SC2Client", exception_logger="Client")
@@ -33,7 +34,7 @@ from worlds._sc2common.bot.data import Race
 from worlds._sc2common.bot.main import run_game
 from worlds._sc2common.bot.player import Bot
 from worlds.sc2.Items import lookup_id_to_name, get_full_item_list, ItemData, type_flaggroups, upgrade_numbers, upgrade_numbers_all
-from worlds.sc2.Locations import SC2WOL_LOC_ID_OFFSET
+from worlds.sc2.Locations import SC2WOL_LOC_ID_OFFSET, LocationType
 from worlds.sc2.MissionTables import lookup_id_to_mission, SC2Campaign, lookup_name_to_mission, \
     lookup_id_to_campaign, MissionConnection, SC2Mission, campaign_mission_table, SC2Race, get_no_build_missions
 from worlds.sc2.Regions import MissionInfo
@@ -276,6 +277,7 @@ class SC2Context(CommonContext):
     generic_upgrade_missions = 0
     generic_upgrade_research = 0
     generic_upgrade_items = 0
+    location_inclusions: typing.Dict[LocationType, LocationInclusion] = {}
     current_tooltip = None
     last_loc_list = None
     difficulty_override = -1
@@ -330,6 +332,14 @@ class SC2Context(CommonContext):
             self.kerrigan_primal_status = args["slot_data"].get("kerrigan_primal_status", KerriganPrimalStatus.option_vanilla)
             self.levels_per_check = args["slot_data"].get("kerrigan_check_level_pack_size", KerriganCheckLevelPackSize.default)
             self.checks_per_level = args["slot_data"].get("kerrigan_checks_per_level_pack", KerriganChecksPerLevelPack.default)
+
+            self.location_inclusions = {
+                LocationType.VICTORY: LocationInclusion.option_enabled, # Victory checks are always enabled
+                LocationType.MISSION_PROGRESS: args["slot_data"].get("mission_progress_locations", MissionProgressLocations.default),
+                LocationType.BONUS: args["slot_data"].get("bonus_locations", BonusLocations.default),
+                LocationType.CHALLENGE: args["slot_data"].get("challenge_locations", ChallengeLocations.default),
+                LocationType.OPTIONAL_BOSS: args["slot_data"].get("optional_boss_locations", OptionalBossLocations.default),
+            }
 
             self.build_location_to_mission_mapping()
 

--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -20,7 +20,7 @@ from CommonClient import CommonContext, server_loop, ClientCommandProcessor, gui
 from Utils import init_logging, is_windows
 from worlds.sc2.Options import MissionOrder, KerriganPrimalStatus, kerrigan_unit_available, Kerriganless, GameSpeed, \
     GenericUpgradeItems, GenericUpgradeResearch, ColorChoice, GenericUpgradeMissions, KerriganCheckLevelPackSize, KerriganChecksPerLevelPack, \
-    LocationInclusion, MissionProgressLocations, OptionalBossLocations, ChallengeLocations, BonusLocations
+    LocationInclusion, MissionProgressLocations, OptionalBossLocations, ChallengeLocations, BonusLocations, EarlyUnit
 
 if __name__ == "__main__":
     init_logging("SC2Client", exception_logger="Client")
@@ -278,6 +278,8 @@ class SC2Context(CommonContext):
     generic_upgrade_research = 0
     generic_upgrade_items = 0
     location_inclusions: typing.Dict[LocationType, LocationInclusion] = {}
+    plando_locations: typing.List[str] = []
+    early_unit = 1
     current_tooltip = None
     last_loc_list = None
     difficulty_override = -1
@@ -340,6 +342,8 @@ class SC2Context(CommonContext):
                 LocationType.CHALLENGE: args["slot_data"].get("challenge_locations", ChallengeLocations.default),
                 LocationType.OPTIONAL_BOSS: args["slot_data"].get("optional_boss_locations", OptionalBossLocations.default),
             }
+            self.plando_locations = args["slot_data"].get("plando_locations", [])
+            self.early_unit = args["slot_data"].get("early_unit", EarlyUnit.default)
 
             self.build_location_to_mission_mapping()
 

--- a/worlds/sc2/Locations.py
+++ b/worlds/sc2/Locations.py
@@ -726,3 +726,5 @@ def get_locations(multiworld: Optional[MultiWorld], player: Optional[int]) -> Tu
                 location_data._replace(name="Beat " + location_data.name.rsplit(": ", 1)[0], code=None)
             )
     return tuple(location_table + beat_events)
+
+lookup_location_id_to_type = {loc.code: loc.type for loc in get_locations(None, None) if loc.code is not None}


### PR DESCRIPTION
## What is this fixing or adding?
This makes the client separate uncollected locations by location type, lists which location types are Trash/Nothing based on the corresponding YAML options, and colors mission names in a lighter blue if the remaining locations are all Trash/Nothing.

## How was this tested?
Checking tooltips & colors with different amounts of remaining checks in Liberation Day.

## If this makes graphical changes, please attach screenshots.
![python_zCDsGRz7uw](https://github.com/Ziktofel/Archipelago/assets/30208051/794f91e8-a7c3-444e-af5d-869e299c9008)
![python_2FpJn6m5IL](https://github.com/Ziktofel/Archipelago/assets/30208051/90362689-1d72-4133-b4d4-d39ea0570fe4)
