### PR TITLE
SC2: Adding skip_cutscenes and disable_forced_camera options

### DIFF
--- a/worlds/sc2/Options.py
+++ b/worlds/sc2/Options.py
@@ -29,6 +29,18 @@ class GameSpeed(Choice):
     option_faster = 5
     default = option_default
 
+class DisableForcedCamera(Toggle):
+    """
+    Prevents the game from moving or locking the camera without the player's consent.
+    """
+    display_name = "Disable Forced Camera Movement"
+
+
+class SkipCutscenes(Toggle):
+    """
+    Skips all cutscenes and prevents dialog from blocking progress.
+    """
+    display_name = "Skip Cutscenes"
 
 class AllInMap(Choice):
     """Determines what version of All-In (final map) that will be generated for the campaign."""
@@ -474,6 +486,8 @@ class OptionalBossLocations(LocationInclusion):
 sc2_options: Dict[str, Option] = {
     "game_difficulty": GameDifficulty,
     "game_speed": GameSpeed,
+    "disable_forced_camera": DisableForcedCamera,
+    "skip_cutscenes": SkipCutscenes,
     "all_in_map": AllInMap,
     "mission_order": MissionOrder,
     "player_color_terran_raynor": PlayerColorTerranRaynor,


### PR DESCRIPTION
## What is this fixing or adding?
Config options to set flags that will skip cutscenes and/or prevent the game from forcefully moving the camera.

## How was this tested?
Generated a world with the settings active, ran it against a modified map that could read the flags, confirmed that the flags were active; ran that same modified map with an older yaml to confirm that it still worked + the flags were disabled; ran an older version of the map with the world containing the flags to confirm that their presence didn't cause unexpected behavior. (ie. tried it out and confirmed backward compatibility of default settings)
