### PR TITLE
sc2: Fixed a typo and incorrect difficulty for location

### DIFF
--- a/worlds/sc2/Locations.py
+++ b/worlds/sc2/Locations.py
@@ -380,7 +380,7 @@ def get_locations(multiworld: Optional[MultiWorld], player: Optional[int]) -> Tu
                      lambda state: logic.terran_basic_anti_air(state) and
                                     (adv_tactics or
                                            logic.terran_common_unit(state) or state.has(ItemNames.REAPER, player))),
-        LocationData("Devil's Playground", "Devil's Playground: Zerg Cleaned", SC2WOL_LOC_ID_OFFSET + 1308, LocationType.EXTRA,
+        LocationData("Devil's Playground", "Devil's Playground: Zerg Cleared", SC2WOL_LOC_ID_OFFSET + 1308, LocationType.CHALLENGE,
                      lambda state: logic.terran_competent_anti_air(state) and (
                                            logic.terran_common_unit(state) or state.has(ItemNames.REAPER, player))),
         LocationData("Welcome to the Jungle", "Welcome to the Jungle: Victory", SC2WOL_LOC_ID_OFFSET + 1400, LocationType.VICTORY,


### PR DESCRIPTION
## What is this fixing or adding?
Changing name and category of Devil's Playground full-clear location. It was originally a Feat of Strength, which was the closest thing WoL had to mastery achievements, so it should be at least challenge if not mastery. The name also didn't sound right and a few people have reported it as a typo already.

## How was this tested?
Regenerated after making this change to make sure nothing broke.

## If this makes graphical changes, please attach screenshots.
