### PR TITLE
sc2: adjusted supply/resource option range maxima

### DIFF
--- a/worlds/sc2/Options.py
+++ b/worlds/sc2/Options.py
@@ -761,7 +761,7 @@ class StartingSupplyPerItem(Range):
     """
     display_name = "Starting Supply Per Item"
     range_start = 0
-    range_end = 8
+    range_end = 16
     default = 2
 
 

--- a/worlds/sc2/Options.py
+++ b/worlds/sc2/Options.py
@@ -741,7 +741,7 @@ class MineralsPerItem(Range):
     """
     display_name = "Minerals Per Item"
     range_start = 0
-    range_end = 500
+    range_end = 200
     default = 25
 
 
@@ -751,7 +751,7 @@ class VespenePerItem(Range):
     """
     display_name = "Vespene Per Item"
     range_start = 0
-    range_end = 500
+    range_end = 200
     default = 25
 
 
@@ -761,8 +761,8 @@ class StartingSupplyPerItem(Range):
     """
     display_name = "Starting Supply Per Item"
     range_start = 0
-    range_end = 200
-    default = 5
+    range_end = 8
+    default = 2
 
 
 @dataclass


### PR DESCRIPTION
## What is this fixing or adding?
Someone in the chat recently set resources per check / supply per check to random, and got some 80 supply per item. I'd call this unreasonable behaviour for a simple, encouraged option ("random"). Setting maximum supply range down to 8 so random behaves better. Higher supply per item is still achievable with `/option`.

## How was this tested?
Attempted to generate with different settings. Vespene over 200 failed to generate, but was okay below. Starting supply 8 was okay, 10 failed.

## If this makes graphical changes, please attach screenshots.
