### PR TITLE
sc2: Updating setup docs and top-level description

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -22,24 +22,22 @@ from .MissionTables import MissionInfo, SC2Campaign, lookup_name_to_mission, SC2
 
 
 class Starcraft2WebWorld(WebWorld):
-    # TODO update the guide
     setup = Tutorial(
         "Multiworld Setup Guide",
         "A guide to setting up the Starcraft 2 randomizer connected to an Archipelago Multiworld",
         "English",
         "setup_en.md",
         "setup/en",
-        ["TheCondor"]
+        ["TheCondor", "Phaneros"]
     )
 
     tutorials = [setup]
 
 
 class SC2World(World):
-    # TODO update this description
     """
-    StarCraft II: Wings of Liberty is a science fiction real-time strategy video game developed and published by Blizzard Entertainment.
-    Command Raynor's Raiders in collecting pieces of the Keystone in order to stop the zerg threat posed by the Queen of Blades.
+    StarCraft II is a science fiction real-time strategy video game developed and published by Blizzard Entertainment.
+    Play as one of three factions across four campaigns in a battle for supremacy of the Koprulu Sector.
     """
 
     game = "Starcraft 2"

--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -3,29 +3,38 @@
 ## What does randomization do to this game?
 
 The following unlocks are randomized as items:
-1. Your ability to build any non-worker unit (including Marines!).
-2. Your ability to upgrade infantry weapons, infantry armor, vehicle weapons, etc.
-3. All armory upgrades
-4. All laboratory upgrades
-5. All mercenaries
-6. Small boosts to your starting mineral and vespene gas totals on each mission
+1. Your ability to build any non-worker unit.
+2. Unit specific upgrades including some combinations not available in the vanilla campaigns, such as both strain choices simultaneously for Zerg and every Spear of Adun upgrade simultaneously for Protoss!
+3. Your ability to get the generic unit upgrades, such as attack and armour upgrades.
+4. Other miscellaneous upgrades such as laboratory upgrades and mercenaries for Terran, Kerrigan levels and upgrades for Zerg, and Spear of Adun upgrades for Protoss.
+5. Small boosts to your starting mineral, vespene gas, and supply totals on each mission.
 
-You find items by making progress in bonus objectives (like by rescuing allies in 'Zero Hour') and by completing
-missions. When you receive items, they will immediately become available, even during a mission, and you will be
-notified via a text box in the top-right corner of the game screen. (The text client for StarCraft 2 also records all
-items in all worlds.)
+You find items by making progress in these categories:
+* Completing missions
+* Completing bonus objectives (like by gathering lab research material in Wings of Liberty)
+* Reaching milestones in the mission, such as completing part of a main objective
+* Completing challenges based on achievements in the base game, such as clearing all Zerg on Devil's Playground
 
-Missions are launched only through the text client. The Hyperion is never visited. Additionally, credits are not used.
+Except for mission completion, these categories can be disabled in the game's settings. For instance, you can disable getting items for reaching required milestones.
+
+When you receive items, they will immediately become available, even during a mission, and you will be
+notified via a text box in the top-right corner of the game screen. Item unlocks are also logged in the Archipelago client.
+
+Missions are launched through the Starcraft 2 Archipelago client, through the Starcraft 2 Launcher tab. The between mission segments on the Hyperion, the Leviathon, and the Spear of Adun are not included. Additionally, metaprogression currencies such as credits and Solarite are not used.
 
 ## What is the goal of this game when randomized?
 
-The goal is to beat the final mission: 'All In'. The config file determines which variant you must complete.
+The goal is to beat the final mission in the mission order. The yaml configuration file controls the mission order and how missions are shuffled.
 
 ## What non-randomized changes are there from vanilla Starcraft 2?
 
 1. Some missions have more vespene geysers available to allow a wider variety of units.
-2. Starports no longer require Factories in order to be built.
-3. In 'A Sinister Turn' and 'Echoes of the Future', you can research Protoss air weapon/armor upgrades.
+2. Many new units and upgrades have been added as items, coming from co-op, melee, later campaigns, later expansions, brood war, and original ideas.
+3. Higher-tech production structures, including Factories, Starports, Robotics Facilities, and Stargates, no longer have tech requirements.
+4. Zerg missions have been adjusted to give the player a starting Lair where they would only have Hatcheries.
+5. Upgrades with a downside have had the downside removed, such as automated refineries costing more or tech reactors taking longer to build.
+6. Unit collision within the vents in Enemy Within has been adjusted to allow larger units to travel through them without getting stuck in odd places.
+7. Several vanilla bugs have been fixed.
 
 ## Which of my items can be in another player's world?
 
@@ -35,20 +44,21 @@ for more information on how to change this.
 
 ## Unique Local Commands
 
