### PR TITLE
Optimize resource fill

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -432,12 +432,12 @@ def fill_resource_locations(multiworld: MultiWorld, player, locked_locations: Li
     open_locations = [location for location in location_cache if location.item is None]
     plando_locations = get_plando_locations(multiworld, player)
     resource_location_types = get_location_types(multiworld, player, LocationInclusion.option_resources)
-    location_data = get_locations(multiworld, player)
+    location_data = {sc2_location.name: sc2_location for sc2_location in get_locations(multiworld, player)}
     for location in open_locations:
         # Go through the locations that aren't locked yet (early unit, etc)
         if location.name not in plando_locations:
             # The location is not plando'd
-            sc2_location = [sc2_location for sc2_location in location_data if sc2_location.name == location.name][0]
+            sc2_location = location_data[location.name]
             if sc2_location.type in resource_location_types:
                 item_name = multiworld.random.choice(filler_items)
                 item = create_item_with_correct_settings(player, item_name)


### PR DESCRIPTION
## What is this fixing or adding?
This is a significant performance improvement for `fill_resource_locations()`; currently every location that isn't plando'd (which is often *every* location) iterates the location data to find itself, so this cuts down on a lot of that work.

## How was this tested?
A couple generations with default settings (except LotV off since it's not implemented).