### PR TITLE
sc2: Fixed wrong description for ultralisk organic carapace

### DIFF
--- a/worlds/sc2/ItemDescriptions.py
+++ b/worlds/sc2/ItemDescriptions.py
@@ -552,7 +552,7 @@ item_descriptions = {
     ItemNames.SWARM_HOST_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(ItemNames.SWARM_HOST),
     ItemNames.ULTRALISK_ANABOLIC_SYNTHESIS: "Ultralisks gain increased movement speed.",
     ItemNames.ULTRALISK_CHITINOUS_PLATING: "Ultralisks gain +2 armor.",
-    ItemNames.ULTRALISK_ORGANIC_CARAPACE: "Ultralisks gain +100 armor.",
+    ItemNames.ULTRALISK_ORGANIC_CARAPACE: "Ultralisks gain +100 life.",
     ItemNames.ULTRALISK_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(ItemNames.ULTRALISK),
     ItemNames.DEVOURER_CORROSIVE_SPRAY: "Devourer attacks will now deal area damage.",
     ItemNames.DEVOURER_GAPING_MAW: "Devourer's attack speed increased by 25%.",


### PR DESCRIPTION

## What is this fixing or adding?
Incorrect description -- pointed out by sraw in the discord.

## How was this tested?
My description export script still worked, so there are no syntax errors. I verified the upgrade affected life by looking at the upgrade data XML manually.

## If this makes graphical changes, please attach screenshots.
