### PR TITLE
SC2: Race-swap Evacuation and Outbreak

### DIFF
--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -2031,10 +2031,6 @@ pvz_defense_ratings = {
     item_names.REAVER: 1,
     # any high templar variant: 2
 }
-pvx_air_defense_ratings = {
-    item_names.CORSAIR: 1,
-    # phoenix or mirage: 1
-}
 
 kerrigan_levels = [
     item_name for item_name, item_data in item_table.items()

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1959,9 +1959,9 @@ filler_items: typing.Tuple[str, ...] = (
 
 # Defense rating table
 # Commented defense ratings are handled in LogicMixin
-defense_ratings = {
+tvx_defense_ratings = {
     item_names.SIEGE_TANK: 5,
-    # "Maelstrom Rounds": 2,
+    # "Graduating Range": 1,
     item_names.PLANETARY_FORTRESS: 3,
     # Bunker w/ Marine/Marauder: 3,
     item_names.PERDITION_TURRET: 2,
@@ -1973,15 +1973,67 @@ defense_ratings = {
     item_names.WIDOW_MINE: 1,
     # "Concealment (Widow Mine)": 1
 }
-zerg_defense_ratings = {
+tvz_defense_ratings = {
     item_names.PERDITION_TURRET: 2,
     # Bunker w/ Firebat: 2,
     item_names.LIBERATOR: -2,
     item_names.HIVE_MIND_EMULATOR: 3,
     item_names.PSI_DISRUPTER: 3,
 }
-air_defense_ratings = {
+tvx_air_defense_ratings = {
     item_names.MISSILE_TURRET: 2,
+}
+zvx_defense_ratings = {
+    # Note that this doesn't include Kerrigan because this is just for race swaps, which doesn't involve her (for now)
+    item_names.SPINE_CRAWLER: 2,
+    # w/ Twin Drones: 1
+    item_names.SWARM_QUEEN: 1,
+    item_names.SWARM_HOST: 1,
+    # impaler: 3
+    #  "Hardened Tentacle Spines (Impaler)": 2
+    # lurker: 1
+    #  "Seismic Spines (Lurker)": 2
+    #  "Adapted Spines (Lurker)": 1
+    # brood lord : 2
+    # corpser roach: 1
+    # creep tumors (swarm queen or overseer): 1
+    # w/ malignant creep: 1
+    item_names.INFESTED_SIEGE_TANKS: 5,
+    # "Graduating Range": 1,
+}
+# zvz_defense_ratings = {
+    # corpser roach: 1
+    # primal igniter: 2
+    # w/ concentrated fire: 1
+    # lurker: 1
+    # w/ adapted spines: -1
+    # impaler: -1
+# }
+zvx_air_defense_ratings = {
+    item_names.SPORE_CRAWLER: 2,
+    # w/ Twin Drones: 1
+}
+pvx_defense_ratings = {
+    item_names.PHOTON_CANNON: 2,
+    item_names.KHAYDARIN_MONOLITH: 3,
+    # khalai ingenuity, enhanced targeting, optimized ordnance: 1 each if either of the above exist
+    item_names.SHIELD_BATTERY: 1,
+    item_names.NEXUS_OVERCHARGE: 2,
+    item_names.CORSAIR: 1,
+    # any of cloak, argus jewel, sustaining disruption: 1
+    item_names.MATRIX_OVERLOAD: 1,
+    item_names.COLOSSUS: 1,
+}
+pvz_defense_ratings = {
+    item_names.KHAYDARIN_MONOLITH: -2,
+    item_names.COLOSSUS: 2,
+    item_names.VANGUARD: 1,
+    item_names.REAVER: 1,
+    # any high templar variant: 2
+}
+pvx_air_defense_ratings = {
+    item_names.CORSAIR: 1,
+    # phoenix or mirage: 1
 }
 
 kerrigan_levels = [

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -1698,8 +1698,86 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                      lambda state: logic.protoss_common_unit(state)),
         make_location_data(SC2Mission.ZERO_HOUR_P.mission_name, "Cavalry's on the Way", SC2_RACESWAP_LOC_ID_OFFSET + 610, LocationType.EXTRA,
                      lambda state: logic.protoss_common_unit(state)),
-        # 70X/80X - Evacuation
-        # 90X/100X - Outbreak
+        make_location_data(SC2Mission.EVACUATION_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 700, LocationType.VICTORY,
+                     lambda state: logic.zerg_common_unit(state) and
+                                   (adv_tactics and logic.zerg_basic_kerriganless_anti_air(state)
+                                    or logic.zerg_competent_anti_air(state))),
+        make_location_data(SC2Mission.EVACUATION_Z.mission_name, "North Chrysalis", SC2_RACESWAP_LOC_ID_OFFSET + 701, LocationType.VANILLA),
+        make_location_data(SC2Mission.EVACUATION_Z.mission_name, "West Chrysalis", SC2_RACESWAP_LOC_ID_OFFSET + 702, LocationType.VANILLA,
+                     lambda state: logic.zerg_common_unit(state)),
+        make_location_data(SC2Mission.EVACUATION_Z.mission_name, "East Chrysalis", SC2_RACESWAP_LOC_ID_OFFSET + 703, LocationType.VANILLA,
+                     lambda state: logic.zerg_common_unit(state)),
+        make_location_data(SC2Mission.EVACUATION_Z.mission_name, "Reach Hanson", SC2_RACESWAP_LOC_ID_OFFSET + 704, LocationType.EXTRA),
+        make_location_data(SC2Mission.EVACUATION_Z.mission_name, "Secret Resource Stash", SC2_RACESWAP_LOC_ID_OFFSET + 705, LocationType.EXTRA),
+        make_location_data(SC2Mission.EVACUATION_Z.mission_name, "Flawless", SC2_RACESWAP_LOC_ID_OFFSET + 706, LocationType.CHALLENGE,
+                     lambda state: logic.zerg_common_unit(state) and
+                                   logic.zerg_competent_defense(state) and
+                                   (adv_tactics and logic.zerg_basic_kerriganless_anti_air(state)
+                                    or logic.zerg_competent_anti_air(state))),
+        make_location_data(SC2Mission.EVACUATION_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 800, LocationType.VICTORY,
+                     lambda state: logic.protoss_common_unit(state) and
+                                   (adv_tactics and logic.protoss_basic_anti_air(state)
+                                    or logic.protoss_competent_anti_air(state))),
+        make_location_data(SC2Mission.EVACUATION_P.mission_name, "North Chrysalis", SC2_RACESWAP_LOC_ID_OFFSET + 801, LocationType.VANILLA),
+        make_location_data(SC2Mission.EVACUATION_P.mission_name, "West Chrysalis", SC2_RACESWAP_LOC_ID_OFFSET + 802, LocationType.VANILLA,
+                     lambda state: logic.protoss_common_unit(state)),
+        make_location_data(SC2Mission.EVACUATION_P.mission_name, "East Chrysalis", SC2_RACESWAP_LOC_ID_OFFSET + 803, LocationType.VANILLA,
+                     lambda state: logic.protoss_common_unit(state)),
+        make_location_data(SC2Mission.EVACUATION_P.mission_name, "Reach Hanson", SC2_RACESWAP_LOC_ID_OFFSET + 804, LocationType.EXTRA),
+        make_location_data(SC2Mission.EVACUATION_P.mission_name, "Secret Resource Stash", SC2_RACESWAP_LOC_ID_OFFSET + 805, LocationType.EXTRA),
+        make_location_data(SC2Mission.EVACUATION_P.mission_name, "Flawless", SC2_RACESWAP_LOC_ID_OFFSET + 806, LocationType.CHALLENGE,
+                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                                   logic.protoss_common_unit(state) and
+                                   (adv_tactics and logic.protoss_basic_anti_air(state)
+                                    or logic.protoss_competent_anti_air(state))),
+        make_location_data(SC2Mission.OUTBREAK_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 900, LocationType.VICTORY,
+                     lambda state: logic.zerg_defense_rating(state, True, False) >= 4 and
+                                   logic.zerg_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_Z.mission_name, "Left Infestor", SC2_RACESWAP_LOC_ID_OFFSET + 901, LocationType.VANILLA,
+                     lambda state: logic.zerg_defense_rating(state, True, False) >= 2 and
+                                   logic.zerg_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_Z.mission_name, "Right Infestor", SC2_RACESWAP_LOC_ID_OFFSET + 902, LocationType.VANILLA,
+                     lambda state: logic.zerg_defense_rating(state, True, False) >= 2 and
+                                   logic.zerg_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_Z.mission_name, "North Infested Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 903, LocationType.EXTRA,
+                     lambda state: logic.zerg_defense_rating(state, True, False) >= 2 and
+                                   logic.zerg_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_Z.mission_name, "South Infested Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 904, LocationType.EXTRA,
+                     lambda state: logic.zerg_defense_rating(state, True, False) >= 2 and
+                                   logic.zerg_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_Z.mission_name, "Northwest Bar", SC2_RACESWAP_LOC_ID_OFFSET + 905, LocationType.EXTRA,
+                     lambda state: logic.zerg_defense_rating(state, True, False) >= 2 and
+                                   logic.zerg_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_Z.mission_name, "North Bar", SC2_RACESWAP_LOC_ID_OFFSET + 906, LocationType.EXTRA,
+                     lambda state: logic.zerg_defense_rating(state, True, False) >= 2 and
+                                   logic.zerg_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_Z.mission_name, "South Bar", SC2_RACESWAP_LOC_ID_OFFSET + 907, LocationType.EXTRA,
+                     lambda state: logic.zerg_defense_rating(state, True, False) >= 2 and
+                                   logic.zerg_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1000, LocationType.VICTORY,
+                     lambda state: logic.protoss_defense_rating(state, True, False) >= 4 and
+                                   logic.protoss_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_P.mission_name, "Left Infestor", SC2_RACESWAP_LOC_ID_OFFSET + 1001, LocationType.VANILLA,
+                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                                   logic.protoss_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_P.mission_name, "Right Infestor", SC2_RACESWAP_LOC_ID_OFFSET + 1002, LocationType.VANILLA,
+                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                                   logic.protoss_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_P.mission_name, "North Infested Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1003, LocationType.EXTRA,
+                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                                   logic.protoss_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_P.mission_name, "South Infested Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1004, LocationType.EXTRA,
+                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                                   logic.protoss_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_P.mission_name, "Northwest Bar", SC2_RACESWAP_LOC_ID_OFFSET + 1005, LocationType.EXTRA,
+                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                                   logic.protoss_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_P.mission_name, "North Bar", SC2_RACESWAP_LOC_ID_OFFSET + 1006, LocationType.EXTRA,
+                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                                   logic.protoss_common_unit(state)),
+        make_location_data(SC2Mission.OUTBREAK_P.mission_name, "South Bar", SC2_RACESWAP_LOC_ID_OFFSET + 1007, LocationType.EXTRA,
+                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                                   logic.protoss_common_unit(state)),
         # 110X/120X - Safe Haven
         # 130X/140X - Haven's Fall
         make_location_data(SC2Mission.SMASH_AND_GRAB_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1500, LocationType.VICTORY,

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -1726,7 +1726,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.EVACUATION_P.mission_name, "Reach Hanson", SC2_RACESWAP_LOC_ID_OFFSET + 804, LocationType.EXTRA),
         make_location_data(SC2Mission.EVACUATION_P.mission_name, "Secret Resource Stash", SC2_RACESWAP_LOC_ID_OFFSET + 805, LocationType.EXTRA),
         make_location_data(SC2Mission.EVACUATION_P.mission_name, "Flawless", SC2_RACESWAP_LOC_ID_OFFSET + 806, LocationType.CHALLENGE,
-                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                     lambda state: logic.protoss_defense_rating(state, True) >= 2 and
                                    logic.protoss_common_unit(state) and
                                    (adv_tactics and logic.protoss_basic_anti_air(state)
                                     or logic.protoss_competent_anti_air(state))),
@@ -1755,28 +1755,28 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                      lambda state: logic.zerg_defense_rating(state, True, False) >= 2 and
                                    logic.zerg_common_unit(state)),
         make_location_data(SC2Mission.OUTBREAK_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1000, LocationType.VICTORY,
-                     lambda state: logic.protoss_defense_rating(state, True, False) >= 4 and
+                     lambda state: logic.protoss_defense_rating(state, True) >= 4 and
                                    logic.protoss_common_unit(state)),
         make_location_data(SC2Mission.OUTBREAK_P.mission_name, "Left Infestor", SC2_RACESWAP_LOC_ID_OFFSET + 1001, LocationType.VANILLA,
-                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                     lambda state: logic.protoss_defense_rating(state, True) >= 2 and
                                    logic.protoss_common_unit(state)),
         make_location_data(SC2Mission.OUTBREAK_P.mission_name, "Right Infestor", SC2_RACESWAP_LOC_ID_OFFSET + 1002, LocationType.VANILLA,
-                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                     lambda state: logic.protoss_defense_rating(state, True) >= 2 and
                                    logic.protoss_common_unit(state)),
         make_location_data(SC2Mission.OUTBREAK_P.mission_name, "North Infested Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1003, LocationType.EXTRA,
-                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                     lambda state: logic.protoss_defense_rating(state, True) >= 2 and
                                    logic.protoss_common_unit(state)),
         make_location_data(SC2Mission.OUTBREAK_P.mission_name, "South Infested Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1004, LocationType.EXTRA,
-                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                     lambda state: logic.protoss_defense_rating(state, True) >= 2 and
                                    logic.protoss_common_unit(state)),
         make_location_data(SC2Mission.OUTBREAK_P.mission_name, "Northwest Bar", SC2_RACESWAP_LOC_ID_OFFSET + 1005, LocationType.EXTRA,
-                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                     lambda state: logic.protoss_defense_rating(state, True) >= 2 and
                                    logic.protoss_common_unit(state)),
         make_location_data(SC2Mission.OUTBREAK_P.mission_name, "North Bar", SC2_RACESWAP_LOC_ID_OFFSET + 1006, LocationType.EXTRA,
-                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                     lambda state: logic.protoss_defense_rating(state, True) >= 2 and
                                    logic.protoss_common_unit(state)),
         make_location_data(SC2Mission.OUTBREAK_P.mission_name, "South Bar", SC2_RACESWAP_LOC_ID_OFFSET + 1007, LocationType.EXTRA,
-                     lambda state: logic.protoss_defense_rating(state, True, False) >= 2 and
+                     lambda state: logic.protoss_defense_rating(state, True) >= 2 and
                                    logic.protoss_common_unit(state)),
         # 110X/120X - Safe Haven
         # 130X/140X - Haven's Fall

--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -103,8 +103,8 @@ class SC2Mission(Enum):
     LIBERATION_DAY = 1, "Liberation Day", SC2Campaign.WOL, "Mar Sara", SC2Race.ANY, MissionPools.STARTER, "ap_liberation_day", MissionFlag.Terran|MissionFlag.NoBuild|MissionFlag.VsTerran
     THE_OUTLAWS = 2, "The Outlaws (Terran)", SC2Campaign.WOL, "Mar Sara", SC2Race.TERRAN, MissionPools.EASY, "ap_the_outlaws", MissionFlag.Terran|MissionFlag.VsTerran|MissionFlag.HasRaceSwap
     ZERO_HOUR = 3, "Zero Hour (Terran)", SC2Campaign.WOL, "Mar Sara", SC2Race.TERRAN, MissionPools.EASY, "ap_zero_hour", MissionFlag.Terran|MissionFlag.TimedDefense|MissionFlag.VsZerg|MissionFlag.HasRaceSwap
-    EVACUATION = 4, "Evacuation", SC2Campaign.WOL, "Colonist", SC2Race.TERRAN, MissionPools.EASY, "ap_evacuation", MissionFlag.Terran|MissionFlag.AutoScroller|MissionFlag.VsZerg
-    OUTBREAK = 5, "Outbreak", SC2Campaign.WOL, "Colonist", SC2Race.TERRAN, MissionPools.EASY, "ap_outbreak", MissionFlag.Terran|MissionFlag.Defense|MissionFlag.VsZerg
+    EVACUATION = 4, "Evacuation (Terran)", SC2Campaign.WOL, "Colonist", SC2Race.TERRAN, MissionPools.EASY, "ap_evacuation", MissionFlag.Terran|MissionFlag.AutoScroller|MissionFlag.VsZerg|MissionFlag.HasRaceSwap
+    OUTBREAK = 5, "Outbreak (Terran)", SC2Campaign.WOL, "Colonist", SC2Race.TERRAN, MissionPools.EASY, "ap_outbreak", MissionFlag.Terran|MissionFlag.Defense|MissionFlag.VsZerg|MissionFlag.HasRaceSwap
     SAFE_HAVEN = 6, "Safe Haven", SC2Campaign.WOL, "Colonist", SC2Race.TERRAN, MissionPools.MEDIUM, "ap_safe_haven", MissionFlag.Terran|MissionFlag.Countdown|MissionFlag.VsProtoss
     HAVENS_FALL = 7, "Haven's Fall", SC2Campaign.WOL, "Colonist", SC2Race.TERRAN, MissionPools.MEDIUM, "ap_havens_fall", MissionFlag.Terran|MissionFlag.VsZerg
     SMASH_AND_GRAB = 8, "Smash and Grab (Terran)", SC2Campaign.WOL, "Artifact", SC2Race.TERRAN, MissionPools.EASY, "ap_smash_and_grab", MissionFlag.Terran|MissionFlag.Countdown|MissionFlag.VsPZ|MissionFlag.HasRaceSwap
@@ -202,8 +202,10 @@ class SC2Mission(Enum):
     THE_OUTLAWS_P = 87, "The Outlaws (Protoss)", SC2Campaign.WOL, "Mar Sara", SC2Race.PROTOSS, MissionPools.EASY, "ap_the_outlaws", MissionFlag.Protoss|MissionFlag.VsTerran|MissionFlag.RaceSwap
     ZERO_HOUR_Z = 88, "Zero Hour (Zerg)", SC2Campaign.WOL, "Mar Sara", SC2Race.ZERG, MissionPools.EASY, "ap_zero_hour", MissionFlag.Zerg|MissionFlag.TimedDefense|MissionFlag.VsZerg|MissionFlag.RaceSwap
     ZERO_HOUR_P = 89, "Zero Hour (Protoss)", SC2Campaign.WOL, "Mar Sara", SC2Race.PROTOSS, MissionPools.EASY, "ap_zero_hour", MissionFlag.Protoss|MissionFlag.TimedDefense|MissionFlag.VsZerg|MissionFlag.RaceSwap
-    # 90/91 - Evacuation
-    # 92/93 - Outbreak
+    EVACUATION_Z = 90, "Evacuation (Zerg)", SC2Campaign.WOL, "Colonist", SC2Race.ZERG, MissionPools.EASY, "ap_evacuation", MissionFlag.Zerg|MissionFlag.AutoScroller|MissionFlag.VsZerg|MissionFlag.RaceSwap
+    EVACUATION_P = 91, "Evacuation (Protoss)", SC2Campaign.WOL, "Colonist", SC2Race.PROTOSS, MissionPools.EASY, "ap_evacuation", MissionFlag.Protoss|MissionFlag.AutoScroller|MissionFlag.VsZerg|MissionFlag.RaceSwap
+    OUTBREAK_Z = 92, "Outbreak (Zerg)", SC2Campaign.WOL, "Colonist", SC2Race.ZERG, MissionPools.EASY, "ap_outbreak", MissionFlag.Zerg|MissionFlag.Defense|MissionFlag.VsZerg|MissionFlag.RaceSwap
+    OUTBREAK_P = 93, "Outbreak (Protoss)", SC2Campaign.WOL, "Colonist", SC2Race.PROTOSS, MissionPools.EASY, "ap_outbreak", MissionFlag.Protoss|MissionFlag.Defense|MissionFlag.VsZerg|MissionFlag.RaceSwap
     # 94/95 - Safe Haven
     # 96/97 - Haven's Fall
     SMASH_AND_GRAB_Z = 98, "Smash and Grab (Zerg)", SC2Campaign.WOL, "Artifact", SC2Race.ZERG, MissionPools.EASY, "ap_smash_and_grab", MissionFlag.Zerg|MissionFlag.Countdown|MissionFlag.VsPZ|MissionFlag.RaceSwap

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -149,7 +149,7 @@ class MaximumCampaignSize(Range):
     """
     display_name = "Maximum Campaign Size"
     range_start = 1
-    range_end = 89
+    range_end = 93
     default = 83
 
 


### PR DESCRIPTION
## What is this fixing or adding?
- Adding Zerg/Protoss versions of Evacuation and Outbreak for a total of 4 new mission variants
- Also adding logic to check zerg/protoss defense ratings, which comes up a lot more often in Wings of Liberty

## How was this tested?
Generated few worlds with the missions added, ensured that they existed (or didn't exist) as needed, and loaded the missions from the launcher to ensure they were configured correctly
