### PR TITLE
sc2: Reduced clutter of initial startup messages

### DIFF
--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -464,11 +464,11 @@ class StarcraftClientProcessor(ClientCommandProcessor):
     def _cmd_download_data(self) -> bool:
         """Download the most recent release of the necessary files for playing SC2 with
         Archipelago. Will overwrite existing files."""
-        pool.submit(self._download_data)
+        pool.submit(self._download_data, self.ctx)
         return True
 
     @staticmethod
-    def _download_data() -> bool:
+    def _download_data(ctx: SC2Context) -> bool:
         if "SC2PATH" not in os.environ:
             check_game_install_path()
 
@@ -493,6 +493,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         else:
             sc2_logger.warning("Download aborted/failed. Read the log for more information.")
             return False
+        ctx.data_out_of_date = False
         return True
 
 
@@ -523,6 +524,7 @@ class SC2Context(CommonContext):
         super(SC2Context, self).__init__(*args, **kwargs)
         self.raw_text_parser = SC2JSONtoTextParser(self)
 
+        self.data_out_of_date: bool = False
         self.difficulty = -1
         self.game_speed = -1
         self.disable_forced_camera = 0
@@ -674,6 +676,7 @@ class SC2Context(CommonContext):
                         ("Run ").coloured("/download_data", colour="slateblue")
                         (" to install.")
                     ).send(self)
+                    self.data_out_of_date = True
             elif maps_present:
                 (
                     ColouredMessage()
@@ -681,6 +684,7 @@ class SC2Context(CommonContext):
                     ("Run ").coloured("/download_data", colour="slateblue")
                     (" to install.")
                 ).send(self)
+                self.data_out_of_date = True
 
     @staticmethod
     def parse_mission_info(mission_info: dict[str, typing.Any]) -> MissionInfo:

--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -669,10 +669,18 @@ class SC2Context(CommonContext):
                     current_ver = f.read()
                     sc2_logger.debug(f"Current version: {current_ver}")
                 if is_mod_update_available(DATA_REPO_OWNER, DATA_REPO_NAME, DATA_API_VERSION, current_ver):
-                    sc2_logger.info("NOTICE: Update for required files found. Run /download_data to install.")
+                    (
+                        ColouredMessage().coloured("NOTICE: Update for required files found. ", colour="red")
+                        ("Run ").coloured("/download_data", colour="slateblue")
+                        (" to install.")
+                    ).send(self)
             elif maps_present:
-                sc2_logger.warning("NOTICE: Your map files may be outdated (version number not found). "
-                                   "Run /download_data to update them.")
+                (
+                    ColouredMessage()
+                    .coloured("NOTICE: Your map files may be outdated (version number not found). ", colour="red")
+                    ("Run ").coloured("/download_data", colour="slateblue")
+                    (" to install.")
+                ).send(self)
 
     @staticmethod
     def parse_mission_info(mission_info: dict[str, typing.Any]) -> MissionInfo:
@@ -1527,12 +1535,12 @@ def is_mod_installed_correctly() -> bool:
         sc2_logger.warning(f"Missing {len(missing_maps)} map files.")
         needs_files = True
     else:  # Must be no maps missing
-        sc2_logger.info(f"All maps found in {mapdir}.")
+        sc2_logger.debug(f"All maps found in {mapdir}.")
 
     # Check for mods.
     for modfile in modfiles:
         if os.path.isfile(modfile) or os.path.isdir(modfile):
-            sc2_logger.info(f"Archipelago mod found at {modfile}.")
+            sc2_logger.debug(f"Archipelago mod found at {modfile}.")
         else:
             sc2_logger.warning(f"Archipelago mod could not be found at {modfile}.")
             needs_files = True

--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -60,6 +60,9 @@ class CampaignScroll(ScrollView):
 class MultiCampaignLayout(GridLayout):
     pass
 
+class DownloadDataWarningMessage(Label):
+    pass
+
 class CampaignLayout(GridLayout):
     pass
 
