### PR TITLE
sc2: Client-side changes for adept war council upgrade - disruptive transfer

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -851,6 +851,7 @@ item_descriptions = {
     item_names.STALKER_PHASE_REACTOR: "Stalker War Council upgrade. Stalkers restore 80 shields over 5 seconds after they Blink.",
     item_names.DRAGOON_PHALANX_SUIT: "Dragoon War Council upgrade. Dragoons gain +2 range, move slightly faster, and can form tighter formations.",
     item_names.INSTIGATOR_RESOURCE_EFFICIENCY: f"Instigator War Council upgrade. {_get_resource_efficiency_desc(item_names.INSTIGATOR)}",
+    item_names.ADEPT_DISRUPTIVE_TRANSFER: "Adept War Council upgrade. Adept shades apply a debuff to enemies they touch, increasing damage taken by +5.",
     item_names.SOA_CHRONO_SURGE: "The Spear of Adun increases a target structure's unit warp in and research speeds by +1000% for 20 seconds.",
     item_names.SOA_PROGRESSIVE_PROXY_PYLON: inspect.cleandoc("""
         Level 1: The Spear of Adun quickly warps in a Pylon to a target location.

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -685,6 +685,7 @@ SENTINEL_RESOURCE_EFFICIENCY                            = "Resource Efficiency (
 STALKER_PHASE_REACTOR                                   = "Phase Reactor (Stalker)"
 DRAGOON_PHALANX_SUIT                                    = "Phalanx Suit (Dragoon)"
 INSTIGATOR_RESOURCE_EFFICIENCY                          = "Resource Efficiency (Instigator)"
+ADEPT_DISRUPTIVE_TRANSFER                               = "Disruptive Transfer (Adept)"
 
 # Spear Of Adun
 SOA_CHRONO_SURGE            = "Chrono Surge (Spear of Adun Calldown)"

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1712,6 +1712,7 @@ item_table = {
     item_names.STALKER_PHASE_REACTOR: ItemData(503 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 3, SC2Race.PROTOSS, parent_item=item_names.STALKER),
     item_names.DRAGOON_PHALANX_SUIT: ItemData(504 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 4, SC2Race.PROTOSS, parent_item=item_names.DRAGOON),
     item_names.INSTIGATOR_RESOURCE_EFFICIENCY: ItemData(505 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 5, SC2Race.PROTOSS, parent_item=item_names.INSTIGATOR),
+    item_names.ADEPT_DISRUPTIVE_TRANSFER: ItemData(506 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 6, SC2Race.PROTOSS, parent_item=item_names.ADEPT),
 
     # SoA Calldown powers
     item_names.SOA_CHRONO_SURGE: ItemData(700 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Spear_Of_Adun, 0, SC2Race.PROTOSS, origin={"lotv"}),


### PR DESCRIPTION
## What is this fixing or adding?
Adding the Adept war council nerf / upgrade - client-side changes.

See [data PR #198](https://github.com/Ziktofel/Archipelago-SC2-data/pull/198)

## How was this tested?
Created a new game, `/send` an adept, started a map, built an adept, verified the upgrade was missing, did a `/send phaneros Disruptive Transfer (Adept)` and verified it appeared in-game

## If this makes graphical changes, please attach screenshots.
See data PR.