### PR TITLE
Mm/dragoon war council nerf

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -593,7 +593,7 @@ def flag_user_excluded_item_sets(world: SC2World, item_list: List[FilterItem]) -
 
 def flag_war_council_excludes(world: SC2World, item_list: List[FilterItem]) -> None:
     """Excludes items based on item set options (`only_vanilla_items`)"""
-    if world.options.allow_unit_nerfs:
+    if world.options.nerf_unit_baselines:
         return
 
     for item in item_list:

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -32,7 +32,7 @@ from .options import (
     LocationInclusion, ExtraLocations, MasteryLocations, ChallengeLocations, VanillaLocations,
     DisableForcedCamera, SkipCutscenes, GrantStoryTech, GrantStoryLevels, TakeOverAIAllies, RequiredTactics,
     SpearOfAdunPresence, SpearOfAdunPresentInNoBuild, SpearOfAdunAutonomouslyCastAbilityPresence,
-    SpearOfAdunAutonomouslyCastPresentInNoBuild, AllowUnitNerfs, LEGACY_GRID_ORDERS,
+    SpearOfAdunAutonomouslyCastPresentInNoBuild, NerfUnitBaselines, LEGACY_GRID_ORDERS,
 )
 
 
@@ -329,7 +329,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             ConfigurableOptionInfo('no_forced_camera', 'disable_forced_camera', options.DisableForcedCamera),
             ConfigurableOptionInfo('skip_cutscenes', 'skip_cutscenes', options.SkipCutscenes),
             ConfigurableOptionInfo('enable_morphling', 'enable_morphling', options.EnableMorphling, can_break_logic=True),
-            ConfigurableOptionInfo('unit_nerfs', 'allow_unit_nerfs', options.AllowUnitNerfs, can_break_logic=True),
+            ConfigurableOptionInfo('unit_nerfs', 'nerf_unit_baselines', options.NerfUnitBaselines, can_break_logic=True),
         )
 
         WARNING_COLOUR = "salmon"
@@ -543,7 +543,7 @@ class SC2Context(CommonContext):
         self.kerrigan_presence: int = KerriganPresence.default
         self.kerrigan_primal_status = 0
         self.enable_morphling = EnableMorphling.default
-        self.allow_unit_nerfs: int = AllowUnitNerfs.default
+        self.nerf_unit_baselines: int = NerfUnitBaselines.default
         self.mission_req_table: typing.Dict[SC2Campaign, typing.Dict[str, MissionInfo]] = {}
         self.final_mission: int = 29
         self.announcements: queue.Queue = queue.Queue()
@@ -651,7 +651,7 @@ class SC2Context(CommonContext):
             self.vespene_per_item = args["slot_data"].get("vespene_per_item", 15)
             self.starting_supply_per_item = args["slot_data"].get("starting_supply_per_item", 2)
             self.nova_covert_ops_only = args["slot_data"].get("nova_covert_ops_only", False)
-            self.allow_unit_nerfs = args["slot_data"].get("allow_unit_nerfs", AllowUnitNerfs.default)
+            self.nerf_unit_baselines = args["slot_data"].get("nerf_unit_baselines", NerfUnitBaselines.default)
 
             if self.required_tactics == RequiredTactics.option_no_logic:
                 # Locking Grant Story Tech/Levels if no logic
@@ -897,7 +897,7 @@ def calculate_items(ctx: SC2Context) -> typing.Dict[SC2Race, typing.List[int]]:
             accumulators[shield_upgrade_item.race][shield_upgrade_item.type.flag_word] += 1 << shield_upgrade_item.number
     
     # War council option
-    if not ctx.allow_unit_nerfs:
+    if not ctx.nerf_unit_baselines:
         accumulators[SC2Race.PROTOSS][ProtossItemType.War_Council.flag_word] = (1 << 30) - 1
 
     # Deprecated Orbital Command handling (Backwards compatibility):

