### PR TITLE
sc2: Fixed an issue that made all campaign mission groups equal to WoL

### DIFF
--- a/worlds/sc2/MissionGroups.py
+++ b/worlds/sc2/MissionGroups.py
@@ -90,7 +90,7 @@ for group_name, campaign in (
     (MissionGroupNames.EPILOGUE_MISSIONS, SC2Campaign.EPILOGUE),
 ):
     mission_groups[group_name] = [
-        mission.mission_name for mission in SC2Mission if mission.campaign == SC2Campaign.WOL
+        mission.mission_name for mission in SC2Mission if mission.campaign == campaign
     ]
 
 for group_name, flags in (


### PR DESCRIPTION
## What is this fixing or adding?
Spotted by Salzkorn:

> ran into a bug with mission groups - the campaign ones all check if a mission's campaign is WoL rather than whichever campaign they're supposed to be (line 93). I've fixed it locally but I imagine you might not want that fix to be part of my massive PR lol

## How was this tested?
Exported all mission groups as a json locally, visually inspected the campaign groups.

## If this makes graphical changes, please attach screenshots.
None