### PR TITLE
SC2: Reserve word 16 for raceswap

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1094,6 +1094,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             kerrigan_options = calculate_kerrigan_options(self.ctx)
             soa_options = caclulate_soa_options(self.ctx)
             uncollected_objectives: typing.List[int] = self.get_uncollected_objectives()
+            mission_variant = 0  # temp value until generator logic is done
             if self.ctx.difficulty_override >= 0:
                 difficulty = calc_difficulty(self.ctx.difficulty_override)
             else:
@@ -1102,7 +1103,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 game_speed = self.ctx.game_speed_override
             else:
                 game_speed = self.ctx.game_speed
-            await self.chat_send("?SetOptions {} {} {} {} {} {} {} {} {} {} {} {} {} {}".format(
+            await self.chat_send("?SetOptions {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}".format(
                 difficulty,
                 self.ctx.generic_upgrade_research,
                 self.ctx.all_in_choice,
@@ -1116,7 +1117,8 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 self.ctx.mission_order,
                 1 if self.ctx.nova_covert_ops_only else 0,
                 self.ctx.grant_story_levels,
-                self.ctx.enable_morphling
+                self.ctx.enable_morphling,
+                mission_variant
             ))
             await self.chat_send("?GiveResources {} {} {}".format(
                 start_items[SC2Race.ANY][0],

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1094,7 +1094,8 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             kerrigan_options = calculate_kerrigan_options(self.ctx)
             soa_options = caclulate_soa_options(self.ctx)
             uncollected_objectives: typing.List[int] = self.get_uncollected_objectives()
-            mission_variant = 0  # temp value until generator logic is done
+            # TODO: Add logic to determine which variant, based on selected map ID
+            mission_variant = 0  # 0/1/2/3 for unchanged/Terran/Zerg/Protoss
             if self.ctx.difficulty_override >= 0:
                 difficulty = calc_difficulty(self.ctx.difficulty_override)
             else:


### PR DESCRIPTION
## What is this fixing or adding?
Just reserving a value in the SetOptions string; the maps' race-swap triggers expect to see either 0 (for no change) or 1/2/3 (for terran/zerg/protoss) on word 16, but the generator logic isn't ready yet, so this will allow that work to be merged and applied without worrying about potential conflicts.

## How was this tested?
1. Compiled the maps with race-swap triggers active
2. Loaded a map that was race-swappable (Smash and Grab); verified that it loaded and ran correctly with a 0 in the race override slot
3. Loaded a map that was NOT race-swappable yet (Zero Hour); verified that it loaded and ran correctly ie. having a value in the slot didn't cause issues
4. Did /download_data to get the version of the maps without race-swap triggers whatsoever; loaded Smash and Grab again, verified that it ran correctly ie. no weird behavior as a result of an extra character in the options string

TLDR having the 0 doesn't break maps that aren't set up to read the value, and correctly produces default behavior on maps that ARE set up to read it
