### PR TITLE
Item Cull Bugfixes

### DIFF
--- a/worlds/sc2/PoolFilter.py
+++ b/worlds/sc2/PoolFilter.py
@@ -464,7 +464,7 @@ class ValidInventory:
                 if item.name not in item_quantities:
                     item_quantities[item.name] = 0
                 item_quantities[item.name] += 1
-                if item_quantities[item.name] < min_upgrades:
+                if item_quantities[item.name] <= min_upgrades:
                     self.locked_items.append(item)
                 else:
                     self.item_pool.append(item)

--- a/worlds/sc2/PoolFilter.py
+++ b/worlds/sc2/PoolFilter.py
@@ -469,7 +469,7 @@ class ValidInventory:
                 else:
                     self.item_pool.append(item)
             elif item_info.type == "Goal":
-                locked_items.append(item)
+                self.locked_items.append(item)
             else:
                 self.item_pool.append(item)
         self.cascade_removal_map: Dict[Item, List[Item]] = dict()

--- a/worlds/sc2/PoolFilter.py
+++ b/worlds/sc2/PoolFilter.py
@@ -395,7 +395,7 @@ class ValidInventory:
 
     def _read_logic(self):
         # General
-        self._sc2_cleared_missions = lambda world, player: SC2Logic._sc2_cleared_missions(self, world, player)
+        self._sc2_cleared_missions = lambda world, player, mission_count: False
         self._sc2_advanced_tactics = lambda world, player: SC2Logic._sc2_advanced_tactics(self, world, player)
         # WoL
         self._sc2wol_has_common_unit = lambda world, player: SC2Logic._sc2wol_has_common_unit(self, world, player)


### PR DESCRIPTION
## What is this fixing or adding?

Fixes generation failures for Piercing the Shroud, minimum upgrades being one below intended, and goal items not being locked correctly.

## How was this tested?

Several generations.