### PR TITLE
sc2: Fixed an issue that wouldn't filter Kerrigan level items if ther…

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -676,7 +676,7 @@ def fill_pool_with_kerrigan_levels(world: SC2World, item_pool: List[Item]):
     total_levels = world.options.kerrigan_level_item_sum.value
     missions = get_all_missions(world.mission_req_table)
     kerrigan_missions = [mission for mission in missions if MissionFlag.Kerrigan in mission.flags]
-    kerrigan_build_missions = [mission for mission in missions if MissionFlag.NoBuild not in mission.flags]
+    kerrigan_build_missions = [mission for mission in kerrigan_missions if MissionFlag.NoBuild not in mission.flags]
     if (world.options.kerrigan_presence.value not in kerrigan_unit_available
         or total_levels == 0
         or not kerrigan_missions


### PR DESCRIPTION
## What is this fixing or adding?
Spotted this issue while reviewing PR #207. Kerrigan level items are not properly filtered when `grant_story_levels` is true and there are no Kerrigan build missions.

## How was this tested?
Ran all unit tests. Ran this fix against Envy's unit tests in #207, and they passed even without his addition to check campaign enablement.

## If this makes graphical changes, please attach screenshots.
None