@@ -139,9 +142,8 @@ class SC2Manager(GameManager):
         self.campaign_panel.clear_widgets()
         if self.ctx.data_out_of_date:
             self.campaign_panel.add_widget(Label(text="", padding=[0, 5, 0, 5]))
-            warning_label = Label(
-                text="[color=d23300]Map/Mod data is out of date. Run /download_data in the client[/color]",
-                markup=True,
+            warning_label = DownloadDataWarningMessage(
+                text="Map/Mod data is out of date. Run /download_data in the client",
                 padding=[0, 25, 0, 25],
             )
             self.campaign_scroll_panel.border_on = True

--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -11,7 +11,7 @@ from kivy.uix.label import Label
 from kivy.uix.button import Button
 from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.scrollview import ScrollView
-from kivy.properties import StringProperty
+from kivy.properties import StringProperty, BooleanProperty
 
 from worlds.sc2.Client import SC2Context, calc_unfinished_missions, parse_unlock
 from worlds.sc2.MissionTables import lookup_id_to_mission, lookup_name_to_mission, campaign_race_exceptions, \
@@ -55,7 +55,7 @@ class MissionButton(HoverableButton):
         return App.get_running_app().ctx
 
 class CampaignScroll(ScrollView):
-    pass
+    border_on = BooleanProperty(False)
 
 class MultiCampaignLayout(GridLayout):
     pass
@@ -76,8 +76,10 @@ class SC2Manager(GameManager):
     ]
     base_title = "Archipelago Starcraft 2 Client"
 
-    campaign_panel: Optional[CampaignLayout] = None
+    campaign_panel: Optional[MultiCampaignLayout] = None
+    campaign_scroll_panel: Optional[CampaignScroll] = None
     last_checked_locations: Set[int] = set()
+    last_data_out_of_date = False
     mission_id_to_button: Dict[int, MissionButton] = {}
     launching: Union[bool, int] = False  # if int -> mission ID
     refresh_from_launching = True
@@ -99,6 +101,7 @@ class SC2Manager(GameManager):
 
         panel = TabbedPanelItem(text="Starcraft 2 Launcher")
         panel.content = CampaignScroll()
+        self.campaign_scroll_panel = panel.content
         self.campaign_panel = MultiCampaignLayout()
         panel.content.add_widget(self.campaign_panel)
 
@@ -109,149 +112,173 @@ class SC2Manager(GameManager):
         return container
 
     def build_mission_table(self, dt) -> None:
