### PR TITLE
Min Upgrades and Ensure Generic Items options

### DIFF
--- a/worlds/sc2/Items.py
+++ b/worlds/sc2/Items.py
@@ -1527,12 +1527,23 @@ item_name_groups["WoL Missions"] = ["Beat " + mission.mission_name for mission i
 # General upgrades and Mercs
 # TODO needs zerg items
 second_pass_placeable_items: typing.Tuple[str, ...] = (
-    # Buildings without upgrades
+    # Global weapon/armor upgrades
+    ItemNames.PROGRESSIVE_TERRAN_ARMOR_UPGRADE,
+    ItemNames.PROGRESSIVE_TERRAN_WEAPON_UPGRADE,
+    ItemNames.PROGRESSIVE_TERRAN_WEAPON_ARMOR_UPGRADE,
+    ItemNames.PROGRESSIVE_ZERG_ARMOR_UPGRADE,
+    ItemNames.PROGRESSIVE_ZERG_WEAPON_UPGRADE,
+    ItemNames.PROGRESSIVE_ZERG_WEAPON_ARMOR_UPGRADE,
+    ItemNames.PROGRESSIVE_PROTOSS_ARMOR_UPGRADE,
+    ItemNames.PROGRESSIVE_PROTOSS_WEAPON_UPGRADE,
+    ItemNames.PROGRESSIVE_PROTOSS_WEAPON_ARMOR_UPGRADE,
+    ItemNames.PROGRESSIVE_PROTOSS_SHIELDS,
+    # Terran Buildings without upgrades
     ItemNames.SENSOR_TOWER,
     ItemNames.HIVE_MIND_EMULATOR,
     ItemNames.PSI_DISRUPTER,
     ItemNames.PERDITION_TURRET,
-    # General upgrades without any dependencies
+    # General Terran upgrades without any dependencies
     ItemNames.SCV_ADVANCED_CONSTRUCTION,
     ItemNames.SCV_DUAL_FUSION_WELDERS,
     ItemNames.PROGRESSIVE_FIRE_SUPPRESSION_SYSTEM,
@@ -1550,21 +1561,41 @@ second_pass_placeable_items: typing.Tuple[str, ...] = (
     ItemNames.HI_SEC_AUTO_TRACKING,
     ItemNames.ADVANCED_OPTICS,
     ItemNames.ROGUE_FORCES,
-    # Mercenaries
-    ItemNames.WAR_PIGS,
-    ItemNames.DEVIL_DOGS,
-    ItemNames.HAMMER_SECURITIES,
-    ItemNames.SPARTAN_COMPANY,
-    ItemNames.SIEGE_BREAKERS,
-    ItemNames.HELS_ANGELS,
-    ItemNames.DUSK_WINGS,
-    ItemNames.JACKSONS_REVENGE,
-    ItemNames.SKIBIS_ANGELS,
-    ItemNames.DEATH_HEADS,
-    ItemNames.WINGED_NIGHTMARES,
-    ItemNames.RAID_LIBERATORS,
-    ItemNames.BRYNHILDS,
-    ItemNames.JOTUN
+    # Mercenaries (All races)
+    *[item_name for item_name, item_data in get_full_item_list().items()
+      if item_data.type == "Mercenary"],
+    # Kerrigan levels and abilities
+    *[item_name for item_name, item_data in get_full_item_list().items()
+      if item_data.type in ("Level", "Ability") and "hots" in item_data.origin],
+    # Zerg static defenses
+    ItemNames.SPORE_CRAWLER,
+    ItemNames.SPINE_CRAWLER,
+    # Spear of Adun Abilities
+    ItemNames.SOA_CHRONO_SURGE,
+    ItemNames.SOA_PROGRESSIVE_PROXY_PYLON,
+    ItemNames.SOA_PYLON_OVERCHARGE,
+    ItemNames.SOA_ORBITAL_STRIKE,
+    ItemNames.SOA_TEMPORAL_FIELD,
+    ItemNames.SOA_SOLAR_LANCE,
+    ItemNames.SOA_MASS_RECALL,
+    ItemNames.SOA_SHIELD_OVERCHARGE,
+    ItemNames.SOA_DEPLOY_FENIX,
+    ItemNames.SOA_PURIFIER_BEAM,
+    ItemNames.SOA_TIME_STOP,
+    ItemNames.SOA_SOLAR_BOBMARDMENT,
+    ItemNames.MATRIX_OVERLOAD,
+    ItemNames.QUATRO,
+    ItemNames.NEXUS_OVERCHARGE,
+    ItemNames.ORBITAL_ASSIMILATORS,
+    ItemNames.WARP_HARMONIZATION,
+    ItemNames.GUARDIAN_SHELL,
+    ItemNames.RECONSTRUCTION_BEAM,
+    ItemNames.OVERWATCH,
+    ItemNames.SUPERIOR_WARP_GATES,
+    # Protoss static defenses
+    ItemNames.PHOTON_CANNON,
+    ItemNames.KHAYDARIN_MONOLITH,
+    ItemNames.SHIELD_BATTERY
 )
 
 

--- a/worlds/sc2/Options.py
+++ b/worlds/sc2/Options.py
@@ -219,16 +219,6 @@ class RequiredTactics(Choice):
     option_no_logic = 2
 
 
-class UnitsAlwaysHaveUpgrades(DefaultOnToggle):
-    """
-    If turned on, all upgrades will be present for each unit and structure in the seed.
-    This usually results in fewer units.
-
-    See also: Max Number of Upgrades
-    """
-    display_name = "Units Always Have Upgrades"
-
-
 class GenericUpgradeMissions(Range):
     """Determines the percentage of missions in the mission order that must be completed before
     level 1 of all weapon and armor upgrades is unlocked.  Level 2 upgrades require double the amount of missions,
@@ -297,19 +287,30 @@ class ExtendedItems(Toggle):
     default = Toggle.option_true
 
 
+# Current maximum number of upgrades for a unit
+MAX_UPGRADES_OPTION = 12
+
+
+class MinNumberOfUpgrades(Range):
+    """
+    Set a minimum to the number of upgrades a unit/structure can have.
+    Note that most units have 4 or 6 upgrades.
+    If a unit has fewer upgrades than the minimum, it will have all of its upgrades.
+    """
+    display_name = "Minimum number of upgrades per unit/structure"
+    range_start = 0
+    range_end = MAX_UPGRADES_OPTION
+    default = 2
+
+
 class MaxNumberOfUpgrades(Range):
     """
     Set a maximum to the number of upgrades a unit/structure can have. -1 is used to define unlimited.
     Note that most unit have 4 or 6 upgrades.
-
-    If used with Units Always Have Upgrades, each unit has this given amount of upgrades (if there enough upgrades exist)
-
-    See also: Units Always Have Upgrades
     """
     display_name = "Maximum number of upgrades per unit/structure"
     range_start = -1
-    # Do not know the maximum, but it is less than 123!
-    range_end = 123
+    range_end = MAX_UPGRADES_OPTION
     default = -1
 
 
@@ -641,7 +642,7 @@ sc2_options: Dict[str, Option] = {
     "shuffle_no_build": ShuffleNoBuild,
     "starter_unit": StarterUnit,
     "required_tactics": RequiredTactics,
-    "units_always_have_upgrades": UnitsAlwaysHaveUpgrades,
+    "min_number_of_upgrades": MinNumberOfUpgrades,
     "max_number_of_upgrades": MaxNumberOfUpgrades,
     "generic_upgrade_missions": GenericUpgradeMissions,
     "generic_upgrade_research": GenericUpgradeResearch,

--- a/worlds/sc2/Options.py
+++ b/worlds/sc2/Options.py
@@ -205,7 +205,7 @@ class StarterUnit(Choice):
 
 class RequiredTactics(Choice):
     """
-    Determines the maximum tactical difficulty of the seed (separate from mission difficulty).  Higher settings
+    Determines the maximum tactical difficulty of the world (separate from mission difficulty).  Higher settings
     increase randomness.
 
     Standard:  All missions can be completed with good micro and macro.
@@ -291,6 +291,19 @@ class ExtendedItems(Toggle):
 MAX_UPGRADES_OPTION = 12
 
 
+class EnsureGenericItems(Range):
+    """
+    Specifies a minimum percentage of the generic item pool that will be present for the slot.
+    The generic item pool is the pool of all generically useful items after all exclusions.
+    Generically-useful items include: Worker upgrades, Building upgrades, economy upgrades,
+    Mercenaries, Kerrigan levels and abilities, and Spear of Adun abilities
+    Increasing this percentage will make units less common.
+    """
+    range_start = 0
+    range_end = 100
+    default = 25
+
+
 class MinNumberOfUpgrades(Range):
     """
     Set a minimum to the number of upgrades a unit/structure can have.
@@ -365,7 +378,7 @@ class KerriganCheckLevelPackSize(Range):
 
 
 class KerriganLevelItemSum(Range):
-    """Determines the sum of the level items in the seed.  This does not affect levels gained from checks."""
+    """Determines the sum of the level items in the world.  This does not affect levels gained from checks."""
     display_name = "Kerrigan Level Item Sum"
     range_start = 0
     range_end = 140
@@ -428,7 +441,7 @@ class KerriganPrimalStatus(Choice):
     Always Zerg:  Kerrigan is always zerg.
     Always Human:  Kerrigan is always human.
     Level 35:  Kerrigan is human until reaching level 35, and zerg thereafter.
-    Half Completion:  Kerrigan is human until half of the missions in the seed are completed,
+    Half Completion:  Kerrigan is human until half of the missions in the world are completed,
     and zerg thereafter.
     Item:  Kerrigan's Primal Form is an item. She is human until it is found, and zerg thereafter."""
     display_name = "Kerrigan Primal Status"
@@ -642,6 +655,7 @@ sc2_options: Dict[str, Option] = {
     "shuffle_no_build": ShuffleNoBuild,
     "starter_unit": StarterUnit,
     "required_tactics": RequiredTactics,
+    "ensure_generic_items": EnsureGenericItems,
     "min_number_of_upgrades": MinNumberOfUpgrades,
     "max_number_of_upgrades": MaxNumberOfUpgrades,
     "generic_upgrade_missions": GenericUpgradeMissions,

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -376,7 +376,7 @@ def get_item_pool(multiworld: MultiWorld, player: int, mission_req_table: Dict[S
             else:
                 pool.append(item)
 
-    existing_items = starter_items + [item for item in multiworld.precollected_items[player]]
+    existing_items = starter_items + [item for item in multiworld.precollected_items[player] if item not in starter_items]
     existing_names = [item.name for item in existing_items]
 
     # Check the parent item integrity, exclude items


### PR DESCRIPTION
## What is this fixing or adding?

Alters the "Units Always Have Upgrades" option into a "Min Number of Upgrades" option.  Default is 2, matching vanilla WoL and HotS.

Adds the "Ensure Generic Items" option, which guarantees the given % of second-pass items to be in the world.  Defaults to 25% to avoid common situation in existing generation rules where final item pool is heavily-biased towards units.

Adds Zerg and Protoss items to second-pass.  Salzkorn and I agree that Zergling Reconstitution provides value on nearly all Zerg maps, and certainly provides more value than Sensor Tower.  Also adds the global-level weapon/armor upgrade items to the second pass, as those items are useful regardless of units rolled.

## How was this tested?

Many generations on many different yamls.
