### PR TITLE
sc2: Skirmisher and Vanguard war council upgrades

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -917,6 +917,7 @@ def calculate_items(ctx: SC2Context) -> typing.Dict[SC2Race, typing.List[int]]:
     # War council option
     if not ctx.nerf_unit_baselines:
         accumulators[SC2Race.PROTOSS][ProtossItemType.War_Council.flag_word] = (1 << 30) - 1
+        accumulators[SC2Race.PROTOSS][ProtossItemType.War_Council_2.flag_word] = (1 << 30) - 1
 
     # Deprecated Orbital Command handling (Backwards compatibility):
     if orbital_command_count > 0:

--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -870,7 +870,27 @@ item_descriptions = {
     item_names.ENERGIZER_MOBILE_CHRONO_BEAM: "Energizer War Council upgrade. Allows Energizers to use Chrono Beam in Mobile Mode.",
     item_names.HAVOC_ENDURING_SIGHT: "Havoc War Council upgrade. Havoc Squad Sight stays up indefinitely and no longer takes energy.",
     item_names.HIGH_TEMPLAR_PLASMA_SURGE: "High Templar War Council upgrade. High Templar Psionic Storm will heal fiendly protoss shields under it.",
+    # Signifier
+    # Ascendant
     item_names.DARK_ARCHON_INDOMITABLE_WILL: "Dark Archon War Council upgrade. Casting Mind Control will no longer deplete the Dark Archon's shields.",
+    # Immortal
+    # Annihilator
+    # Vanguard
+    # Stalwart
+    # Colossus
+    # Wrathwalker
+    # Reaver
+    # Disruptor
+    # Warp Prism
+    # Observer
+    # Phoenix
+    # Corsair
+    # Mirage
+    item_names.SKIRMISHER_PEER_CONTEMPT: "Skirmisher War Council upgrade. Allows Skirmishers to target air units.",
+    # Void Ray
+    # Destroyer
+    # Warp Ray
+    # Dawnbringer
     item_names.SOA_CHRONO_SURGE: "The Spear of Adun increases a target structure's unit warp in and research speeds by +1000% for 20 seconds.",
     item_names.SOA_PROGRESSIVE_PROXY_PYLON: inspect.cleandoc("""
         Level 1: The Spear of Adun quickly warps in a Pylon to a target location.

--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -875,7 +875,8 @@ item_descriptions = {
     item_names.DARK_ARCHON_INDOMITABLE_WILL: "Dark Archon War Council upgrade. Casting Mind Control will no longer deplete the Dark Archon's shields.",
     # Immortal
     # Annihilator
-    # Vanguard
+    item_names.VANGUARD_RAPIDFIRE_CANNON: "Vanguard War Council upgrade. Vanguards attack 37% faster.",
+    item_names.VANGUARD_FUSION_MORTARS: "Vanguard War Council upgrade. Vanguards deal +7 damage to armored targets per attack.",
     # Stalwart
     # Colossus
     # Wrathwalker

--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -875,7 +875,7 @@ item_descriptions = {
     item_names.DARK_ARCHON_INDOMITABLE_WILL: "Dark Archon War Council upgrade. Casting Mind Control will no longer deplete the Dark Archon's shields.",
     # Immortal
     # Annihilator
-    item_names.VANGUARD_RAPIDFIRE_CANNON: "Vanguard War Council upgrade. Vanguards attack 37% faster.",
+    item_names.VANGUARD_RAPIDFIRE_CANNON: "Vanguard War Council upgrade. Vanguards attack 38% faster.",
     item_names.VANGUARD_FUSION_MORTARS: "Vanguard War Council upgrade. Vanguards deal +7 damage to armored targets per attack.",
     # Stalwart
     # Colossus

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -717,6 +717,14 @@ DARK_ARCHON_INDOMITABLE_WILL                            = "Indomitable Will (Dar
 # Disruptor
 # Warp Prism
 # Observer
+# Phoenix
+# Corsair
+# Mirage
+SKIRMISHER_PEER_CONTEMPT                                = "Peer Contempt (Skirmisher)"
+# Void Ray
+# Destroyer
+# Warp Ray
+# Dawnbringer
 
 # Spear Of Adun
 SOA_CHRONO_SURGE            = "Chrono Surge (Spear of Adun Calldown)"

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -709,7 +709,8 @@ HIGH_TEMPLAR_PLASMA_SURGE                               = "Plasma Surge (High Te
 DARK_ARCHON_INDOMITABLE_WILL                            = "Indomitable Will (Dark Archon)"
 # IMMORTAL_IMPROVED_BARRIER                               = "Improved Barrier (Immortal)"
 # Annihilator
-# Vanguard
+VANGUARD_RAPIDFIRE_CANNON                               = "Rapid-Fire Cannon (Vanguard)"
+VANGUARD_FUSION_MORTARS                                 = "Fusion Mortars (Vanguard)"
 # Stalwart
 # Colossus
 # Wrathwalker

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -79,6 +79,7 @@ class ProtossItemType(ItemTypeEnum):
     Forge_3 = "Forge", 9
     """General Protoss unit upgrades"""
     War_Council = "War Council", 10
+    War_Council_2 = "War Council", 11
     
 
 class FactionlessItemType(ItemTypeEnum):
@@ -1760,6 +1761,14 @@ item_table = {
     # 525 reserved for Disruptor
     # 526 reserved for Warp Prism
     # 527 reserved for Observer
+    # 530 reserved for Phoenix
+    # 531 reserved for Corsair
+    # 532 reserved for Mirage
+    item_names.SKIRMISHER_PEER_CONTEMPT: ItemData(533 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 3, SC2Race.PROTOSS, parent_item=item_names.SKIRMISHER),
+    # 534 reserved for Void Ray
+    # 535 reserved for Destroyer
+    # 536 reserved for Warp Ray
+    # 537 reserved for Dawnbringer
 
     # SoA Calldown powers
     item_names.SOA_CHRONO_SURGE: ItemData(700 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Spear_Of_Adun, 0, SC2Race.PROTOSS, origin={"lotv"}),

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1765,7 +1765,7 @@ item_table = {
     # 530 reserved for Phoenix
     # 531 reserved for Corsair
     # 532 reserved for Mirage
-    item_names.SKIRMISHER_PEER_CONTEMPT: ItemData(533 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 3, SC2Race.PROTOSS, parent_item=item_names.SKIRMISHER),
+    item_names.SKIRMISHER_PEER_CONTEMPT: ItemData(533 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 3, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.SKIRMISHER),
     # 534 reserved for Void Ray
     # 535 reserved for Destroyer
     # 536 reserved for Warp Ray

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1753,14 +1753,15 @@ item_table = {
     item_names.DARK_ARCHON_INDOMITABLE_WILL: ItemData(518 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 18, SC2Race.PROTOSS),
     # 518 reserved for Immortal
     # 519 reserved for Annihilator
-    # 520 reserved for Vanguard
-    # 521 reserved for Stalwart
-    # 522 reserved for Colossus
-    # 523 reserved for Wrathwalker
-    # 524 reserved for Reaver
-    # 525 reserved for Disruptor
-    # 526 reserved for Warp Prism
-    # 527 reserved for Observer
+    item_names.VANGUARD_RAPIDFIRE_CANNON: ItemData(520 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 20, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
+    item_names.VANGUARD_FUSION_MORTARS: ItemData(521 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 21, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
+    # 522 reserved for Stalwart
+    # 523 reserved for Colossus
+    # 524 reserved for Wrathwalker
+    # 525 reserved for Reaver
+    # 526 reserved for Disruptor
+    # 527 reserved for Warp Prism
+    # 528 reserved for Observer
     # 530 reserved for Phoenix
     # 531 reserved for Corsair
     # 532 reserved for Mirage

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -584,28 +584,34 @@ class SC2Logic:
                 and state.has(item_names.IMMORTAL_ANNIHILATOR_STALWART_ADVANCED_TARGETING_MECHANICS, self.player))
 
     def protoss_anti_light_anti_air(self, state: CollectionState) -> bool:
-        return self.protoss_competent_anti_air(state) \
+        return (
+            self.protoss_competent_anti_air(state)
             or state.has_any({
-                item_names.PHOENIX, item_names.MIRAGE, item_names.SKIRMISHER, item_names.CORSAIR, item_names.CARRIER,
+                item_names.PHOENIX, item_names.MIRAGE, item_names.CORSAIR, item_names.CARRIER,
             }, self.player)
+            or state.has_all((item_names.SKIRMISHER, item_names.SKIRMISHER_PEER_CONTEMPT), self.player)
+        )
 
     def protoss_competent_anti_air(self, state: CollectionState) -> bool:
-        return state.has_any({
-            item_names.STALKER, item_names.SLAYER, item_names.INSTIGATOR, item_names.DRAGOON, item_names.ADEPT,
-            item_names.VOID_RAY, item_names.DESTROYER, item_names.TEMPEST, item_names.SKYLORD, item_names.PURGER
-        }, self.player) \
-            or (
+        return (
+            state.has_any({
+                item_names.STALKER, item_names.SLAYER, item_names.INSTIGATOR, item_names.DRAGOON, item_names.ADEPT,
+                item_names.VOID_RAY, item_names.DESTROYER, item_names.TEMPEST, item_names.SKYLORD, item_names.PURGER
+            }, self.player)
+            or ((
                     state.has_any({
-                        item_names.PHOENIX, item_names.MIRAGE, item_names.SKIRMISHER,
-                        item_names.CORSAIR, item_names.CARRIER,
+                        item_names.PHOENIX, item_names.MIRAGE, item_names.CORSAIR, item_names.CARRIER,
                     }, self.player)
-                    and state.has_any({
-                        item_names.SCOUT, item_names.WRATHWALKER, item_names.WARP_RAY
-                    }, self.player)
-            ) \
+                    or state.has_all((item_names.SKIRMISHER, item_names.SKIRMISHER_PEER_CONTEMPT), self.player)
+                )
+                and state.has_any({
+                    item_names.SCOUT, item_names.WRATHWALKER, item_names.WARP_RAY
+                }, self.player)
+            )
             or (self.advanced_tactics
                 and state.has_any({item_names.IMMORTAL, item_names.ANNIHILATOR, item_names.STALWART}, self.player)
                 and state.has(item_names.IMMORTAL_ANNIHILATOR_STALWART_ADVANCED_TARGETING_MECHANICS, self.player))
+        )
 
     def protoss_has_blink(self, state: CollectionState) -> bool:
         return state.has_any({item_names.STALKER, item_names.INSTIGATOR, item_names.SLAYER}, self.player) \


### PR DESCRIPTION
## What is this fixing or adding?
* Adding Skirmisher war council upgrade -- Peer contempt. Lets them hit air.
* Adding Vanguard war council upgrades -- Fusion Mortars gives them +7 damage vs armoured, Rapidfire Cannons gives them 38% faster attack speed.

Added a new Protoss item category for the air units' war council stuff. Skipping around the order a little bit so I can get some easy ones before I do a playthrough.

Pairs with [data PR #tbd]

## How was this tested?
The usual: gen'd, started, `/send`, verified.

Did that for both skirmisher and vanguard.

## If this makes graphical changes, please attach screenshots.
See data PR.