### PR TITLE
Remove some redundant code

### DIFF
--- a/worlds/sc2/Regions.py
+++ b/worlds/sc2/Regions.py
@@ -606,8 +606,6 @@ def setup_final_location(final_location, location_cache):
     # Final location should be near the end of the cache
     for i in range(len(location_cache) - 1, -1, -1):
         if location_cache[i].name == final_location:
-            location_cache[i].locked = True
-            location_cache[i].event = True
             location_cache[i].address = None
             break
 
@@ -616,10 +614,6 @@ def create_location(player: int, location_data: LocationData, region: Region,
                     location_cache: List[Location]) -> Location:
     location = Location(player, location_data.name, location_data.code, region)
     location.access_rule = location_data.rule
-
-    if id is None:
-        location.event = True
-        location.locked = True
 
     location_cache.append(location)
 


### PR DESCRIPTION
## What is this fixing or adding?
This removes us manually setting event/locked flags on locations.

For `create_location`, this was never even called because `id` is a built-in function and thus never `None`, and we never change the variable locally.

For `setup_final_location`, we never check for location event/locked flags in the world, and any location with `address is None` is caught by `__init__.setup_events`, which calls `Location.place_locked_item`, which in turn sets both the event and locked flags, so us manually setting it on any location with address `None` is redundant.

## How was this tested?
A few generations and checking spoiler logs for abnormalities.