### PR TITLE
Mm/misc client fixes

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -24,6 +24,7 @@ from .options import (
     get_enabled_campaigns, SpearOfAdunAutonomouslyCastAbilityPresence, Starcraft2Options,
     GrantStoryTech, GenericUpgradeResearch, GenericUpgradeItems,
 )
+from . import settings
 from .pool_filter import filter_items
 from .mission_tables import (
     MissionInfo, SC2Campaign, SC2Mission, SC2Race, MissionFlag
@@ -84,6 +85,7 @@ class SC2World(World):
 
     game = "Starcraft 2"
     web = Starcraft2WebWorld()
+    settings: ClassVar[settings.Starcraft2Settings]
 
     item_name_to_id = {name: data.code for name, data in get_full_item_list().items()}
     location_name_to_id = {location.name: location.code for location in get_locations(None)}

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -35,6 +35,7 @@ from .options import (
     SpearOfAdunAutonomouslyCastPresentInNoBuild, NerfUnitBaselines, LEGACY_GRID_ORDERS,
 )
 from .mission_tables import MissionFlag
+from . import SC2World
 
 
 if __name__ == "__main__":
@@ -416,6 +417,17 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             self.ctx.__dict__[var_names[faction]] = match_colors.index(color.lower())
             self.ctx.pending_color_update = True
             self.output(f"Color for {faction} set to " + player_colors[self.ctx.__dict__[var_names[faction]]])
+
+    def _cmd_windowed_mode(self, value="") -> None:
+        if not value:
+            pass
+        elif value.casefold() in ('t', 'true', 'yes', 'y'):
+            SC2World.settings.game_windowed_mode = True
+            force_settings_save_on_close()
+        else:
+            SC2World.settings.game_windowed_mode = False
+            force_settings_save_on_close()
+        sc2_logger.info(f"Windowed mode is: {SC2World.settings.game_windowed_mode}")
 
     def _cmd_disable_mission_check(self) -> bool:
         """Disables the check to see if a mission is available to play.  Meant for co-op runs where one player can play
@@ -1077,8 +1089,11 @@ async def starcraft_launch(ctx: SC2Context, mission_id: int):
     sc2_logger.info(f"Launching {lookup_id_to_mission[mission_id].mission_name}. If game does not launch check log file for errors.")
 
     with DllDirectory(None):
-        run_game(bot.maps.get(lookup_id_to_mission[mission_id].map_file), [Bot(Race.Terran, ArchipelagoBot(ctx, mission_id),
-                                                                name="Archipelago", fullscreen=True)], realtime=True)
+        run_game(
+            bot.maps.get(lookup_id_to_mission[mission_id].map_file),
+            [Bot(Race.Terran, ArchipelagoBot(ctx, mission_id), name="Archipelago", fullscreen=not SC2World.settings.game_windowed_mode)],
+            realtime=True,
+        )
 
 
 class ArchipelagoBot(bot.bot_ai.BotAI):
@@ -1727,6 +1742,20 @@ def is_mod_update_available(owner: str, repo: str, api_version: str, metadata: s
 def get_location_offset(mission_id):
     return SC2WOL_LOC_ID_OFFSET if mission_id <= SC2Mission.ALL_IN.id \
         else (SC2HOTS_LOC_ID_OFFSET - SC2Mission.ALL_IN.id * VICTORY_MODULO)
+
+
+_has_forced_save = False
+def force_settings_save_on_close() -> None:
+    """
+    Settings has an existing auto-save feature, but it only triggers if a new key was introduced.
+    Force it to mark things as changed by introducing a new key and then cleaning up.
+    """
+    global _has_forced_save
+    if _has_forced_save:
+        return
+    SC2World.settings.update({'invalid_attribute': True})
+    del SC2World.settings.invalid_attribute
+    _has_forced_save = True
 
 
 def launch():

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -731,9 +731,10 @@ class SC2Context(CommonContext):
         super(SC2Context, self).on_print_json(args)
 
     def run_gui(self) -> None:
+        from .gui_config import apply_window_defaults
+        warnings = apply_window_defaults()
         from .client_gui import start_gui
-        start_gui(self)
-
+        start_gui(self, warnings)
 
     async def shutdown(self) -> None:
         await super(SC2Context, self).shutdown()

--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -14,7 +14,7 @@ from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.scrollview import ScrollView
 from kivy.properties import StringProperty, BooleanProperty
 
-from worlds.sc2.client import SC2Context, calc_unfinished_missions, parse_unlock
+from worlds.sc2.client import SC2Context, calc_unfinished_missions, parse_unlock, force_settings_save_on_close
 from worlds.sc2.mission_tables import lookup_id_to_mission, lookup_name_to_mission, campaign_race_exceptions, \
     SC2Mission, SC2Race, SC2Campaign
 from worlds.sc2.locations import LocationType, lookup_location_id_to_type
@@ -72,20 +72,6 @@ class MissionLayout(GridLayout):
 
 class MissionCategory(GridLayout):
     pass
-
-
-_has_forced_save = False
-def force_settings_save_on_close() -> None:
-    """
-    Settings has an existing auto-save feature, but it only triggers if a new key was introduced.
-    Force it to mark things as changed by introducing a new key and then cleaning up.
-    """
-    global _has_forced_save
-    if _has_forced_save:
-        return
-    SC2World.settings.update({'invalid_attribute': True})
-    del SC2World.settings.invalid_attribute
-    _has_forced_save = True
 
 
 class SC2Manager(GameManager):

--- a/worlds/sc2/gui_config.py
+++ b/worlds/sc2/gui_config.py
@@ -1,0 +1,40 @@
+"""
+Import this before importing client_gui.py to set window defaults from world settings.
+"""
+from .settings import Starcraft2Settings
+from typing import List
+
+def apply_window_defaults() -> List[str]:
+    """
+    Set the kivy config keys from the sc2world user settings.
+    Returns a list of warnings to be printed once the GUI is started.
+    """
+    from . import SC2World
+    # This is necessary to prevent kivy from failing because it got invalid command-line args,
+    # or from spamming the logs.
+    # Must happen before importing kivy.config
+    import os
+    os.environ["KIVY_NO_CONSOLELOG"] = "1"
+    os.environ["KIVY_NO_FILELOG"] = "1"
+    os.environ["KIVY_NO_ARGS"] = "1"
+    os.environ["KIVY_LOG_ENABLE"] = "0"
+
+    # validate settings
+    warnings: List[str] = []
+    if isinstance(SC2World.settings.window_height, int) and SC2World.settings.window_height > 0:
+        window_height = SC2World.settings.window_height
+    else:
+        warnings.append(f"Invalid value for options.yaml key sc2_options.window_height: '{SC2World.settings.window_height}'. Expected a positive integer.")
+        window_height = Starcraft2Settings.window_height
+    if isinstance(SC2World.settings.window_width, int) and SC2World.settings.window_width > 0:
+        window_width = SC2World.settings.window_width
+    else:
+        warnings.append(f"Invalid value for options.yaml key sc2_options.window_width: '{SC2World.settings.window_width}'. Expected a positive integer.")
+        window_width = Starcraft2Settings.window_width
+
+    from kivy.config import Config
+    Config.set('graphics', 'width', str(window_width))
+    Config.set('graphics', 'height', str(window_height))
+    if SC2World.settings.window_maximized:
+        Config.set('graphics', 'window_state', 'maximized')
+    return warnings

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -203,6 +203,11 @@ class PlayerColorZergPrimal(ColorChoice):
     display_name = "Zerg Player Color (Primal)"
 
 
+class PlayerColorNova(ColorChoice):
+    """Determines in-game team color for playable Zerg factions after Kerrigan becomes Primal Kerrigan."""
+    display_name = "Terran Player Color (Nova)"
+
+
 class EnableWolMissions(DefaultOnToggle):
     """
     Enables missions from main Wings of Liberty campaign.
@@ -943,6 +948,7 @@ class Starcraft2Options(PerGameCommonOptions):
     player_color_protoss: PlayerColorProtoss
     player_color_zerg: PlayerColorZerg
     player_color_zerg_primal: PlayerColorZergPrimal
+    player_color_nova: PlayerColorNova
     selected_races: SelectRaces
     enable_wol_missions: EnableWolMissions
     enable_prophecy_missions: EnableProphecyMissions

--- a/worlds/sc2/settings.py
+++ b/worlds/sc2/settings.py
@@ -9,7 +9,10 @@ class Starcraft2Settings(settings.Group):
         """The starting height the client window in pixels"""
     class StartMaximized(settings.Bool):
         """Controls whether the client window should start maximized"""
+    class GameWindowedMode(settings.Bool):
+        """Controls whether the game should start in windowed mode"""
 
     window_width = WindowWidth(1080)
     window_height = WindowHeight(720)
     window_maximized: Union[StartMaximized, bool] = False
+    game_windowed_mode: Union[GameWindowedMode, bool] = False

--- a/worlds/sc2/settings.py
+++ b/worlds/sc2/settings.py
@@ -1,0 +1,15 @@
+from typing import Union
+import settings
+
+
+class Starcraft2Settings(settings.Group):
+    class WindowWidth(int):
+        """The starting width the client window in pixels"""
+    class WindowHeight(int):
+        """The starting height the client window in pixels"""
+    class StartMaximized(settings.Bool):
+        """Controls whether the client window should start maximized"""
+
+    window_width = WindowWidth(1080)
+    window_height = WindowHeight(720)
+    window_maximized: Union[StartMaximized, bool] = False


### PR DESCRIPTION
## What is this fixing or adding?
Some configuration configuration options we've been lacking for a while:
* yaml option for Nova colour
* Added settings class
* Bigger window start size (configurable in options.yaml)
* Client maximize state is remembered across sessions (and stored in options.yaml)
* sc2 can now boot in windowed mode (controlled with a setting in options.yaml, or changeable with `/windowed_mode` in client)

## How was this tested?
* Closed and restarted the client a lot, maximizing, restoring, and minimizing to check the state
* Verified the client started larger by default, and size was configurable with options.yaml
* If an invalid window size was specified (not an int, negative), verified the window fell back to default values and printed a warning
* Set the Nova colour in the yaml and verified the client saw it with `/color nova`
* Set the `/windowed_mode` option and started a mission

## If this makes graphical changes, please attach screenshots.
new default size:
![image](https://github.com/user-attachments/assets/4cf43348-88e8-47e3-b454-f22be90a7891)

New windowed mode:
![image](https://github.com/user-attachments/assets/06b1172f-431c-4ec9-bf14-cc4f976e074b)
