### PR TITLE
Changes Early Unit to Starter Unit and Remove Nothing Locations

### DIFF
--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -23,7 +23,7 @@ from worlds.sc2 import ItemNames
 from worlds.sc2.Options import MissionOrder, KerriganPrimalStatus, kerrigan_unit_available, KerriganPresence, GameSpeed, \
     GenericUpgradeItems, GenericUpgradeResearch, ColorChoice, GenericUpgradeMissions, KerriganCheckLevelPackSize, \
     KerriganChecksPerLevelPack, \
-    LocationInclusion, MissionProgressLocations, OptionalBossLocations, ChallengeLocations, BonusLocations, EarlyUnit, \
+    LocationInclusion, MissionProgressLocations, OptionalBossLocations, ChallengeLocations, BonusLocations, \
     DisableForcedCamera, SkipCutscenes, GrantStoryTech, TakeOverAIAllies, RequiredTactics
 
 if __name__ == "__main__":

--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -303,7 +303,6 @@ class SC2Context(CommonContext):
     generic_upgrade_items = 0
     location_inclusions: typing.Dict[LocationType, LocationInclusion] = {}
     plando_locations: typing.List[str] = []
-    early_unit = 1
     current_tooltip = None
     last_loc_list = None
     difficulty_override = -1
@@ -383,7 +382,6 @@ class SC2Context(CommonContext):
                 LocationType.OPTIONAL_BOSS: args["slot_data"].get("optional_boss_locations", OptionalBossLocations.default),
             }
             self.plando_locations = args["slot_data"].get("plando_locations", [])
-            self.early_unit = args["slot_data"].get("early_unit", EarlyUnit.default)
 
             self.build_location_to_mission_mapping()
 

--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -17,7 +17,7 @@ from CommonClient import CommonContext
 from worlds.sc2.Client import SC2Context, calc_unfinished_missions, parse_unlock
 from worlds.sc2.MissionTables import lookup_id_to_mission, lookup_name_to_mission, SC2Mission, MissionInfo
 from worlds.sc2.Locations import LocationType, lookup_location_id_to_type
-from worlds.sc2.Options import LocationInclusion, EarlyUnit
+from worlds.sc2.Options import LocationInclusion
 from worlds.sc2 import SC2World, get_first_mission, get_early_unit_location_name
 
 

--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -161,7 +161,7 @@ class SC2Manager(GameManager):
                             mission_obj: SC2Mission = lookup_name_to_mission[mission]
                             mission_id: int = mission_obj.id
                             mission_data = self.ctx.mission_req_table[campaign][mission]
-                            remaining_locations, plando_locations, early_unit, remaining_count = self.sort_unfinished_locations(mission)
+                            remaining_locations, plando_locations, remaining_count = self.sort_unfinished_locations(mission)
                             # Map has uncollected locations
                             if mission in unfinished_missions:
                                 if self.any_valuable_locations(remaining_locations):
@@ -204,8 +204,6 @@ class SC2Manager(GameManager):
                                         else:
                                             tooltip += f"\n{self.get_location_type_title(loctype)}:\n- "
                                             tooltip += "\n- ".join(remaining_locations[loctype])
-                                if early_unit:
-                                    tooltip += f"\nEarly Unit:\n- {early_unit}"
                                 if len(plando_locations) > 0:
                                     tooltip += f"\nPlando:\n- "
                                     tooltip += "\n- ".join(plando_locations)
@@ -255,13 +253,6 @@ class SC2Manager(GameManager):
                 count += 1
                 locations[lookup_location_id_to_type[loc]].append(self.ctx.location_names[loc])
 
-        early_unit = None
-        if self.ctx.early_unit != EarlyUnit.option_off and mission_name == self.first_mission:
-            early_unit = get_early_unit_location_name(mission_name)
-            for loctype in LocationType:
-                if early_unit in locations[loctype]:
-                    locations[loctype].remove(early_unit)
-
         plando_locations = []
         for plando_loc in self.ctx.plando_locations:
             for loctype in LocationType:
@@ -269,7 +260,7 @@ class SC2Manager(GameManager):
                     locations[loctype].remove(plando_loc)
                     plando_locations.append(plando_loc)
 
-        return locations, plando_locations, early_unit, count
+        return locations, plando_locations, count
 
     def any_valuable_locations(self, locations: Dict[LocationType, List[str]]) -> bool:
         for loctype in LocationType:
@@ -279,10 +270,10 @@ class SC2Manager(GameManager):
 
     def get_location_type_title(self, location_type: LocationType) -> str:
         title = location_type.name.title().replace("_", " ")
-        if self.ctx.location_inclusions[location_type] == LocationInclusion.option_nothing:
+        if self.ctx.location_inclusions[location_type] == LocationInclusion.option_disabled:
             title += " (Nothing)"
-        elif self.ctx.location_inclusions[location_type] == LocationInclusion.option_trash:
-            title += " (Trash)"
+        elif self.ctx.location_inclusions[location_type] == LocationInclusion.option_resources:
+            title += " (Resources)"
         else:
             title += ""
         return title

--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -18,7 +18,7 @@ from worlds.sc2.Client import SC2Context, calc_unfinished_missions, parse_unlock
 from worlds.sc2.MissionTables import lookup_id_to_mission, lookup_name_to_mission, SC2Mission, MissionInfo
 from worlds.sc2.Locations import LocationType, lookup_location_id_to_type
 from worlds.sc2.Options import LocationInclusion
-from worlds.sc2 import SC2World, get_first_mission, get_early_unit_location_name
+from worlds.sc2 import SC2World, get_first_mission
 
 
 class HoverableButton(HoverBehavior, Button):

