### PR TITLE
sc2: Added Dark Archon War Council upgrade -- Indomitable Will

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -870,7 +870,7 @@ item_descriptions = {
     item_names.ENERGIZER_MOBILE_CHRONO_BEAM: "Energizer War Council upgrade. Allows Energizers to use Chrono Beam in Mobile Mode.",
     item_names.HAVOC_ENDURING_SIGHT: "Havoc War Council upgrade. Havoc Squad Sight stays up indefinitely and no longer takes energy.",
     item_names.HIGH_TEMPLAR_PLASMA_SURGE: "High Templar War Council upgrade. High Templar Psionic Storm will heal fiendly protoss shields under it.",
-    # item_names.DARK_ARCHON_INDOMITABLE_WILL: "Dark Archon War Council upgrade. Casting Mind Control will no longer deplete the Dark Archon's shields.",
+    item_names.DARK_ARCHON_INDOMITABLE_WILL: "Dark Archon War Council upgrade. Casting Mind Control will no longer deplete the Dark Archon's shields.",
     item_names.SOA_CHRONO_SURGE: "The Spear of Adun increases a target structure's unit warp in and research speeds by +1000% for 20 seconds.",
     item_names.SOA_PROGRESSIVE_PROXY_PYLON: inspect.cleandoc("""
         Level 1: The Spear of Adun quickly warps in a Pylon to a target location.

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -706,7 +706,7 @@ HAVOC_ENDURING_SIGHT                                    = "Enduring Sight (Havoc
 HIGH_TEMPLAR_PLASMA_SURGE                               = "Plasma Surge (High Templar)"
 # Signifier
 # Ascendant
-# DARK_ARCHON_INDOMITABLE_WILL                            = "Indomitable Will (Dark Archon)"
+DARK_ARCHON_INDOMITABLE_WILL                            = "Indomitable Will (Dark Archon)"
 # IMMORTAL_IMPROVED_BARRIER                               = "Improved Barrier (Immortal)"
 # Annihilator
 # Vanguard

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1749,7 +1749,7 @@ item_table = {
     item_names.HIGH_TEMPLAR_PLASMA_SURGE: ItemData(515 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 15, SC2Race.PROTOSS, parent_item=item_names.HIGH_TEMPLAR),
     # 516 reserved for Signifier
     # 517 reserved for Ascendant
-    # item_names.DARK_ARCHON_INDOMITABLE_WILL: ItemData(518 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 18, SC2Race.PROTOSS),
+    item_names.DARK_ARCHON_INDOMITABLE_WILL: ItemData(518 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 18, SC2Race.PROTOSS),
     # 518 reserved for Immortal
     # 519 reserved for Annihilator
     # 520 reserved for Vanguard


### PR DESCRIPTION
## What is this fixing or adding?
Adding Dark Archon war council upgrade.

See [data PR #219](https://github.com/Ziktofel/Archipelago-SC2-data/pull/219) for details.

## How was this tested?
The usual: generated, started a mission, verified nerf behaviour, `/send`, verified item received and new behaviour.

## If this makes graphical changes, please attach screenshots.
See data PR.