-        if (not self.launching and (not self.last_checked_locations == self.ctx.checked_locations or
-                                    not self.refresh_from_launching)) or self.first_check:
-            assert self.campaign_panel is not None
-            self.refresh_from_launching = True
-
-            self.campaign_panel.clear_widgets()
-            if self.ctx.mission_req_table:
-                self.last_checked_locations = self.ctx.checked_locations.copy()
-                self.first_check = False
-                self.first_mission = get_first_mission(self.ctx.mission_req_table).mission_name
-
-                self.mission_id_to_button = {}
-
-                available_missions, unfinished_missions = calc_unfinished_missions(self.ctx)
-
-                multi_campaign_layout_height = 0
-
-                for campaign, missions in sorted(self.ctx.mission_req_table.items(), key=lambda item: item[0].id):
-                    categories: Dict[str, List[str]] = {}
-
-                    # separate missions into categories
-                    for mission_index in missions:
-                        mission_info = self.ctx.mission_req_table[campaign][mission_index]
-                        if mission_info.category not in categories:
-                            categories[mission_info.category] = []
-
-                        categories[mission_info.category].append(mission_index)
-
-                    max_mission_count = max(len(categories[category]) for category in categories)
-                    if max_mission_count == 1:
-                        campaign_layout_height = 115
-                    else:
-                        campaign_layout_height = (max_mission_count + 2) * 50
-                    multi_campaign_layout_height += campaign_layout_height
-                    campaign_layout = CampaignLayout(size_hint_y=None, height=campaign_layout_height)
-                    if campaign != SC2Campaign.GLOBAL:
-                        campaign_layout.add_widget(
-                            Label(text=campaign.campaign_name, size_hint_y=None, height=25, outline_width=1)
-                        )
-                    mission_layout = MissionLayout()
-
-                    for category in categories:
-                        category_name_height = 0
-                        category_spacing = 3
-                        if category.startswith('_'):
-                            category_display_name = ''
-                        else:
-                            category_display_name = category
-                            category_name_height += 25
-                            category_spacing = 10
-                        category_panel = MissionCategory(padding=[category_spacing,6,category_spacing,6])
-                        category_panel.add_widget(
-                            Label(text=category_display_name, size_hint_y=None, height=category_name_height, outline_width=1))
-
-                        for mission in categories[category]:
-                            text: str = mission
-                            tooltip: str = ""
-                            mission_obj: SC2Mission = lookup_name_to_mission[mission]
-                            mission_id: int = mission_obj.id
-                            mission_data = self.ctx.mission_req_table[campaign][mission]
-                            remaining_locations, plando_locations, remaining_count = self.sort_unfinished_locations(mission_obj)
-                            # Map has uncollected locations
-                            if mission in unfinished_missions:
-                                if self.any_valuable_locations(remaining_locations):
-                                    text = f"[color=6495ED]{text}[/color]"
-                                else:
-                                    text = f"[color=A0BEF4]{text}[/color]"
-                            elif mission in available_missions:
-                                text = f"[color=FFFFFF]{text}[/color]"
-                            # Map requirements not met
-                            else:
-                                text = f"[color=a9a9a9]{text}[/color]"
-                                tooltip = f"Requires: "
-                                if mission_data.required_world:
-                                    tooltip += ", ".join(list(self.ctx.mission_req_table[parse_unlock(req_mission).campaign])[parse_unlock(req_mission).connect_to - 1] for
-                                                            req_mission in
-                                                            mission_data.required_world)
-
-                                    if mission_data.number:
-                                        tooltip += " and "
-                                if mission_data.number:
-                                    tooltip += f"{self.ctx.mission_req_table[campaign][mission].number} missions completed"
-
-                            if mission_id == self.ctx.final_mission:
-                                if mission in available_missions:
-                                    text = f"[color=FFBC95]{mission}[/color]"
-                                else:
-                                    text = f"[color=D0C0BE]{mission}[/color]"
-                                if tooltip:
-                                    tooltip += "\n"
-                                tooltip += "Final Mission"
-
-                            if remaining_count > 0:
-                                if tooltip:
-                                    tooltip += "\n\n"
-                                tooltip += f"-- Uncollected locations --"
-                                for loctype in LocationType:
-                                    if len(remaining_locations[loctype]) > 0:
-                                        if loctype == LocationType.VICTORY:
-                                            tooltip += f"\n- {remaining_locations[loctype][0]}"
-                                        else:
-                                            tooltip += f"\n{self.get_location_type_title(loctype)}:\n- "
-                                            tooltip += "\n- ".join(remaining_locations[loctype])
-                                if len(plando_locations) > 0:
-                                    tooltip += f"\nPlando:\n- "
-                                    tooltip += "\n- ".join(plando_locations)
-                            
-                            MISSION_BUTTON_HEIGHT = 50
-                            for pad in range(mission_data.ui_vertical_padding):
-                                column_spacer = Label(text='', size_hint_y=None, height=MISSION_BUTTON_HEIGHT)
-                                category_panel.add_widget(column_spacer)
-                            mission_button = MissionButton(text=text, size_hint_y=None, height=MISSION_BUTTON_HEIGHT)
-                            mission_race = mission_obj.race
-                            if mission_race == SC2Race.ANY:
-                                mission_race = mission_obj.campaign.race
-                            race = campaign_race_exceptions.get(mission_obj, mission_race)
-                            racial_colors = {
-                                SC2Race.TERRAN: (0.24, 0.84, 0.68),
-                                SC2Race.ZERG: (1, 0.65, 0.37),
-                                SC2Race.PROTOSS: (0.55, 0.7, 1)
-                            }
-                            if race in racial_colors:
-                                mission_button.background_color = racial_colors[race]
-                            mission_button.tooltip_text = tooltip
-                            mission_button.bind(on_press=self.mission_callback)
-                            self.mission_id_to_button[mission_id] = mission_button
-                            category_panel.add_widget(mission_button)
-
-                        category_panel.add_widget(Label(text=""))
-                        mission_layout.add_widget(category_panel)
-                    campaign_layout.add_widget(mission_layout)
-                    self.campaign_panel.add_widget(campaign_layout)
-                self.campaign_panel.height = multi_campaign_layout_height
-
-        elif self.launching:
+        if self.launching:
             assert self.campaign_panel is not None
             self.refresh_from_launching = False
 
             self.campaign_panel.clear_widgets()
