### PR TITLE
sc2: Added blood hunter war council upgrade -- brutal efficiency

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -857,6 +857,7 @@ item_descriptions = {
     item_names.AVENGER_KRYHAS_CLOAK: "Avenger War Council upgrade. Avengers are now permanently cloaked.",
     item_names.DARK_TEMPLAR_LESSER_SHADOW_FURY: "Dark Templar War Council upgrade. Dark Templar gain two strikes of their Shadow Fury ability.",
     item_names.DARK_TEMPLAR_GREATER_SHADOW_FURY: "Dark Templar War Council upgrade. Dark Templar gain three strikes of their Shadow Fury ability.",
+    item_names.BLOOD_HUNTER_BRUTAL_EFFICIENCY: "Blood Hunter War Council upgrade. Blood Hunters attack over twice as quickly.",
     item_names.SOA_CHRONO_SURGE: "The Spear of Adun increases a target structure's unit warp in and research speeds by +1000% for 20 seconds.",
     item_names.SOA_PROGRESSIVE_PROXY_PYLON: inspect.cleandoc("""
         Level 1: The Spear of Adun quickly warps in a Pylon to a target location.

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -691,6 +691,7 @@ SLAYER_PHASE_BLINK                                      = "Phase Blink (Slayer)"
 AVENGER_KRYHAS_CLOAK                                    = "Kryhas Cloak (Avenger)"
 DARK_TEMPLAR_LESSER_SHADOW_FURY                         = "Lesser Shadow Fury (Dark Templar)"
 DARK_TEMPLAR_GREATER_SHADOW_FURY                        = "Greater Shadow Fury (Dark Templar)"
+BLOOD_HUNTER_BRUTAL_EFFICIENCY                          = "Brutal Efficiency (Blood Hunter)"
 
 # Spear Of Adun
 SOA_CHRONO_SURGE            = "Chrono Surge (Spear of Adun Calldown)"

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1720,6 +1720,7 @@ item_table = {
     item_names.AVENGER_KRYHAS_CLOAK: ItemData(508 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 8, SC2Race.PROTOSS, parent_item=item_names.AVENGER),
     item_names.DARK_TEMPLAR_LESSER_SHADOW_FURY: ItemData(509 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 9, SC2Race.PROTOSS, parent_item=item_names.DARK_TEMPLAR),
     item_names.DARK_TEMPLAR_GREATER_SHADOW_FURY: ItemData(510 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 10, SC2Race.PROTOSS, parent_item=item_names.DARK_TEMPLAR),
+    item_names.BLOOD_HUNTER_BRUTAL_EFFICIENCY: ItemData(511 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 11, SC2Race.PROTOSS, parent_item=item_names.BLOOD_HUNTER),
 
     # SoA Calldown powers
     item_names.SOA_CHRONO_SURGE: ItemData(700 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Spear_Of_Adun, 0, SC2Race.PROTOSS, origin={"lotv"}),


### PR DESCRIPTION
## What is this fixing or adding?
Added the Blood Hunter war council upgrade -- Brutal Efficiency. Greatly increases the blood hunter's attack rate.

Pairs with [data PR #210](https://github.com/Ziktofel/Archipelago-SC2-data/pull/210)

## How was this tested?
The usual - spun up a world, checked the nerf was present, `/send` to get the upgrade, checked vanilla stats were restored.

## If this makes graphical changes, please attach screenshots.
See data PR