--- a/worlds/sc2/Options.py
+++ b/worlds/sc2/Options.py
@@ -175,18 +175,15 @@ class ShuffleNoBuild(DefaultOnToggle):
     display_name = "Shuffle No-Build Missions"
 
 
-class EarlyUnit(Choice):
+class StarterUnit(Choice):
     """
-    Guarantees that the first mission will contain a unit.
+    Unlocks a random unit at the start of the game.
 
-    Each mission available to be the first mission has a pre-defined location where the unit should spawn.
-    This location gets overriden over any exclusion. It's guaranteed to be reachable with an empty inventory.
-
-    Off: No unit guaranteed in the first mission
-    Balanced: A unit that doesn't give the player too much power early on is spawned
-    Any Starter Unit: Any starter unit can be spawned
+    Off: No units are provided, the first unit must be obtained from the randomizer
+    Balanced: A unit that doesn't give the player too much power early on is given
+    Any Starter Unit: Any starter unit can be given
     """
-    display_name = "Early Unit"
+    display_name = "Starter Unit"
     option_off = 0
     option_balanced = 1
     option_any_starter_unit = 2
@@ -466,8 +463,8 @@ class ExcludedMissions(OptionSet):
 
 class LocationInclusion(Choice):
     option_enabled = 0
-    option_trash = 1
-    option_nothing = 2
+    option_resources = 1
+    option_disabled = 2
 
 
 class MissionProgressLocations(LocationInclusion):
@@ -477,8 +474,8 @@ class MissionProgressLocations(LocationInclusion):
     Clearing an expansion base also counts here.
 
     Enabled: All locations fitting into this do their normal rewards
-    Trash: Forces a trash item in
-    Nothing: No rewards for this type of tasks, effectively disabling such locations
+    Resources: Forces these locations to contain Starting Resources
+    Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
     See also: Excluded Locations, Item Plando (https://archipelago.gg/tutorial/Archipelago/plando/en#item-plando)
@@ -493,8 +490,8 @@ class BonusLocations(LocationInclusion):
     Research, credits, bonus units or resources, etc.
 
     Enabled: All locations fitting into this do their normal rewards
-    Trash: Forces a trash item in
-    Nothing: No rewards for this type of tasks, effectively disabling such locations
+    Resources: Forces these locations to contain Starting Resources
+    Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
     See also: Excluded Locations, Item Plando (https://archipelago.gg/tutorial/Archipelago/plando/en#item-plando)
@@ -510,8 +507,8 @@ class ChallengeLocations(LocationInclusion):
     You might be required to visit the same mission later when getting stronger in order to finish these tasks.
 
     Enabled: All locations fitting into this do their normal rewards
-    Trash: Forces a trash item in
-    Nothing: No rewards for this type of tasks, effectively disabling such locations
+    Resources: Forces these locations to contain Starting Resources
+    Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
     See also: Excluded Locations, Item Plando (https://archipelago.gg/tutorial/Archipelago/plando/en#item-plando)
@@ -526,8 +523,8 @@ class OptionalBossLocations(LocationInclusion):
     All Brutalisks, Loki, etc. belongs here.
 
     Enabled: All locations fitting into this do their normal rewards
-    Trash: Forces a trash item in
-    Nothing: No rewards for this type of tasks, effectively disabling such locations
+    Resources: Forces these locations to contain Starting Resources
+    Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
     See also: Excluded Locations, Item Plando (https://archipelago.gg/tutorial/Archipelago/plando/en#item-plando)
@@ -554,7 +551,7 @@ sc2_options: Dict[str, Option] = {
     "enable_hots_missions": EnableHotsMissions,
     "shuffle_campaigns": ShuffleCampaigns,
     "shuffle_no_build": ShuffleNoBuild,
-    "early_unit": EarlyUnit,
+    "starter_unit": StarterUnit,
     "required_tactics": RequiredTactics,
     "units_always_have_upgrades": UnitsAlwaysHaveUpgrades,
     "max_number_of_upgrades": MaxNumberOfUpgrades,

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -441,22 +441,6 @@ def place_exclusion_item(item_name, location, locked_locations, player):
     locked_locations.append(location.name)
 
 
-def get_plando_locations(multiworld: MultiWorld, player) -> List[str]:
-    """
-
-    :param multiworld:
-    :param player:
-    :return: A list of locations affected by a plando in a world
-    """
-    plando_locations = []
-    for plando_setting in multiworld.plando_items[player]:
-        plando_locations += plando_setting.get("locations", [])
-        plando_setting_location = plando_setting.get("location", None)
-        if plando_setting_location is not None:
-            plando_locations.append(plando_setting_location)
-
-    return plando_locations
-
 def fill_pool_with_kerrigan_levels(multiworld: MultiWorld, player: int, item_pool: List[Item]):
     total_levels = get_option_value(multiworld, player, "kerrigan_level_item_sum")
     if get_option_value(multiworld, player, "kerrigan_presence") not in kerrigan_unit_available \


### PR DESCRIPTION
## What is this fixing or adding?

- This replaces the Early Unit option with the Starter Unit option, which places a random unit directly into the player's start inventory, mirroring the behavior of Starting Primary Ability and item overflow from PoolFilter.
- It also allows for locations to be removed from the game entirely, rather than filling them with Nothing items.
- When a game is logically impossible and Starter Unit is inactive, a Starter Unit is forced to increase the chance of beatability.
- Non-Victory Locations can be removed independently of the other options when added to exclude_locations.

## How was this tested?

Four different YAMLS were generated, one was tested in gameplay.