### PR TITLE
Generation: Add reusable items to second pass item placement

### DIFF
--- a/worlds/sc2/PoolFilter.py
+++ b/worlds/sc2/PoolFilter.py
@@ -274,7 +274,7 @@ class ValidInventory:
             unit_nb_upgrades = {}
             for item in inventory:
                 cItem = item_list[item.name]
-                if cItem.type in UPGRADABLE_ITEMS and item.name not in unit_avail_upgrades:
+                if cItem.parent_item in UPGRADABLE_ITEMS and item.name not in unit_avail_upgrades:
                     unit_avail_upgrades[item.name] = []
                     unit_nb_upgrades[item.name] = 0
                 elif cItem.parent_item is not None:
@@ -287,7 +287,7 @@ class ValidInventory:
             # For those two categories, we count them but dont include them in removal
             for item in locked_items + self.existing_items:
                 cItem = item_list[item.name]
-                if cItem.type in UPGRADABLE_ITEMS and item.name not in unit_avail_upgrades:
+                if cItem.parent_item in UPGRADABLE_ITEMS and item.name not in unit_avail_upgrades:
                     unit_avail_upgrades[item.name] = []
                     unit_nb_upgrades[item.name] = 0
                 elif cItem.parent_item is not None:
@@ -346,6 +346,7 @@ class ValidInventory:
                 removable_generic_items.append(item)
 
         # Main cull process
+        unused_items = [] # Reusable items for the second pass
         while len(inventory) + len(locked_items) > inventory_size:
             if len(inventory) == 0:
                 # There are more items than locations and all of them are already locked due to YAML or logic.
@@ -389,7 +390,9 @@ class ValidInventory:
                             continue
                         attempt_removal(item_to_remove)
             else:
-                attempt_removal(item)
+                # Unimportant upgrades may be added again in the second pass
+                if attempt_removal(item):
+                    unused_items.append(item.name)
 
         # Removing extra dependencies
         # WoL
@@ -475,7 +478,9 @@ class ValidInventory:
         replacement_items = [item for item in self.item_pool
                              if (item not in inventory
                                  and item not in self.locked_items
-                                 and item.name in second_pass_placeable_items)]
+                                 and (
+                                     item.name in second_pass_placeable_items
+                                     or item.name in unused_items))]
         self.multiworld.random.shuffle(replacement_items)
         while len(inventory) < inventory_size and len(replacement_items) > 0:
             item = replacement_items.pop()


### PR DESCRIPTION
## What is this fixing or adding?
Currently, some YAMLs are getting a lot of starting resources when they could have extra upgrades.
This PR collects a subset of culled items and allows them back into the item pool in the second pass, alongside the generic filler items.
I can make the following assertions about these items:
* They are not excluded or locked, because they are in the inventory during culling
* They are sometimes generic items, but not ones reserved by the `ensure_generic_items` option, because those are locked
* They respect the minimum and maximum upgrade counts, because the minimum option locks items and the maximum's removed items are not used
* They do not have children
  * This is a design choice because otherwise the second pass would have to respect min/max upgrade options

For these reasons, the chosen items should be safe to return to the item pool for the second pass.
With these changes, the YAML I tested with went from generating worlds with 5-20 starting resource items, to 0 starting resource items with 5-10 extra unused items to spare.

This also fixes a bug preventing the `max_number_of_upgrades` option from working as intended.

## How was this tested?
Genning a couple of times with a previously affected YAML and comparing item pools.