### PR TITLE
SC2: Fine-tuning mission gui

### DIFF
--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -152,14 +152,14 @@ class SC2Manager(GameManager):
 
                     for category in categories:
                         category_name_height = 0
-                        category_spacing = 5
+                        category_spacing = 3
                         if category.startswith('_'):
                             category_display_name = ''
                         else:
                             category_display_name = category
                             category_name_height += 25
-                            category_spacing += 5
-                        category_panel = MissionCategory(padding=[category_spacing,5,category_spacing,5])
+                            category_spacing = 10
+                        category_panel = MissionCategory(padding=[category_spacing,6,category_spacing,6])
                         category_panel.add_widget(
                             Label(text=category_display_name, size_hint_y=None, height=category_name_height, outline_width=1))
 

--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -138,22 +138,30 @@ class SC2Manager(GameManager):
                         categories[mission_info.category].append(mission_index)
 
                     max_mission_count = max(len(categories[category]) for category in categories)
-                    campaign_layout_height = (max_mission_count + 2) * 50
+                    if max_mission_count == 1:
+                        campaign_layout_height = 115
+                    else:
+                        campaign_layout_height = (max_mission_count + 2) * 50
                     multi_campaign_layout_height += campaign_layout_height
                     campaign_layout = CampaignLayout(size_hint_y=None, height=campaign_layout_height)
-                    campaign_layout.add_widget(
-                        Label(text=campaign.campaign_name, size_hint_y=None, height=25, outline_width=1)
-                    )
+                    if campaign.campaign_name != "Global":
+                        campaign_layout.add_widget(
+                            Label(text=campaign.campaign_name, size_hint_y=None, height=25, outline_width=1)
+                        )
                     mission_layout = MissionLayout()
 
                     for category in categories:
-                        category_panel = MissionCategory()
+                        category_name_height = 0
+                        category_spacing = 5
                         if category.startswith('_'):
                             category_display_name = ''
                         else:
                             category_display_name = category
+                            category_name_height += 25
+                            category_spacing += 5
+                        category_panel = MissionCategory(padding=[category_spacing,5,category_spacing,5])
                         category_panel.add_widget(
-                            Label(text=category_display_name, size_hint_y=None, height=25, outline_width=1))
+                            Label(text=category_display_name, size_hint_y=None, height=category_name_height, outline_width=1))
 
                         for mission in categories[category]:
                             text: str = mission

--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -15,7 +15,7 @@ from kivy.properties import StringProperty
 
 from worlds.sc2.Client import SC2Context, calc_unfinished_missions, parse_unlock
 from worlds.sc2.MissionTables import lookup_id_to_mission, lookup_name_to_mission, campaign_race_exceptions, \
-    SC2Mission, SC2Race
+    SC2Mission, SC2Race, SC2Campaign
 from worlds.sc2.Locations import LocationType, lookup_location_id_to_type
 from worlds.sc2.Options import LocationInclusion
 from worlds.sc2 import SC2World, get_first_mission
@@ -144,7 +144,7 @@ class SC2Manager(GameManager):
                         campaign_layout_height = (max_mission_count + 2) * 50
                     multi_campaign_layout_height += campaign_layout_height
                     campaign_layout = CampaignLayout(size_hint_y=None, height=campaign_layout_height)
-                    if campaign.campaign_name != "Global":
+                    if campaign != SC2Campaign.GLOBAL:
                         campaign_layout.add_widget(
                             Label(text=campaign.campaign_name, size_hint_y=None, height=25, outline_width=1)
                         )

--- a/worlds/sc2/Starcraft2.kv
+++ b/worlds/sc2/Starcraft2.kv
@@ -7,7 +7,7 @@
     cols: 1
     size_hint_y: None
     height: self.minimum_height + 15
-    padding: [0,0,dp(12),0]
+    padding: [5,0,dp(12),0]
 
 <CampaignLayout>:
     cols: 1

--- a/worlds/sc2/Starcraft2.kv
+++ b/worlds/sc2/Starcraft2.kv
@@ -7,6 +7,7 @@
     cols: 1
     size_hint_y: None
     height: self.minimum_height + 15
+    padding: [0,0,dp(12),0]
 
 <CampaignLayout>:
     cols: 1
@@ -16,7 +17,6 @@
 
 <MissionCategory>:
     cols: 1
-    padding: [10,5,10,5]
     spacing: [0,5]
 
 <MissionButton>:
@@ -25,5 +25,4 @@
     halign: 'center'
     valign: 'middle'
     padding: [5,0,5,0]
-    markup: True
     outline_width: 1


### PR DESCRIPTION
## What is this fixing or adding?
The mission select window had some edge-case visual bugs; this PR is intended to smooth out some of those issues for a more professional look.

- Added right-side padding to accommodate scroll bar
- Grid no longer adds a campaign title if the title would be "Global" (ie. no more filler campaign title on grid/blitz/etc)
- Categories no longer add space for a title if the title would be empty
- If there are no category titles (ie. they're just columns), the spacing is evened out so that the horizontal and vertical gaps between buttons are equal; if the columns ARE separate categories, they still have more spacing to indicate distinction
- Single-row mini-campaigns had some odd spacing issues due to an assumption of column length, so if the column height is 1 then the spacing is handled differently

## How was this tested?
Generated a few SC2 worlds locally with various sizes and arrangements, then loaded them in the SC2 client for a visual check + screenshots.

## If this makes graphical changes, please attach screenshots.

Vanilla layout:
![image](https://github.com/Ziktofel/Archipelago/assets/138727357/fc400944-f358-40b7-845a-fcbaa90b5439)

Grid layout:
![image](https://github.com/Ziktofel/Archipelago/assets/138727357/1a13b9d2-2a56-4678-84ea-b40440c1a7d1)
