### PR TITLE
sc2: Fixed duplicate key in options

### DIFF
--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -935,7 +935,6 @@ class StartingSupplyPerItem(Range):
 
 @dataclass
 class Starcraft2Options(PerGameCommonOptions):
-    selected_races: SelectRaces
     game_difficulty: GameDifficulty
     game_speed: GameSpeed
     disable_forced_camera: DisableForcedCamera


### PR DESCRIPTION
## What is this fixing or adding?
Minor fix -- duplicate key.

## How was this tested?
Generated and started playing a game with this change. The option worked as expected (protoss+zerg only generated only protoss and zerg missions)

Wrote a script to read all the lines in the Starcraft2Options class and look for more duplicates. None found.

## If this makes graphical changes, please attach screenshots.
None