### PR TITLE
sc2: consolidated and polished some client commands

### DIFF
--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -222,7 +222,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
 
         items = get_full_item_list()
         categorized_items: typing.Dict[SC2Race, typing.List[int]] = {}
-        parent_to_child: typing.Dict[str, typing.List[int]] = {}
+        parent_to_child: typing.Dict[int, typing.List[int]] = {}
         items_received: typing.Dict[int, typing.List[NetworkItem]] = {}
         for item in self.ctx.items_received:
             items_received.setdefault(item.item, []).append(item)
@@ -249,7 +249,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
                 for child_item in parent_to_child.get(item_id, ()):
                     received_items_of_this_type = items_received.get(child_item, ())
                     for item in received_items_of_this_type:
-                        (ColouredMessage('* ').item(item.item, item.flags)
+                        (ColouredMessage('  * ').item(item.item, item.flags)
                             (" from ").location(item.location, self.ctx.slot)
                             (" by ").player(item.player)
                         ).send(self.ctx)

--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -270,22 +270,23 @@ class StarcraftClientProcessor(ClientCommandProcessor):
 
         LOGIC_WARNING = f"  *Note changing this may result in logically unbeatable games*\n"
 
-        KERRIGAN_PRESENCE = ConfigurableOptionInfo('kerrigan_presence', 'kerrigan_presence', Options.KerriganPresence, can_break_logic=True)
-        SOA_PRESENCE = ConfigurableOptionInfo('soa_presence', 'spear_of_adun_presence', Options.SpearOfAdunPresence, can_break_logic=True)
-        SOA_IN_NOBUILDS = ConfigurableOptionInfo('soa_in_nobuilds', 'spear_of_adun_present_in_no_build', Options.SpearOfAdunPresentInNoBuild, can_break_logic=True)
-        CONTROL_ALLY = ConfigurableOptionInfo('control_ally', 'take_over_ai_allies', Options.TakeOverAIAllies, can_break_logic=True)
-        MINERALS_PER_CHECK = ConfigurableOptionInfo('minerals_per_item', 'minerals_per_item', Options.MineralsPerItem, ConfigurableOptionType.INTEGER)
-        GAS_PER_CHECK = ConfigurableOptionInfo('gas_per_item', 'vespene_per_item', Options.VespenePerItem, ConfigurableOptionType.INTEGER)
-        SUPPLY_PER_CHECK = ConfigurableOptionInfo('supply_per_item', 'starting_supply_per_item', Options.StartingSupplyPerItem, ConfigurableOptionType.INTEGER)
-        FORCED_CAMERA = ConfigurableOptionInfo('no_forced_camera', 'disable_forced_camera', Options.DisableForcedCamera)
-        SKIP_CUTSCENES = ConfigurableOptionInfo('skip_cutscenes', 'skip_cutscenes', Options.SkipCutscenes)
         options = (
-            KERRIGAN_PRESENCE, SOA_PRESENCE, SOA_IN_NOBUILDS, CONTROL_ALLY,
-            MINERALS_PER_CHECK, GAS_PER_CHECK, SUPPLY_PER_CHECK, FORCED_CAMERA, SKIP_CUTSCENES,
+            ConfigurableOptionInfo('kerrigan_presence', 'kerrigan_presence', Options.KerriganPresence, can_break_logic=True),
+            ConfigurableOptionInfo('soa_presence', 'spear_of_adun_presence', Options.SpearOfAdunPresence, can_break_logic=True),
+            ConfigurableOptionInfo('soa_in_nobuilds', 'spear_of_adun_present_in_no_build', Options.SpearOfAdunPresentInNoBuild, can_break_logic=True),
+            ConfigurableOptionInfo('control_ally', 'take_over_ai_allies', Options.TakeOverAIAllies, can_break_logic=True),
+            ConfigurableOptionInfo('minerals_per_item', 'minerals_per_item', Options.MineralsPerItem, ConfigurableOptionType.INTEGER),
+            ConfigurableOptionInfo('gas_per_item', 'vespene_per_item', Options.VespenePerItem, ConfigurableOptionType.INTEGER),
+            ConfigurableOptionInfo('supply_per_item', 'starting_supply_per_item', Options.StartingSupplyPerItem, ConfigurableOptionType.INTEGER),
+            ConfigurableOptionInfo('no_forced_camera', 'disable_forced_camera', Options.DisableForcedCamera),
+            ConfigurableOptionInfo('skip_cutscenes', 'skip_cutscenes', Options.SkipCutscenes),
         )
 
         WARNING_COLOUR = "salmon"
         CMD_COLOUR = "slateblue"
+        boolean_option_map = {
+            'y': 'true', 'yes': 'true', 'n': 'false', 'no': 'false',
+        }
 
         help_message = ColouredMessage(inspect.cleandoc("""
             Options
@@ -304,6 +305,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             return True
         for option in options:
             if option_name == option.name:
+                option_value = boolean_option_map.get(option_value, option_value)
                 if not option_value:
                     pass
                 elif option.option_type == ConfigurableOptionType.ENUM and option_value in option.option_class.options:

--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -239,7 +239,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             for item_id in categorized_items[faction]:
                 received_items_of_this_type = items_received.get(item_id, ())
                 for item in received_items_of_this_type:
-                    (ColouredMessage('* ').item(item.item, item.flags)
+                    (ColouredMessage('* ').item(item.item, flags=item.flags)
                         (" from ").location(item.location, self.ctx.slot)
                         (" by ").player(item.player)
                     ).send(self.ctx)
@@ -249,7 +249,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
                 for child_item in parent_to_child.get(item_id, ()):
                     received_items_of_this_type = items_received.get(child_item, ())
                     for item in received_items_of_this_type:
-                        (ColouredMessage('  * ').item(item.item, item.flags)
+                        (ColouredMessage('  * ').item(item.item, flags=item.flags)
                             (" from ").location(item.location, self.ctx.slot)
                             (" by ").player(item.player)
                         ).send(self.ctx)

--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -258,14 +258,16 @@ class StarcraftClientProcessor(ClientCommandProcessor):
 
         LOGIC_WARNING = f"*Note changing this may result in logically unbeatable games*"
         KERRIGAN_PRESENCE = ConfigurableOptionInfo('kerrigan_presence', f'Controls whether Kerrigan will appear in missions')
+        SOA_PRESENCE = ConfigurableOptionInfo('soa_presence', 'Controls when the Spear of Adun topbar will appear')
+        SOA_IN_NOBUILDS = ConfigurableOptionInfo('soa_in_nobuilds', 'Controls if the Spear of Adun will appera in no-build missions')
+        CONTROL_ALLY = ConfigurableOptionInfo('control_ally', f'Controls whether you gain command of your AI allies')
         MINERALS_PER_CHECK = ConfigurableOptionInfo('minerals_per_check', f'The amount of gas you receive per {ItemNames.STARTING_MINERALS} item')
         GAS_PER_CHECK = ConfigurableOptionInfo('gas_per_check', f'The amount of gas you receive per {ItemNames.STARTING_VESPENE} item')
         SUPPLY_PER_CHECK = ConfigurableOptionInfo('supply_per_check', f'The amount of gas you receive per {ItemNames.STARTING_SUPPLY} item')
-        CONTROL_ALLY = ConfigurableOptionInfo('control_ally', f'Controls whether you gain command of your AI allies')
         FORCED_CAMERA = ConfigurableOptionInfo('forced_camera', 'Controls whether the game can move or lock your camera')
         SKIP_CUTSCENES = ConfigurableOptionInfo('skip_cutscenes', 'Controls whether in-game cutscenes will be skipped')
 
-        WARNING_COLOUR = JSONtoTextParser.color_codes["red"]
+        WARNING_COLOUR = JSONtoTextParser.color_codes["salmon"]
         CMD_COLOUR = JSONtoTextParser.color_codes["slateblue"]
 
         help_text = inspect.cleandoc(f"""
@@ -273,11 +275,15 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         --------------------
         [color={CMD_COLOUR}]{KERRIGAN_PRESENCE.name}[/color]: vanilla | not_present | no_passives -- {KERRIGAN_PRESENCE.description}
           [color={WARNING_COLOUR}]{LOGIC_WARNING}[/color]
+        [color={CMD_COLOUR}]{SOA_PRESENCE.name}[/color]: lotv_protoss | protoss | everywhere | not_present -- {SOA_PRESENCE.description}
+          [color={WARNING_COLOUR}]{LOGIC_WARNING}[/color]
+        [color={CMD_COLOUR}]{SOA_IN_NOBUILDS.name}[/color]: true | false -- {SOA_IN_NOBUILDS.description}
+          [color={WARNING_COLOUR}]{LOGIC_WARNING}[/color]
+        [color={CMD_COLOUR}]{CONTROL_ALLY.name}[/color]: true | false -- {CONTROL_ALLY.description}
+          [color={WARNING_COLOUR}]{LOGIC_WARNING}[/color]
         [color={CMD_COLOUR}]{MINERALS_PER_CHECK.name}[/color]: integer -- {MINERALS_PER_CHECK.description}
         [color={CMD_COLOUR}]{GAS_PER_CHECK.name}[/color]: integer -- {GAS_PER_CHECK.description}
         [color={CMD_COLOUR}]{SUPPLY_PER_CHECK.name}[/color]: integer -- {SUPPLY_PER_CHECK.description}
-        [color={CMD_COLOUR}]{CONTROL_ALLY.name}[/color]: true | false -- {CONTROL_ALLY.description}
-          [color={WARNING_COLOUR}]{LOGIC_WARNING}[/color]
         [color={CMD_COLOUR}]{FORCED_CAMERA.name}[/color]: true | false -- {FORCED_CAMERA.description}
         [color={CMD_COLOUR}]{SKIP_CUTSCENES.name}[/color]: true | false -- {SKIP_CUTSCENES.description}
         --------------------
@@ -298,6 +304,36 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             else:
                 self.output(f"Unknown option value '{option_values[0]}'")
             self.output(f"{KERRIGAN_PRESENCE.name} is '{KerriganPresence.get_option_name(self.ctx.kerrigan_presence)}'")
+        elif option_name == SOA_PRESENCE.name:
+            if not option_values:
+                pass
+            elif option_values[0].lower() == 'lotv_protoss':
+                self.ctx.kerrigan_presence = SpearOfAdunPresence.option_lotv_protoss
+            elif option_values[0].lower() == 'protoss':
+                self.ctx.kerrigan_presence = SpearOfAdunPresence.option_protoss
+            elif option_values[0].lower() == 'everywhere':
+                self.ctx.kerrigan_presence = SpearOfAdunPresence.option_everywhere
+            elif option_values[0].lower() == 'not_present':
+                self.ctx.kerrigan_presence = SpearOfAdunPresence.option_not_present
+            else:
+                self.output(f"Unknown option value '{option_values[0]}'")
+            self.output(f"{SOA_PRESENCE.name} is '{SpearOfAdunPresence.get_option_name(self.ctx.spear_of_adun_presence)}'")
+        elif option_name == SOA_IN_NOBUILDS.name:
+            if not option_values:
+                pass
+            elif option_values[0].lower() in false_values:
+                self.ctx.spear_of_adun_present_in_no_build = 0
+            else:
+                self.ctx.spear_of_adun_present_in_no_build = 1
+            self.output(f"{SOA_IN_NOBUILDS.name} is '{bool(self.ctx.spear_of_adun_present_in_no_build)}'")
+        elif option_name == CONTROL_ALLY.name:
+            if not option_values:
+                pass
+            elif option_values[0].lower() in false_values:
+                self.ctx.take_over_ai_allies = TakeOverAIAllies.option_false
+            else:
+                self.ctx.take_over_ai_allies = TakeOverAIAllies.option_true
+            self.output(f"{CONTROL_ALLY.name} is '{bool(self.ctx.take_over_ai_allies)}'")
         elif option_name == MINERALS_PER_CHECK.name:
             if not option_values:
                 pass
@@ -324,15 +360,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
                     self.ctx.starting_supply_per_item = int(option_values[0], base=0)
                 except ValueError:
                     self.output(f"{option_values[0]} is not a valid integer")
-            self.output(f"{GAS_PER_CHECK.name} is '{self.ctx.starting_supply_per_item}'")
-        elif option_name == CONTROL_ALLY.name:
-            if not option_values:
-                pass
-            elif option_values[0].lower() in false_values:
-                self.ctx.take_over_ai_allies = TakeOverAIAllies.option_false
-            else:
-                self.ctx.take_over_ai_allies = TakeOverAIAllies.option_true
-            self.output(f"{CONTROL_ALLY.name} is '{bool(self.ctx.take_over_ai_allies)}'")
+            self.output(f"{SUPPLY_PER_CHECK.name} is '{self.ctx.starting_supply_per_item}'")
         elif option_name == FORCED_CAMERA.name:
             # Flipping the truth-value here to avoid double-negatives
             if not option_values:

--- a/worlds/sc2/Items.py
+++ b/worlds/sc2/Items.py
@@ -10,7 +10,7 @@ from . import ItemNames
 
 
 class ItemData(typing.NamedTuple):
-    code: typing.Optional[int]
+    code: int
     type: str
     number: int  # Important for bot commands to send the item into the game
     race: SC2Race

--- a/worlds/sc2/Options.py
+++ b/worlds/sc2/Options.py
@@ -736,7 +736,7 @@ class MasteryLocations(LocationInclusion):
 
 class MineralsPerItem(Range):
     """
-    Configures how many minerals per resource item are given.
+    Configures how many minerals are given per resource item.
     """
     display_name = "Minerals Per Item"
     range_start = 0
@@ -746,7 +746,7 @@ class MineralsPerItem(Range):
 
 class VespenePerItem(Range):
     """
-    Configures how many vespene per resource item is given.
+    Configures how much vespene gas is given per resource item.
     """
     display_name = "Vespene Per Item"
     range_start = 0
@@ -756,7 +756,7 @@ class VespenePerItem(Range):
 
 class StartingSupplyPerItem(Range):
     """
-    Configures how many starting supply per item is given.
+    Configures how much starting supply per is given per item.
     """
     display_name = "Starting Supply Per Item"
     range_start = 0


### PR DESCRIPTION
* Added a sorted and formatted `/received` command
* Moved many misc options to an `/option` command
* Added a helper for outputting formatted / coloured text that still displays fine in command-line
  * This is based on Berserker's core [PR #2715](https://github.com/ArchipelagoMW/Archipelago/pull/2715), which displays `/received` with coloured text. Unfortunately, these core utilities don't support filtering bold / underline tags to look good in CLI.

## What is this fixing or adding?
Making the client text commands a little nicer
* Moving misc options into sub-commands keeps the help text a little leaner and more manageable
* `/received` always became unusable past ~40 items -- this makes it better
* Currently `/received` colours all items, locations, and players, with extra colours for section headings and unobtained items that have child items that are obtains. I find this to be too many colours and so would be in favour of making all received items show in one colour (progression's plum is a good one, but any item colour works). Formatting things ourselves can also open the door to displaying the description in a tooltip.

### TODO
- [x] `/received` should properly display the number of items received if there are multiply (currently only displays one)
~~- [ ] Filter arguments for the `/received` command~~
  * "I'm personally interested in searching by race, partial item name, and item group"  -- Salzkorn
  * ~~This would better happen once we move unit groups to be enums; I started work on that and quickly discovered it would be a big ask that could likely introduce bugs; it's better to wait for next release.~~
  * After more discussion with Salzkorn, one of us will likely revisit this sooner. We can either hook straight into the item type names (I don't like this, as categories like Armory 2 vs Armory 4 aren't very user-friendly), or we find some other dimension to filter by. I'd still like to leave that for a future PR

## How was this tested?
Played around with the command line a bunch. Would be even nicer if [Text processor echoing](https://github.com/ArchipelagoMW/Archipelago/pull/2760) was merged to AP main.

## If this makes graphical changes, please attach screenshots.
`/option`:
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/c530e644-be4c-43d5-ba11-16e8cbaff1c5)

`/option kerrigan_presence`:
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/7a6bb69d-561a-42ba-99ed-d859ab5fc643)

`/option kerrigan_presence vanilla`:
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/e1d1f4f3-2327-4df2-8185-aa45bb58a635)

`/option gas_per_check`:
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/2544548a-e308-43ea-9b11-581acb1d910f)

`/received`:
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/b236862d-ae3f-4d84-b84a-452befe00c48)

`/received ap`: ("ap" = any + protoss)
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/7c6a21a9-a71e-44da-9ef3-c4f42cdaf6ce)

Text still prints well in command-line:
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/88beb492-aa82-4aa9-b3f1-4f6df0838266)