-            self.campaign_panel.add_widget(Label(text="Launching Mission: " +
-                                                        lookup_id_to_mission[self.launching].mission_name))
+            self.campaign_panel.add_widget(Label(
+                text="Launching Mission: " + lookup_id_to_mission[self.launching].mission_name
+            ))
             if self.ctx.ui:
                 self.ctx.ui.clear_tooltip()
+            return
+        
+        needs_redraw = (
+            self.last_checked_locations != self.ctx.checked_locations
+            or not self.refresh_from_launching
+            or self.last_data_out_of_date != self.ctx.data_out_of_date
+            or self.first_check
+        )
+        if not needs_redraw:
+            return
+
+        assert self.campaign_panel is not None
+        self.refresh_from_launching = True
+
+        self.campaign_panel.clear_widgets()
+        if self.ctx.data_out_of_date:
+            self.campaign_panel.add_widget(Label(text="", padding=[0, 5, 0, 5]))
+            warning_label = Label(
+                text="[color=d23300]Map/Mod data is out of date. Run /download_data in the client[/color]",
+                markup=True,
+                padding=[0, 25, 0, 25],
+            )
+            self.campaign_scroll_panel.border_on = True
+            self.campaign_panel.add_widget(warning_label)
+        else:
+            self.campaign_scroll_panel.border_on = False
+        self.last_data_out_of_date = self.ctx.data_out_of_date
+        if not self.ctx.mission_req_table:
+            self.campaign_panel.add_widget(Label(text="Connect to a world to see a mission layout here."))
+            return
+
+        self.last_checked_locations = self.ctx.checked_locations.copy()
+        self.first_check = False
+        self.first_mission = get_first_mission(self.ctx.mission_req_table).mission_name
+
+        self.mission_id_to_button = {}
+
+        available_missions, unfinished_missions = calc_unfinished_missions(self.ctx)
+
+        multi_campaign_layout_height = 0
+
+        for campaign, missions in sorted(self.ctx.mission_req_table.items(), key=lambda item: item[0].id):
+            categories: Dict[str, List[str]] = {}
+
+            # separate missions into categories
+            for mission_index in missions:
+                mission_info = self.ctx.mission_req_table[campaign][mission_index]
+                if mission_info.category not in categories:
+                    categories[mission_info.category] = []
+
+                categories[mission_info.category].append(mission_index)
+
+            max_mission_count = max(len(categories[category]) for category in categories)
+            if max_mission_count == 1:
+                campaign_layout_height = 115
+            else:
+                campaign_layout_height = (max_mission_count + 2) * 50
+            multi_campaign_layout_height += campaign_layout_height
+            campaign_layout = CampaignLayout(size_hint_y=None, height=campaign_layout_height)
+            if campaign != SC2Campaign.GLOBAL:
+                campaign_layout.add_widget(
+                    Label(text=campaign.campaign_name, size_hint_y=None, height=25, outline_width=1)
+                )
+            mission_layout = MissionLayout()
+
+            for category in categories:
+                category_name_height = 0
+                category_spacing = 3
+                if category.startswith('_'):
+                    category_display_name = ''
+                else:
+                    category_display_name = category
+                    category_name_height += 25
+                    category_spacing = 10
+                category_panel = MissionCategory(padding=[category_spacing,6,category_spacing,6])
+                category_panel.add_widget(
+                    Label(text=category_display_name, size_hint_y=None, height=category_name_height, outline_width=1))
+
+                for mission in categories[category]:
+                    text: str = mission
+                    tooltip: str = ""
+                    mission_obj: SC2Mission = lookup_name_to_mission[mission]
+                    mission_id: int = mission_obj.id
+                    mission_data = self.ctx.mission_req_table[campaign][mission]
+                    remaining_locations, plando_locations, remaining_count = self.sort_unfinished_locations(mission_obj)
+                    # Map has uncollected locations
+                    if mission in unfinished_missions:
+                        if self.any_valuable_locations(remaining_locations):
+                            text = f"[color=6495ED]{text}[/color]"
+                        else:
+                            text = f"[color=A0BEF4]{text}[/color]"
+                    elif mission in available_missions:
+                        text = f"[color=FFFFFF]{text}[/color]"
+                    # Map requirements not met
+                    else:
+                        text = f"[color=a9a9a9]{text}[/color]"
+                        tooltip = f"Requires: "
+                        if mission_data.required_world:
+                            tooltip += ", ".join(list(self.ctx.mission_req_table[parse_unlock(req_mission).campaign])[parse_unlock(req_mission).connect_to - 1] for
+                                                    req_mission in
+                                                    mission_data.required_world)
+
+                            if mission_data.number:
+                                tooltip += " and "
+                        if mission_data.number:
+                            tooltip += f"{self.ctx.mission_req_table[campaign][mission].number} missions completed"
+
+                    if mission_id == self.ctx.final_mission:
+                        if mission in available_missions:
+                            text = f"[color=FFBC95]{mission}[/color]"
+                        else:
+                            text = f"[color=D0C0BE]{mission}[/color]"
+                        if tooltip:
+                            tooltip += "\n"
+                        tooltip += "Final Mission"
+
+                    if remaining_count > 0:
+                        if tooltip:
+                            tooltip += "\n\n"
+                        tooltip += f"-- Uncollected locations --"
+                        for loctype in LocationType:
+                            if len(remaining_locations[loctype]) > 0:
+                                if loctype == LocationType.VICTORY:
+                                    tooltip += f"\n- {remaining_locations[loctype][0]}"
+                                else:
+                                    tooltip += f"\n{self.get_location_type_title(loctype)}:\n- "
+                                    tooltip += "\n- ".join(remaining_locations[loctype])
+                        if len(plando_locations) > 0:
+                            tooltip += f"\nPlando:\n- "
+                            tooltip += "\n- ".join(plando_locations)
+                    
+                    MISSION_BUTTON_HEIGHT = 50
+                    for pad in range(mission_data.ui_vertical_padding):
+                        column_spacer = Label(text='', size_hint_y=None, height=MISSION_BUTTON_HEIGHT)
+                        category_panel.add_widget(column_spacer)
+                    mission_button = MissionButton(text=text, size_hint_y=None, height=MISSION_BUTTON_HEIGHT)
+                    mission_race = mission_obj.race
+                    if mission_race == SC2Race.ANY:
+                        mission_race = mission_obj.campaign.race
+                    race = campaign_race_exceptions.get(mission_obj, mission_race)
+                    racial_colors = {
+                        SC2Race.TERRAN: (0.24, 0.84, 0.68),
+                        SC2Race.ZERG: (1, 0.65, 0.37),
+                        SC2Race.PROTOSS: (0.55, 0.7, 1)
+                    }
+                    if race in racial_colors:
+                        mission_button.background_color = racial_colors[race]
+                    mission_button.tooltip_text = tooltip
+                    mission_button.bind(on_press=self.mission_callback)
+                    self.mission_id_to_button[mission_id] = mission_button
+                    category_panel.add_widget(mission_button)
+
+                category_panel.add_widget(Label(text=""))
+                mission_layout.add_widget(category_panel)
+            campaign_layout.add_widget(mission_layout)
+            self.campaign_panel.add_widget(campaign_layout)
+        self.campaign_panel.height = multi_campaign_layout_height
 
     def mission_callback(self, button: MissionButton) -> None:
         if not self.launching:

