### PR TITLE
SC2: Making disable-forced-camera default to "true"

### DIFF
--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -563,8 +563,8 @@ class SpearOfAdunPresence(Choice):
 
     Not Present: Spear of Adun calldowns are unavailable.
     LotV Protoss: Spear of Adun calldowns are only available in LotV main campaign
-    Protoss: Spear od Adun calldowns are available in any Protoss mission
-    Everywhere: Spear od Adun calldowns are available in any mission of any race
+    Protoss: Spear of Adun calldowns are available in any Protoss mission
+    Everywhere: Spear of Adun calldowns are available in any mission of any race
     """
     display_name = "Spear of Adun Presence"
     option_not_present = 0

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -98,7 +98,7 @@ class GameSpeed(Choice):
     default = option_default
 
 
-class DisableForcedCamera(Toggle):
+class DisableForcedCamera(DefaultOnToggle):
     """
     Prevents the game from moving or locking the camera without the player's consent.
     """
@@ -599,8 +599,8 @@ class SpearOfAdunAutonomouslyCastAbilityPresence(Choice):
 
     Not Presents: Autocasts are not available.
     LotV Protoss: Spear of Adun autocasts are only available in LotV main campaign
-    Protoss: Spear od Adun autocasts are available in any Protoss mission
-    Everywhere: Spear od Adun autocasts are available in any mission of any race
+    Protoss: Spear of Adun autocasts are available in any Protoss mission
+    Everywhere: Spear of Adun autocasts are available in any mission of any race
     """
     display_name = "Spear of Adun Autonomously Cast Powers Presence"
     option_not_present = 0


### PR DESCRIPTION
## What is this fixing or adding?
Setting the QoL "disable forced camera" option to default on, because almost nobody plays with it off. Just saves people a click.

Also fixed a few typos where the commented code said "Spear od Adun".

## How was this tested?
Generated a yaml and verified the changes had taken effect.