### PR TITLE
sc2: Added creep stomach upgrades to client

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -659,6 +659,7 @@ item_descriptions = {
     item_names.TWIN_DRONES: "Drones morph in groups of two at no additional cost and require less supply.",
     item_names.MALIGNANT_CREEP: "Your units and structures gain increased life regeneration and 30% increased attack speed while on creep. Creep Tumors also spread creep faster and farther.",
     item_names.VESPENE_EFFICIENCY: "Extractors produce Vespene gas 25% faster.",
+    item_names.ZERG_CREEP_STOMACH: "Zerg buildings no longer take damage off-creep. Spore and Spine Crawlers can now root off-creep.",
     item_names.KERRIGAN_INFEST_BROODLINGS: "Enemies damaged by Kerrigan become infested and will spawn Broodlings with timed life if killed quickly.",
     item_names.KERRIGAN_FURY: "Each of Kerrigan's attacks temporarily increase her attack speed by 15%. Can stack up to 75%.",
     item_names.KERRIGAN_ABILITY_EFFICIENCY: "Kerrigan's abilities have their cooldown and energy cost reduced by 20%.",

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -493,11 +493,12 @@ KERRIGAN_DROP_PODS               = "Drop-Pods (Kerrigan Ability)"
 KERRIGAN_PRIMAL_FORM             = "Primal Form (Kerrigan)"
 
 # Misc Upgrades
-ZERGLING_RECONSTITUTION          = "Zergling Reconstitution"
-AUTOMATED_EXTRACTORS             = "Automated Extractors"
-TWIN_DRONES                      = "Twin Drones"
-MALIGNANT_CREEP                  = "Malignant Creep"
-VESPENE_EFFICIENCY               = "Vespene Efficiency"
+ZERGLING_RECONSTITUTION          = "Zergling Reconstitution (Zerg)"
+AUTOMATED_EXTRACTORS             = "Automated Extractors (Zerg)"
+TWIN_DRONES                      = "Twin Drones (Zerg)"
+MALIGNANT_CREEP                  = "Malignant Creep (Zerg)"
+VESPENE_EFFICIENCY               = "Vespene Efficiency (Zerg)"
+ZERG_CREEP_STOMACH               = "Creep Stomach (Zerg)"
 
 # Kerrigan Levels
 KERRIGAN_LEVELS_1  = "1 Kerrigan Level"

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1411,6 +1411,7 @@ item_table = {
     item_names.KERRIGAN_DROP_PODS: ItemData(420 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 14, SC2Race.ZERG, origin={"hots"}, classification=ItemClassification.progression),
     # Handled separately from other abilities
     item_names.KERRIGAN_PRIMAL_FORM: ItemData(421 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Primal_Form, 0, SC2Race.ZERG, origin={"hots"}),
+    item_names.ZERG_CREEP_STOMACH: ItemData(422 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 10, SC2Race.ZERG),
 
     item_names.KERRIGAN_LEVELS_10: ItemData(500 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Level, 10, SC2Race.ZERG, origin={"hots"}, quantity=0, classification=ItemClassification.progression),
     item_names.KERRIGAN_LEVELS_9: ItemData(501 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Level, 9, SC2Race.ZERG, origin={"hots"}, quantity=0, classification=ItemClassification.progression),


### PR DESCRIPTION
## What is this fixing or adding?
Client-side changes for adding the Creep Stomachs upgrade/item. See [#146](https://github.com/Ziktofel/Archipelago-SC2-data/pull/146) for details.

## How was this tested?
Ran the unit tests; generated a world, ran `/send phaneros Creep Stomach (Zerg)`, the item name was recognized. Opened Waking the Ancient and checked I had the upgrade.

## If this makes graphical changes, please attach screenshots.
None