--- a/worlds/sc2/Starcraft2.kv
+++ b/worlds/sc2/Starcraft2.kv
@@ -10,7 +10,7 @@
             rectangle: self.x+1, self.y+1, self.width-1, self.height-1
 
 <DownloadDataWarningMessage>
-    color: (0, 0, 0, 1)
+    color: (1, 1, 1, 1)
     canvas.before:
         Color:
             rgba: (0xd2/0xff, 0x33/0xff, 0, 1)

--- a/worlds/sc2/Starcraft2.kv
+++ b/worlds/sc2/Starcraft2.kv
@@ -2,6 +2,12 @@
     scroll_type: ["content", "bars"]
     bar_width: dp(12)
     effect_cls: "ScrollEffect"
+    canvas.after:
+        Color:
+            rgba: (0.82, 0.2, 0, 1)
+        Line:
+            width: 1.5
+            rectangle: self.x+1 - 30*(not root.border_on), self.y+1 - 30*(not root.border_on), self.width-1 if root.border_on else 1, self.height-1 if root.border_on else 1
 
 <MultiCampaignLayout>
     cols: 1

--- a/worlds/sc2/Starcraft2.kv
+++ b/worlds/sc2/Starcraft2.kv
@@ -4,10 +4,19 @@
     effect_cls: "ScrollEffect"
     canvas.after:
         Color:
