### PR TITLE
sc2: Added location groups

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -15,6 +15,7 @@ from .items import (
 )
 from . import items
 from . import item_groups
+from . import location_groups
 from .locations import get_locations, get_location_types, get_plando_locations
 from .regions import create_regions
 from .options import (
@@ -90,6 +91,7 @@ class SC2World(World):
     options: Starcraft2Options
 
     item_name_groups = item_groups.item_name_groups
+    location_name_groups = location_groups.get_location_groups()
     locked_locations: List[str]
     """Locations locked to contain specific items, such as victory events or forced resources"""
     location_cache: List[Location]

--- a/worlds/sc2/location_groups.py
+++ b/worlds/sc2/location_groups.py
@@ -1,0 +1,40 @@
+"""
+Location group definitions
+"""
+
+from typing import Dict, Set, Iterable
+from .locations import get_locations, LocationData
+from .mission_tables import lookup_name_to_mission, MissionFlag
+
+def get_location_groups() -> Dict[str, Set[str]]:
+    result: Dict[str, Set[str]] = {}
+    locations: Iterable[LocationData] = get_locations(None)
+
+    for location in locations:
+        if location.code is None:
+            # Beat events
+            continue
+        mission = lookup_name_to_mission.get(location.region)
+        if mission is None:
+            continue
+
+        if (MissionFlag.HasRaceSwap|MissionFlag.RaceSwap) & mission.flags:
+            # Location group including race-swapped variants of a location
+            agnostic_location_name = (
+                location.name
+                .replace(' (Terran)', '')
+                .replace(' (Protoss)', '')
+                .replace(' (Zerg)', '')
+            )
+            result.setdefault(agnostic_location_name, set()).add(location.name)
+
+            # Location group including all locations in all raceswaps
+            result.setdefault(mission.mission_name[:mission.mission_name.find(' (')], set()).add(location.name)
+
+        # Location group including all locations in a mission
+        result.setdefault(mission.mission_name, set()).add(location.name)
+
+        # Location group by location category
+        result.setdefault(location.type.name.title(), set()).add(location.name)
+
+    return result

--- a/worlds/sc2/test/test_location_groups.py
+++ b/worlds/sc2/test/test_location_groups.py
@@ -1,0 +1,37 @@
+import unittest
+from .. import location_groups
+from ..mission_tables import SC2Mission, MissionFlag
+
+
+class TestLocationGroups(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.location_groups = location_groups.get_location_groups()
+
+    def test_location_categories_have_a_group(self) -> None:
+        self.assertIn('Victory', self.location_groups)
+        self.assertIn(f'{SC2Mission.LIBERATION_DAY.mission_name}: Victory', self.location_groups['Victory'])
+        self.assertIn(f'{SC2Mission.IN_UTTER_DARKNESS.mission_name}: Defeat', self.location_groups['Victory'])
+        self.assertIn('Vanilla', self.location_groups)
+        self.assertIn(f'{SC2Mission.WELCOME_TO_THE_JUNGLE.mission_name}: Close Relic', self.location_groups['Vanilla'])
+        self.assertIn('Extra', self.location_groups)
+        self.assertIn(f'{SC2Mission.SMASH_AND_GRAB.mission_name}: First Forcefield Area Busted', self.location_groups['Extra'])
+        self.assertIn('Challenge', self.location_groups)
+        self.assertIn(f'{SC2Mission.ZERO_HOUR.mission_name}: First Hatchery', self.location_groups['Challenge'])
+        self.assertIn('Mastery', self.location_groups)
+        self.assertIn(f'{SC2Mission.WELCOME_TO_THE_JUNGLE.mission_name}: Main Base', self.location_groups['Mastery'])
+
+    def test_missions_have_a_group(self) -> None:
+        self.assertIn(SC2Mission.LIBERATION_DAY.mission_name, self.location_groups)
+        self.assertIn(f'{SC2Mission.LIBERATION_DAY.mission_name}: Victory', self.location_groups[SC2Mission.LIBERATION_DAY.mission_name])
+        self.assertIn(f'{SC2Mission.LIBERATION_DAY.mission_name}: Special Delivery', self.location_groups[SC2Mission.LIBERATION_DAY.mission_name])
+
+    def test_race_swapped_locations_share_a_group(self) -> None:
+        self.assertIn(MissionFlag.HasRaceSwap, SC2Mission.ZERO_HOUR.flags)
+        ZERO_HOUR = 'Zero Hour'
+        self.assertNotEqual(ZERO_HOUR, SC2Mission.ZERO_HOUR.mission_name)
+        self.assertIn(ZERO_HOUR, self.location_groups)
+        self.assertIn(f'{ZERO_HOUR}: Victory', self.location_groups)
+        self.assertIn(f'{SC2Mission.ZERO_HOUR.mission_name}: Victory', self.location_groups[f'{ZERO_HOUR}: Victory'])
+        self.assertIn(f'{SC2Mission.ZERO_HOUR_P.mission_name}: Victory', self.location_groups[f'{ZERO_HOUR}: Victory'])
+        self.assertIn(f'{SC2Mission.ZERO_HOUR_Z.mission_name}: Victory', self.location_groups[f'{ZERO_HOUR}: Victory'])


### PR DESCRIPTION
## What is this fixing or adding?
Added location groups per discussion in discord:
* Race-swapped variants of a location get a group (ie "Outlaws (z): Rebel Base", "Outlaws (t): Rebel Base" -> "Outlaws: Rebel Base")
* All locations belonging to any race-swap of a mission get a group
* All locations in a mission get a group
* Location categories get a group

## How was this tested?
* Opened the client, ran `/location_groups` to verify AP was picking up the groups
* Added some unit tests to sanity check some basic cases of the new item groups
* Generated with a yaml that excluded `The Outlaws: North Resource Pickups`. Verified all race-swapped variants were excluded in the spoiler (other Outlaws locations still appeared just fine)

## If this makes graphical changes, please attach screenshots.
None