### PR TITLE
sc2: Fixed an issue where setting a location category to resources wo…

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -623,7 +623,6 @@ def flag_and_add_resource_locations(world: SC2World, item_list: List[FilterItem]
                 item_name = world.random.choice(filler_items)
                 item = create_item_with_correct_settings(world.player, item_name)
                 location.place_locked_item(item)
-                item_list.append(FilterItem(item_name, items.item_table[item_name], 0, ItemFilterFlags.Plando|ItemFilterFlags.Locked))
                 world.locked_locations.append(location.name)
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Fixed an issue where setting a location category to "resources" would generate way too many starting resources.

## How was this tested?
Generated a few games, checked the spoiler. Generations were still successful, total amounts of starting resource items were reduced, but they still appeared on the extra locations properly.

## If this makes graphical changes, please attach screenshots.
None