-            rgba: (0.82, 0.2, 0, 1)
+            rgba: (0.82, 0.2, 0, root.border_on)
         Line:
             width: 1.5
-            rectangle: self.x+1 - 30*(not root.border_on), self.y+1 - 30*(not root.border_on), self.width-1 if root.border_on else 1, self.height-1 if root.border_on else 1
+            rectangle: self.x+1, self.y+1, self.width-1, self.height-1
+
+<DownloadDataWarningMessage>
+    color: (0, 0, 0, 1)
+    canvas.before:
+        Color:
+            rgba: (0xd2/0xff, 0x33/0xff, 0, 1)
+        Rectangle: 
+            pos: (self.x - 8, self.y - 8)
+            size: (self.width + 30, self.height + 16)
 
 <MultiCampaignLayout>
     cols: 1


### PR DESCRIPTION
* Set some detailed messages to debug rather than info
* `/download_data` warnings are now coloured
* Part 2: Made a red border / message in the mission launcher if map/mod data is out of date
* Note parts 1 and 2 are in separate commits and can be reviewed separately

## What is this fixing or adding?
Removed some clutter, and made the important `/download_data` message highlighted in red.

## How was this tested?
* Started the client, compared messages and checked logs (debug messages and coloured messages were still in the logs)
* Went into sc2 directory, renamed Archipelago version and metadata files so the client wouldn't find them, restarted the client and checked that the missing data message displayed properly

## If this makes graphical changes, please attach screenshots.
Old startup:
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/25c90627-255e-4c0d-b163-39602e1e9b97)

New startup:
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/4efbff95-55df-4123-a835-abb957ff9aef)

# Part 2 -- Added a red border and message to the launcher if maps are out of date
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/160d6d63-a8d0-41bb-becd-008dad5fbcfd)

## How was this tested?
1. Opened the client with the maps out of date. Verified the border and message appeared.
2. Resized the window a bunch to make sure that didn't break it.
3. Ran `/downlod_data`. Verified the border / message went away when the download completed
4. Closed and re-opened the client. Verified the border was not present with fresh data
5. Deleted AP metadata file in the sc2 directory. Closed and re-opened the client. Verified the red border and message appeared again.