### PR TITLE
sc2: Fixed a bug where generic_upgrade_missions would cause a crash on mission startup

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -921,7 +921,7 @@ def calculate_items(ctx: SC2Context) -> typing.Dict[SC2Race, typing.List[int]]:
     # Upgrades from completed missions
     if ctx.generic_upgrade_missions > 0:
         total_missions = sum(len(ctx.mission_req_table[campaign]) for campaign in ctx.mission_req_table)
-        num_missions = (ctx.generic_upgrade_missions // 100) * total_missions
+        num_missions = int((ctx.generic_upgrade_missions / 100) * total_missions)
         completed = len([id for id in ctx.mission_id_to_location_ids if get_location_offset(id) + VICTORY_MODULO * id in ctx.checked_locations])
         upgrade_count = min(completed // num_missions, WEAPON_ARMOR_UPGRADE_MAX_LEVEL)
 


### PR DESCRIPTION
## What is this fixing or adding?
The first mission will crash on startup if generic_upgrade_missions is set to a non-zero value

## How was this tested?
Played a sync after this change was put in. upgrade still seem to came at around the right time, though I didn't count the exact mission count

## If this makes graphical changes, please attach screenshots.
None