### PR TITLE
sc2: Fix bug that caused the terran_basic_anti_air rule to crash sometimes

### DIFF
--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -107,16 +107,16 @@ class SC2Logic:
         :return:
         """
         return (
-            state.has_any({
+            state.has_any((
                 item_names.MISSILE_TURRET, item_names.THOR, item_names.WAR_PIGS, item_names.SPARTAN_COMPANY,
                 item_names.HELS_ANGELS, item_names.BATTLECRUISER, item_names.MARINE, item_names.WRAITH,
-                item_names.VALKYRIE, item_names.CYCLONE, item_names.WINGED_NIGHTMARES, item_names.BRYNHILDS
-            }, self.player)
+                item_names.VALKYRIE, item_names.CYCLONE, item_names.WINGED_NIGHTMARES, item_names.BRYNHILDS,
+            ), self.player)
             or self.terran_competent_anti_air(state)
             or self.advanced_tactics and (
-                state.has_any({item_names.GHOST, item_names.SPECTRE, item_names.WIDOW_MINE, item_names.LIBERATOR}, self.player)
+                state.has_any((item_names.GHOST, item_names.SPECTRE, item_names.WIDOW_MINE, item_names.LIBERATOR), self.player)
                 or (
-                        state.has_all(item_names.SIEGE_TANK, item_names.MEDIVAC)
+                        state.has_all((item_names.SIEGE_TANK, item_names.MEDIVAC), self.player)
                         and state.count(item_names.SIEGE_TANK_PROGRESSIVE_TRANSPORT_HOOK, self.player) >= 2
                 )
             )


### PR DESCRIPTION
## What is this fixing or adding?
Bug reported by [CrazedCollie in the discord](https://discord.com/channels/731205301247803413/1101186175722598521/1253044933141729422)

Also changed parens in that function to tuple literals rather than set literals. Did a quick test that seemed to suggest creation times were faster for tuples, then lists, then sets, and checking times were about the same (more random for sets).

## How was this tested?
Ran some generations on advanced tactics. Ran mypy and it no longer highlights that line.

## If this makes graphical changes, please attach screenshots.
None