### PR TITLE
sc2: Adding a new location category for speedrun objectives

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -29,7 +29,7 @@ from . import options
 from .options import (
     MissionOrder, KerriganPrimalStatus, kerrigan_unit_available, KerriganPresence, EnableMorphling,
     GameSpeed, GenericUpgradeItems, GenericUpgradeResearch, ColorChoice, GenericUpgradeMissions,
-    LocationInclusion, ExtraLocations, MasteryLocations, ChallengeLocations, VanillaLocations,
+    LocationInclusion, ExtraLocations, MasteryLocations, SpeedrunLocations, ChallengeLocations, VanillaLocations,
     DisableForcedCamera, SkipCutscenes, GrantStoryTech, GrantStoryLevels, TakeOverAIAllies, RequiredTactics,
     SpearOfAdunPresence, SpearOfAdunPresentInNoBuild, SpearOfAdunAutonomouslyCastAbilityPresence,
     SpearOfAdunAutonomouslyCastPresentInNoBuild, NerfUnitBaselines, LEGACY_GRID_ORDERS,
@@ -665,6 +665,7 @@ class SC2Context(CommonContext):
                 LocationType.EXTRA: args["slot_data"].get("extra_locations", ExtraLocations.default),
                 LocationType.CHALLENGE: args["slot_data"].get("challenge_locations", ChallengeLocations.default),
                 LocationType.MASTERY: args["slot_data"].get("mastery_locations", MasteryLocations.default),
+                LocationType.SPEEDRUN: args["slot_data"].get("speedrun_locations", SpeedrunLocations.default),
             }
             self.plando_locations = args["slot_data"].get("plando_locations", [])
 

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -31,6 +31,7 @@ class LocationType(IntEnum):
     EXTRA = 2  # Additional locations based on mission progression, collecting in-mission rewards, etc. that do not significantly increase the challenge.
     CHALLENGE = 3  # Challenging objectives, often harder than just completing a mission, and often associated with Achievements
     MASTERY = 4  # Extremely challenging objectives often associated with Masteries and Feats of Strength in the original campaign
+    SPEEDRUN = 5  # Objectives based around beating objectives within a time-limit
 
 
 class LocationData(NamedTuple):
@@ -53,9 +54,7 @@ def make_location_data(
 
 def get_location_types(world: 'SC2World', inclusion_type: int) -> Set[LocationType]:
     """
-
-    :param multiworld:
-    :param player:
+    :param world: The starcraft 2 world object
     :param inclusion_type: Level of inclusion to check for
     :return: A list of location types that match the inclusion type
     """
@@ -63,7 +62,8 @@ def get_location_types(world: 'SC2World', inclusion_type: int) -> Set[LocationTy
         ("vanilla_locations", LocationType.VANILLA),
         ("extra_locations", LocationType.EXTRA),
         ("challenge_locations", LocationType.CHALLENGE),
-        ("mastery_locations", LocationType.MASTERY)
+        ("mastery_locations", LocationType.MASTERY),
+        ("speedrun_locations", LocationType.SPEEDRUN),
     ]
     excluded_location_types = set()
     for option_name, location_type in exclusion_options:

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -882,6 +882,22 @@ class MasteryLocations(LocationInclusion):
     display_name = "Mastery Locations"
 
 
+class SpeedrunLocations(LocationInclusion):
+    """
+    Enables or disables item rewards for overcoming speedrun challenges.
+    These challenges are often based on speed achievements or community challenges.
+    Enable these locations if you want to be rewarded for going fast.
+
+    Enabled: All locations fitting into this do their normal rewards
+    Resources: Forces these locations to contain Starting Resources
+    Disabled: Removes item rewards from these locations.
+
+    Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
+    See also: Excluded Locations, Item Plando (https://archipelago.gg/tutorial/Archipelago/plando/en#item-plando)
+    """
+    display_name = "Speedrun Locations"
+
+
 class MineralsPerItem(Range):
     """
     Configures how many minerals are given per resource item.
@@ -973,6 +989,7 @@ class Starcraft2Options(PerGameCommonOptions):
     extra_locations: ExtraLocations
     challenge_locations: ChallengeLocations
     mastery_locations: MasteryLocations
+    speedrun_locations: SpeedrunLocations
     minerals_per_item: MineralsPerItem
     vespene_per_item: VespenePerItem
     starting_supply_per_item: StartingSupplyPerItem


### PR DESCRIPTION
## What is this fixing or adding?
Adding a new location category for speedrun objectives (beat / achieve X in Y amount of time). Spurred by having several of these objectives in the planner with no clear category to put them in, and Gemster already having a couple implemented.

## How was this tested?
Set Liberation Day statue 2 to a speedrun category, gen'd and ran the mission with speedrun locations option set differently in the yaml (once enabled, once disabled). Verified:
* The correct number of checks showed in the mission
* The client display showed the objective in a category when enabled
* The client display didn't show the location when the category was excluded

(I reset the statue category when I was done ofc)

## If this makes graphical changes, please attach screenshots.
With speedrun _included_
![image](https://github.com/user-attachments/assets/506f244c-e030-4627-83fb-ad4f1b0b4ab6)
With speedrun _excluded_
![image](https://github.com/user-attachments/assets/fb970acf-8294-48e8-8d56-604431bfa731)