-The following commands are only available when using the Starcraft 2 Client to play with Archipelago.
+The following commands are only available when using the Starcraft 2 Client to play with Archipelago. You can list them any time in the client with `/help`.
 
-- `/difficulty [difficulty]` Overrides the difficulty set for the world.
-  - Options: casual, normal, hard, brutal
-- `/game_speed [game_speed]` Overrides the game speed for the world
-  - Options: default, slower, slow, normal, fast, faster
-- `/color [color]` Changes your color (Currently has no effect)
-  - Options: white, red, blue, teal, purple, yellow, orange, green, lightpink, violet, lightgrey, darkgreen, brown,
-    lightgreen, darkgrey, pink, rainbow, random, default
-- `/disable_mission_check` Disables the check to see if a mission is available to play. Meant for co-op runs where one
-  player can play the next mission in a chain the other player is doing.
-- `/play [mission_id]` Starts a Starcraft 2 mission based off of the mission_id provided
-- `/available` Get what missions are currently available to play
-- `/unfinished` Get what missions are currently available to play and have not had all locations checked
-- `/set_path [path]` Menually set the SC2 install directory (if the automatic detection fails)
-- `/download_data` Download the most recent release of the necassry files for playing SC2 with Archipelago. Will
-  overwrite existing files
+* `/download_data` Download the most recent release of the necessary files for playing SC2 with Archipelago. Will overwrite existing files
+* `/difficulty [difficulty]` Overrides the difficulty set for the world.
+    * Options: casual, normal, hard, brutal
+* `/game_speed [game_speed]` Overrides the game speed for the world
+    * Options: default, slower, slow, normal, fast, faster
+* `/color [faction] [color]` Changes your color for one of your playable factions.
+    * Faction options: raynor, kerrigan, primal, protoss, nova
+    * Color options: white, red, blue, teal, purple, yellow, orange, green, lightpink, violet, lightgrey, darkgreen, brown, lightgreen, darkgrey, pink, rainbow, random, default
+* `/option [option_name] [option_value]` Sets an option normally controlled by your yaml after generation.
+    * Run without arguments to list all options.
+    * Options pertain to automatic cutscene skipping, Kerrigan presence, Spear of Adun presence, starting resource amounts, controlling AI allies, etc.
+* `/disable_mission_check` Disables the check to see if a mission is available to play. Meant for co-op runs where one player can play the next mission in a chain the other player is doing.
+* `/play [mission_id]` Starts a Starcraft 2 mission based off of the mission_id provided
+* `/available` Get what missions are currently available to play
+* `/unfinished` Get what missions are currently available to play and have not had all locations checked
+* `/set_path [path]` Manually set the SC2 install directory (if the automatic detection fails)

--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -56,7 +56,7 @@ An empty list is just a matching pair of square brackets: `[]`. That's the defau
 
 #### How do I specify items for the starting inventory?
 
