### PR TITLE
sc2: Adding Dark Templar war council upgrades (Shadow Strike)

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -855,6 +855,8 @@ item_descriptions = {
     item_names.ADEPT_DISRUPTIVE_TRANSFER: "Adept War Council upgrade. Adept shades apply a debuff to enemies they touch, increasing damage taken by +5.",
     item_names.SLAYER_PHASE_BLINK: "Slayer War Council upgrade. Slayers can now blink. After blinking, the Slayer's next attack within 8 seconds deals double damage.",
     item_names.AVENGER_KRYHAS_CLOAK: "Avenger War Council upgrade. Avengers are now permanently cloaked.",
+    item_names.DARK_TEMPLAR_LESSER_SHADOW_FURY: "Dark Templar War Council upgrade. Dark Templar gain two strikes of their Shadow Fury ability.",
+    item_names.DARK_TEMPLAR_GREATER_SHADOW_FURY: "Dark Templar War Council upgrade. Dark Templar gain three strikes of their Shadow Fury ability.",
     item_names.SOA_CHRONO_SURGE: "The Spear of Adun increases a target structure's unit warp in and research speeds by +1000% for 20 seconds.",
     item_names.SOA_PROGRESSIVE_PROXY_PYLON: inspect.cleandoc("""
         Level 1: The Spear of Adun quickly warps in a Pylon to a target location.

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -689,6 +689,8 @@ INSTIGATOR_RESOURCE_EFFICIENCY                          = "Resource Efficiency (
 ADEPT_DISRUPTIVE_TRANSFER                               = "Disruptive Transfer (Adept)"
 SLAYER_PHASE_BLINK                                      = "Phase Blink (Slayer)"
 AVENGER_KRYHAS_CLOAK                                    = "Kryhas Cloak (Avenger)"
+DARK_TEMPLAR_LESSER_SHADOW_FURY                         = "Lesser Shadow Fury (Dark Templar)"
+DARK_TEMPLAR_GREATER_SHADOW_FURY                        = "Greater Shadow Fury (Dark Templar)"
 
 # Spear Of Adun
 SOA_CHRONO_SURGE            = "Chrono Surge (Spear of Adun Calldown)"

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1718,6 +1718,8 @@ item_table = {
     item_names.ADEPT_DISRUPTIVE_TRANSFER: ItemData(506 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 6, SC2Race.PROTOSS, parent_item=item_names.ADEPT),
     item_names.SLAYER_PHASE_BLINK: ItemData(507 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 7, SC2Race.PROTOSS, parent_item=item_names.SLAYER),
     item_names.AVENGER_KRYHAS_CLOAK: ItemData(508 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 8, SC2Race.PROTOSS, parent_item=item_names.AVENGER),
+    item_names.DARK_TEMPLAR_LESSER_SHADOW_FURY: ItemData(509 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 9, SC2Race.PROTOSS, parent_item=item_names.DARK_TEMPLAR),
+    item_names.DARK_TEMPLAR_GREATER_SHADOW_FURY: ItemData(510 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 10, SC2Race.PROTOSS, parent_item=item_names.DARK_TEMPLAR),
 
     # SoA Calldown powers
     item_names.SOA_CHRONO_SURGE: ItemData(700 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Spear_Of_Adun, 0, SC2Race.PROTOSS, origin={"lotv"}),


### PR DESCRIPTION
## What is this fixing or adding?
Client-side changes for DT war council upgrade (Shadow Fury).

Pairs with [Data PR #208](https://github.com/Ziktofel/Archipelago-SC2-data/pull/208)

## How was this tested?
The usual:
* Spun up a new world
* Started a mission, checked DTs don't have shadow fury
* `/send phaneros lesser shadow fury (dark templar)`, verified it showed up correctly
* `/send phaneros greater shadow fury (dark templar)`, verified it showed up correctly

## If this makes graphical changes, please attach screenshots.
See data PR for details.