### PR TITLE
SC2: Tagging Guardian Shell as SoA passive

### DIFF
--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -833,6 +833,11 @@ def calculate_items(ctx: SC2Context) -> typing.Dict[SC2Race, typing.List[int]]:
         if item_data.quantity == 1:
             accumulators[item_data.race][item_data.type.flag_word] |= 1 << item_data.number
 
+            # Guardian Shell breaks without SoA on version 4+, but can be generated without SoA on version 3
+            if ctx.slot_data_version < 4 and name == ItemNames.GUARDIAN_SHELL \
+                    and ctx.spear_of_adun_autonomously_cast_ability_presence != SpearOfAdunAutonomouslyCastAbilityPresence.option_everywhere:
+                ctx.spear_of_adun_autonomously_cast_ability_presence = SpearOfAdunAutonomouslyCastAbilityPresence.option_protoss
+
         # exists multiple times
         elif item_data.quantity > 1:
             flaggroup = item_data.type.flag_word

--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -833,11 +833,6 @@ def calculate_items(ctx: SC2Context) -> typing.Dict[SC2Race, typing.List[int]]:
         if item_data.quantity == 1:
             accumulators[item_data.race][item_data.type.flag_word] |= 1 << item_data.number
 
-            # Guardian Shell breaks without SoA on version 4+, but can be generated without SoA on version 3
-            if ctx.slot_data_version < 4 and name == ItemNames.GUARDIAN_SHELL \
-                    and ctx.spear_of_adun_autonomously_cast_ability_presence != SpearOfAdunAutonomouslyCastAbilityPresence.option_everywhere:
-                ctx.spear_of_adun_autonomously_cast_ability_presence = SpearOfAdunAutonomouslyCastAbilityPresence.option_protoss
-
         # exists multiple times
         elif item_data.quantity > 1:
             flaggroup = item_data.type.flag_word
@@ -974,6 +969,9 @@ def caclulate_soa_options(ctx: SC2Context) -> int:
         soa_autocasts_presence_value = 2
     elif ctx.spear_of_adun_autonomously_cast_ability_presence == SpearOfAdunAutonomouslyCastAbilityPresence.option_everywhere:
         soa_autocasts_presence_value = 3
+    # Guardian Shell breaks without SoA on version 4+, but can be generated without SoA on version 3
+    if ctx.slow_data_version < 4 and soa_autocasts_presence_value < 2:
+        soa_autocasts_presence_value = 2
     options |= soa_autocasts_presence_value << 3
 
     # Bit 5

--- a/worlds/sc2/Items.py
+++ b/worlds/sc2/Items.py
@@ -1853,6 +1853,7 @@ spear_of_adun_calldowns = {
 spear_of_adun_castable_passives = {
     ItemNames.RECONSTRUCTION_BEAM,
     ItemNames.OVERWATCH,
+    ItemNames.GUARDIAN_SHELL,
 }
 
 nova_equipment = {


### PR DESCRIPTION
## What is this fixing or adding?
Related to https://github.com/Ziktofel/Archipelago-SC2-data/pull/119 

Adding Guardian Shell to the list of SoA passives so that it isn't added to the pool when those passives are disabled.