### PR TITLE
sc2: Improved /color command

### DIFF
--- a/worlds/sc2/Items.py
+++ b/worlds/sc2/Items.py
@@ -42,9 +42,7 @@ SC2LOTV_ITEM_ID_OFFSET = SC2HOTS_ITEM_ID_OFFSET + 1000
 WEAPON_ARMOR_UPGRADE_NOTE = inspect.cleandoc("""
     Must be researched during the mission if the mission type isn't set to auto-unlock generic upgrades.
 """)
-LASER_TARGETING_SYSTEMS_DESCRIPTION = inspect.cleandoc("""
-    Increases vision by 2 and weapon range by 1.
-""")
+LASER_TARGETING_SYSTEMS_DESCRIPTION = "Increases vision by 2 and weapon range by 1."
 STIMPACK_SMALL_COST = 10
 STIMPACK_SMALL_HEAL = 30
 STIMPACK_LARGE_COST = 20
@@ -55,9 +53,7 @@ STIMPACK_TEMPLATE = inspect.cleandoc("""
 """)
 STIMPACK_SMALL_DESCRIPTION = STIMPACK_TEMPLATE.format(STIMPACK_SMALL_COST, STIMPACK_SMALL_HEAL)
 STIMPACK_LARGE_DESCRIPTION = STIMPACK_TEMPLATE.format(STIMPACK_LARGE_COST, STIMPACK_LARGE_HEAL)
-SMART_SERVOS_DESCRIPTION = inspect.cleandoc("""
-    Increases transformation speed between modes.
-""")
+SMART_SERVOS_DESCRIPTION = "Increases transformation speed between modes."
 INTERNAL_TECH_MODULE_DESCRIPTION_TEMPLATE = "{} can be trained from a {} without an attached Tech Lab."
 RESOURCE_EFFICIENCY_DESCRIPTION_TEMPLATE = "Reduces {} resource and supply cost."
 RESOURCE_EFFICIENCY_NO_SUPPLY_DESCRIPTION_TEMPLATE = "Reduces {} resource cost."
@@ -427,7 +423,7 @@ item_table = {
     ItemNames.FIREBAT_INFERNAL_PRE_IGNITER:
         ItemData(235 + SC2WOL_ITEM_ID_OFFSET, "Armory 2", 2, SC2Race.TERRAN,
                  parent_item=ItemNames.FIREBAT, origin={"bw"},
-                 description="Firebats do additional 4 damage to Light Armor."),
+                 description="Firebats do an additional 4 damage to Light Armor."),
     ItemNames.FIREBAT_KINETIC_FOAM:
         ItemData(236 + SC2WOL_ITEM_ID_OFFSET, "Armory 2", 3, SC2Race.TERRAN,
                  parent_item=ItemNames.FIREBAT, origin={"ext"},
@@ -435,7 +431,7 @@ item_table = {
     ItemNames.FIREBAT_NANO_PROJECTORS:
         ItemData(237 + SC2WOL_ITEM_ID_OFFSET, "Armory 2", 4, SC2Race.TERRAN,
                  parent_item=ItemNames.FIREBAT, origin={"ext"},
-                 description="Increasex Firebat attack range by 2"),
+                 description="Increases Firebat attack range by 2"),
     ItemNames.MARAUDER_JUGGERNAUT_PLATING:
         ItemData(238 + SC2WOL_ITEM_ID_OFFSET, "Armory 2", 5, SC2Race.TERRAN,
                  parent_item=ItemNames.MARAUDER, origin={"ext"},


### PR DESCRIPTION
## What is this fixing or adding?
* Adds a description to `/color` in the client
* Adds a faction parameter to the color
  * Can be Raynor, Kerrigan, Primal, Protoss, or Nova
* Updated response / help text to explain usage
  * No arguments lists all current colours and all possible factions and colours
  * Providing a faction lists the current colour and possible colours
  * Providing an invalid faction gives and error and lists factions
  * Providing all arguments works as before, with the same error message if an invalid colour is given
* Colours can now be updated mid-mission

Nova missions and many LotV missions are missing a faction hookup to take advantage of these changes. I've listed the deficiencies at the bottom. For the Nova faction, I used the code "nova" as it was not yet defined.

## How was this tested?
Help text was tested in the client manually by targeting each branch:
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/619d40be-ca7e-4647-bdd1-67b3601faeb1)

Effects were tested in game. Note due to missing faction identifiers, this currently doesn't affect NCO mission colours; I've set things up so only a map-side change is necessary to use the new system
![Screenshot2024-01-20 00_16_25](https://github.com/Ziktofel/Archipelago/assets/31861583/57b21190-b3ff-40a1-bb9b-2a0e52d8d1e0)
![Screenshot2024-01-20 00_18_23](https://github.com/Ziktofel/Archipelago/assets/31861583/844169f2-c58a-43b5-818f-150cd9832105)
![Screenshot2024-01-20 00_20_21](https://github.com/Ziktofel/Archipelago/assets/31861583/cc5f674f-ce46-4b25-8ffe-7dc745567282)
![Screenshot2024-01-20 00_22_13](https://github.com/Ziktofel/Archipelago/assets/31861583/7edf4676-3540-4788-9a5c-69cb31dad0b3)
(Video of live colour-changing uploaded to the Discord [here](https://discord.com/channels/731205301247803413/1101186175722598521/1198190327752818688))

### Remaining issues
Not all factions are specified on the map side of things. The missing factions I identified:
* Brothers in Arms -- Raynor
* Sky Shield -- Raynor
* Harbinger of Oblivion -- Artanis
* Purification -- Artanis
* Rak'Shir -- Artanis
* Steps of the Rite -- Artanis
* Templar's Charge -- Artanis
* Templar's Return -- Artanis
* The Host -- Artanis
* Unsealing the Past -- Artanis
* all 9 NCO missions -- Nova

Added this list to #134 