--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -839,9 +839,10 @@ item_descriptions = {
     item_names.ZEALOT_SENTINEL_CENTURION_LEG_ENHANCEMENTS: "Zealots, Sentinels, and Centurions gain increased movement speed.",
     item_names.ZEALOT_SENTINEL_CENTURION_SHIELD_CAPACITY: "Zealots, Sentinels, and Centurions gain +30 maximum shields.",
     item_names.ZEALOT_WHIRLWIND: "Zealot War Council upgrade. Gives Zealots the whirlwind ability, dealing damage in an area over 3 seconds.",
-    item_names.CENTURION_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(item_names.CENTURION),
-    item_names.SENTINEL_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(item_names.SENTINEL),
-    item_names.STALKER_PHASE_REACTOR: "Stalkers restore 80 shields over 5 seconds after they Blink.",
+    item_names.CENTURION_RESOURCE_EFFICIENCY: "Centurion War Council upgrade. " + _get_resource_efficiency_desc(item_names.CENTURION),
+    item_names.SENTINEL_RESOURCE_EFFICIENCY: "Sentinel War Council upgrade. " + _get_resource_efficiency_desc(item_names.SENTINEL),
+    item_names.STALKER_PHASE_REACTOR: "Stalker War Council upgrade. Stalkers restore 80 shields over 5 seconds after they Blink.",
+    item_names.DRAGOON_PHALANX_SUIT: "Dragoon War Council upgrade. Dragoons gain +2 range, move slightly faster, and can form tighter formations.",
     item_names.SOA_CHRONO_SURGE: "The Spear of Adun increases a target structure's unit warp in and research speeds by +1000% for 20 seconds.",
     item_names.SOA_PROGRESSIVE_PROXY_PYLON: inspect.cleandoc("""
         Level 1: The Spear of Adun quickly warps in a Pylon to a target location.

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -602,6 +602,7 @@ DRAGOON_HIGH_IMPACT_PHASE_DISRUPTORS                    = "High Impact Phase Dis
 DRAGOON_TRILLIC_COMPRESSION_SYSTEM                      = "Trillic Compression System (Dragoon)"
 DRAGOON_SINGULARITY_CHARGE                              = "Singularity Charge (Dragoon)"
 DRAGOON_ENHANCED_STRIDER_SERVOS                         = "Enhanced Strider Servos (Dragoon)"
+DRAGOON_PHALANX_SUIT                                    = "Phalanx Suit (Dragoon)"
 SCOUT_COMBAT_SENSOR_ARRAY                               = "Combat Sensor Array (Scout)"
 SCOUT_APIAL_SENSORS                                     = "Apial Sensors (Scout)"
 SCOUT_GRAVITIC_THRUSTERS                                = "Gravitic Thrusters (Scout)"

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1694,6 +1694,7 @@ item_table = {
     item_names.CENTURION_RESOURCE_EFFICIENCY: ItemData(501 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 1, SC2Race.PROTOSS, parent_item=item_names.CENTURION),
     item_names.SENTINEL_RESOURCE_EFFICIENCY: ItemData(502 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 2, SC2Race.PROTOSS, parent_item=item_names.SENTINEL),
     item_names.STALKER_PHASE_REACTOR: ItemData(503 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 3, SC2Race.PROTOSS, parent_item=item_names.STALKER),
+    item_names.DRAGOON_PHALANX_SUIT: ItemData(504 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 4, SC2Race.PROTOSS, parent_item=item_names.DRAGOON),
 
     # SoA Calldown powers
     item_names.SOA_CHRONO_SURGE: ItemData(700 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Spear_Of_Adun, 0, SC2Race.PROTOSS, origin={"lotv"}),

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -556,7 +556,7 @@ class EnableMorphling(Toggle):
     display_name = "Enable Morphling"
 
 
-class AllowUnitNerfs(Toggle):
+class NerfUnitBaselines(Toggle):
     """
     Controls whether some units can initially be found in a nerfed state, with upgrades restoring their stronger power level.
     For example, nerfed Zealots will lack the whirlwind upgrade until it is found as an item.
@@ -937,7 +937,7 @@ class Starcraft2Options(PerGameCommonOptions):
     start_primary_abilities: StartPrimaryAbilities
     kerrigan_primal_status: KerriganPrimalStatus
     enable_morphling: EnableMorphling
-    allow_unit_nerfs: AllowUnitNerfs
+    nerf_unit_baselines: NerfUnitBaselines
     spear_of_adun_presence: SpearOfAdunPresence
     spear_of_adun_present_in_no_build: SpearOfAdunPresentInNoBuild
     spear_of_adun_autonomously_cast_ability_presence: SpearOfAdunAutonomouslyCastAbilityPresence

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -482,7 +482,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             'enable_epilogue_missions': False,
             'enable_nco_missions': False,
             'mission_order': options.MissionOrder.option_grid,
-            'allow_unit_nerfs': options.AllowUnitNerfs.option_false,
+            'nerf_unit_baselines': options.NerfUnitBaselines.option_false,
         }
 
         self.generate_world(world_options)
@@ -491,4 +491,4 @@ class TestItemFiltering(Sc2SetupTestBase):
         present_war_council_items = war_council_item_names.intersection(itempool)
 
         self.assertTrue(itempool)
-        self.assertFalse(present_war_council_items, f'Found war council upgrades when allow_unit_nerfs is false: {present_war_council_items}')
+        self.assertFalse(present_war_council_items, f'Found war council upgrades when nerf_unit_baselines is false: {present_war_council_items}')


### PR DESCRIPTION
## What is this fixing or adding?
Adding Dragoon Phalanx Suit item data. Also changed the war council option name per discord user feedback.
Pairs with Data PR [#159](https://github.com/Ziktofel/Archipelago-SC2-data/pull/159)

## How was this tested?
Gen'd a world, started a mission with unit nerfs on, verified Dragoons didn't have the upgrade, turned the option off, verified they got it for free, and gave the item from the server and verified they got the upgrade.

## If this makes graphical changes, please attach screenshots.
See data PR