### PR TITLE
Fix Spear of Adun & Kerrigan Primal Form exclusion options

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -178,13 +178,13 @@ def get_excluded_items(multiworld: MultiWorld, player: int) -> Set[str]:
 
     # Nova gear exclusion if NCO not in campaigns
     if SC2Campaign.NCO not in enabled_campaigns:
-        excluded_items = excluded_items.union(nova_equipment)
+        excluded_items = excluded_items.update(nova_equipment)
 
     kerrigan_presence = get_option_value(multiworld, player, "kerrigan_presence")
     # no Kerrigan & remove all passives => remove all abilities
     if kerrigan_presence == KerriganPresence.option_not_present_and_no_passives:
         for tier in range(7):
-            smart_exclude(kerrigan_actives[tier].union(kerrigan_passives[tier]), 0)
+            smart_exclude(kerrigan_actives[tier].update(kerrigan_passives[tier]), 0)
     else:
         # no Kerrigan, but keep non-Kerrigan passives
         if kerrigan_presence == KerriganPresence.option_not_present:
@@ -195,11 +195,11 @@ def get_excluded_items(multiworld: MultiWorld, player: int) -> Set[str]:
     # SOA exclusion, other cases are handled by generic race logic
     if (soa_presence == SpearOfAdunPresence.option_lotv_protoss and SC2Campaign.LOTV not in enabled_campaigns) \
             or soa_presence == SpearOfAdunPresence.option_not_present:
-        excluded_items.union(spear_of_adun_calldowns)
-    if soa_autocast_presence == SpearOfAdunAutonomouslyCastAbilityPresence.option_lotv_protoss \
-            and SC2Campaign.LOTV not in enabled_campaigns \
+        excluded_items.update(spear_of_adun_calldowns)
+    if (soa_autocast_presence == SpearOfAdunAutonomouslyCastAbilityPresence.option_lotv_protoss \
+            and SC2Campaign.LOTV not in enabled_campaigns) \
             or soa_autocast_presence == SpearOfAdunAutonomouslyCastAbilityPresence.option_not_present:
-        excluded_items.union(spear_of_adun_castable_passives)
+        excluded_items.update(spear_of_adun_castable_passives)
 
     return excluded_items
 


### PR DESCRIPTION
## What is this fixing or adding?
- Spear of Adun exclusion options now work
- Primal Form is now excluded if Kerrigan is not present

As a note, we have logic for checking that no item is both in `locked_items` and `excluded_items`, but this doesn't respect items being excluded by other options and currently just quietly succeeds with locked items being excluded. For example, if I lock a Spear of Adun ability but turn the Spear of Adun off, the locked ability is not in the world. I don't know if this is desired behavior or if it should fail to generate.

Also, we're currently only using `smart_exclude` with 0 items to keep, which is equivalent to `excluded_items.update`. I don't want to throw out working code for a bugfix PR, but it would be a small performance improvement to exchange them (mostly the 7 `random.sample` calls, I'd imagine), so I'll leave the decision to you.

## How was this tested?
Generating with a YAML using these options and checking the spoiler log.