-The starting inventory is a YAML mapping rather than a list, which associates an item with the amount you start with. The syntax looks they item name, followed by a colon, then a whitespace character, and then the value:
+The starting inventory is a YAML mapping rather than a list, which associates an item with the amount you start with. The syntax looks like the item name, followed by a colon, then a whitespace character, and then the value:
 
 ```yaml
 start_inventory:

--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -7,12 +7,10 @@ to obtain a config file for StarCraft 2.
 
 - [StarCraft 2](https://starcraft2.com/en-us/)
 - [The most recent Archipelago release](https://github.com/ArchipelagoMW/Archipelago/releases)
-- [StarCraft 2 AP Maps and Data](https://github.com/Ziktofel/Archipelago-SC2-data/releases)
 
 ## How do I install this randomizer?
 
-1. Install StarCraft 2 and Archipelago using the first two links above. (The StarCraft 2 client for Archipelago is
-   included by default.)
+1. Install StarCraft 2 and Archipelago using the links above. The StarCraft 2 Archipelago client is downloaded by the Archipelago installer.
    - Linux users should also follow the instructions found at the bottom of this page 
      (["Running in Linux"](#running-in-linux)).
 2. Run ArchipelagoStarcraft2Client.exe.
@@ -21,25 +19,66 @@ to obtain a config file for StarCraft 2.
 
 ## Where do I get a config file (aka "YAML") for this game?
 
-The [Player Settings](https://archipelago.gg/games/Starcraft%202%20Wings%20of%20Liberty/player-settings) page on this
-website allows you to choose your personal settings for the randomizer and download them into a config file. Remember
-the name you type in the `Player Name` box; that's the "slot name" the client will ask you for when you attempt to
-connect!
+Yaml files are configuration files that tell Archipelago how you'd like your game to be randomized, even if you're only using default settings.
+When you're setting up a multiworld, every world needs its own yaml file.
 
-### And why do I need a config file?
+There are three basic ways to get a yaml:
+* You can go to the [Player Options](https://archipelago.gg/games/Starcraft%202/player-options) page, set your options in the GUI, and export the yaml.
+* You can generate a template, either by downloading it from the [Player Options](https://archipelago.gg/games/Starcraft%202/player-options) page or by generating it from the Launcher (ArchipelagoLauncher.exe). The template includes descriptions of each option, you just have to edit it in your text editor of choice.
+* You can ask someone else to share their yaml to use it for yourself or adjust it as you wish.
 
-Config files tell Archipelago how you'd like your game to be randomized, even if you're only using default settings.
-When you're setting up a multiworld, every world needs its own config file.
-Check out [Creating a YAML](https://archipelago.gg/tutorial/Archipelago/setup/en#creating-a-yaml) for more information.
+Remember the name you enter in the options page or in the yaml file, you'll need it to connect later!
+
+Note that the basic Player Options page doesn't allow you to change all advanced options, such as excluding particular units or upgrades. Go through the [Weighted Options](https://archipelago.gg/weighted-options) page for that.
+
+Check out [Creating a YAML](https://archipelago.gg/tutorial/Archipelago/setup/en#creating-a-yaml) for more game-agnostic information.
+
+### Common yaml questions
+#### How do I know I set my yaml up correctly?
+
+The simplest way to check is to test it out. Save your yaml to the Players/ folder within your Archipelago installation and run ArchipelagoGenerate.exe. You should see a new .zip file within the output/ folder of your Archipelago installation if things worked correctly. It's advisable to run ArchipelagoGenerate through a terminal so that you can see the printout, which will include any errors and the precise output file name if it's successful. If you don't like terminals, you can also check the log file in the logs/ folder.
+
+#### What does Progression Balancing do?
+
+For Starcraft 2, not much. It's an Archipelago-wide option meant to shift required items earlier in the playthrough, but Starcraft 2 tends to be much more open in what items you can use. As such, this adjustment isn't very noticeable. It can also increase generation times, so we generally recommend turning it off.
+
+#### How do I specify items in a list, like in excluded items?
+
+You can look up the syntax for yaml collections in the [YAML specification](https://yaml.org/spec/1.2.2/#21-collections). For lists, every item goes on its own line, started with a hyphen:
+
+```yaml
+excluded_items:
+  - Battlecruiser
+  - Drop-Pods (Kerrigan Tier 7)
+```
+
+An empty list is just a matching pair of square brackets: `[]`. That's the default value in the template, which should let you know to use this syntax.
+
+#### How do I specify items for the starting inventory?
+
+The starting inventory is a YAML mapping rather than a list, which associates an item with the amount you start with. The syntax looks they item name, followed by a colon, then a whitespace character, and then the value:
+
+```yaml
+start_inventory:
+  Micro-Filtering: 1
+  Additional Starting Vespene: 5
+```
+
+An empty mapping is just a matching pair of curly braces: `{}`. That's the default value in the template, which should let you know to use this syntax.
+
+#### How do I know the exact names of items?
+
+You can look up a complete list if item names in the [Icon Repository](https://matthewmarinets.github.io/ap_sc2_icons/).
 
 ## How do I join a MultiWorld game?
 
 1. Run ArchipelagoStarcraft2Client.exe.
    - macOS users should instead follow the instructions found at ["Running in macOS"](#running-in-macos) for this step only.
 2. Type `/connect [server ip]`.
-3. Type your slot name and the server's password when prompted.
-4. Once connected, switch to the 'StarCraft 2 Launcher' tab in the client. There, you can see every mission. By default,
-   only 'Liberation Day' will be available at the beginning. Just click on a mission to start it!
+   - If you're running through the website, the server IP should be displayed near the top of the room page.
+3. Type your slot name from your YAML when prompted.
+4. If the server has a password, enter that when prompted.
+5. Once connected, switch to the 'StarCraft 2 Launcher' tab in the client. There, you can see all the missions in your world. Unreachable missions will have greyed-out text. Just click on an available mission to start it!
 
 ## The game isn't launching when I try to start a mission.
 


### PR DESCRIPTION
## What is this fixing or adding?
Updating the setup guide and the top-level description. Also updated game info page, based on a first draft from genderdruid.

I noticed on the game info page, the nested list items in the commands list didn't properly show up as listed in the output. After playing with it a bit, it looks like they have to be double-indented (ie 4 spaces) to properly get picked up as nested for some reason.

## How was this tested?
Ran local webhost

## If this makes graphical changes, please attach screenshots.
Setup page:
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/c0e319cc-b753-4806-85af-1fbf2380156d)
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/92cd6e48-eb66-4a98-9394-60b043af2189)

Game info page:
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/7d3d0994-069b-4366-ab02-d23a2851280d)
