### PR TITLE
Mm/war council destroyer

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -133,7 +133,7 @@ class SC2World(World):
         flag_start_inventory(self, item_list)
         flag_unused_upgrade_types(self, item_list)
         flag_user_excluded_item_sets(self, item_list)
-        flag_war_council_excludes(self, item_list)
+        flag_war_council_items(self, item_list)
         flag_and_add_resource_locations(self, item_list)
         pool: List[Item] = prune_item_pool(self, item_list)
         pad_item_pool_with_filler(self, len(self.location_cache) - len(self.locked_locations) - len(pool), pool)
@@ -595,15 +595,14 @@ def flag_user_excluded_item_sets(world: SC2World, item_list: List[FilterItem]) -
                 item.flags |= ItemFilterFlags.Excluded
             vanilla_nonprogressive_count[item.name] += 1
 
-def flag_war_council_excludes(world: SC2World, item_list: List[FilterItem]) -> None:
-    """Excludes items based on item set options (`only_vanilla_items`)"""
+def flag_war_council_items(world: SC2World, item_list: List[FilterItem]) -> None:
+    """Excludes / start-inventories items based on `nerf_unit_baselines` option"""
     if world.options.nerf_unit_baselines:
         return
 
     for item in item_list:
-        if item.data.type != ProtossItemType.War_Council:
-            continue
-        item.flags |= ItemFilterFlags.Excluded
+        if item.data.type in (ProtossItemType.War_Council, ProtossItemType.War_Council_2):
+            item.flags |= ItemFilterFlags.StartInventory
 
 
 def flag_and_add_resource_locations(world: SC2World, item_list: List[FilterItem]) -> None:

--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -63,6 +63,7 @@ resource_efficiency_cost_reduction = {
     item_names.REAVER:        (100, 100, 2),
     DISPLAY_NAME_CLOAKED_ASSASSIN: (0, 50, 0),
     item_names.SCOUT:         (125, 25, 1),
+    item_names.DESTROYER:     (50, 25, 1),
 
     # War Council
     item_names.CENTURION:     (0, 50, 0),
@@ -811,7 +812,7 @@ item_descriptions = {
     item_names.CARRIER_SKYLORD_PURGER_GRAVITON_CATAPULT: "Carriers can launch Interceptors more quickly.",
     item_names.CARRIER_SKYLORD_PURGER_HULL_OF_PAST_GLORIES: "Carriers gain +2 armour.",
     item_names.VOID_RAY_DESTROYER_WARP_RAY_DAWNBRINGER_FLUX_VANES: "Increases movement speed of Void Ray variants.",
-    item_names.DESTROYER_REFORGED_BLOODSHARD_CORE: "When fully charged, the Destroyer's Destruction Beam weapon does full damage to secondary targets.",
+    item_names.DESTROYER_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(item_names.DESTROYER),
     item_names.WARP_PRISM_GRAVITIC_DRIVE: "Increases the movement speed of Warp Prisms.",
     item_names.WARP_PRISM_PHASE_BLASTER: "Equips Warp Prisms with an auto-attack that can hit ground and air targets.",
     item_names.WARP_PRISM_WAR_CONFIGURATION: "Warp Prisms transform faster and gain increased power radius in Phasing Mode.",
@@ -889,7 +890,7 @@ item_descriptions = {
     # Mirage
     item_names.SKIRMISHER_PEER_CONTEMPT: "Skirmisher War Council upgrade. Allows Skirmishers to target air units.",
     # Void Ray
-    # Destroyer
+    item_names.DESTROYER_REFORGED_BLOODSHARD_CORE: "Destroyer War Council upgrade. When fully charged, the Destroyer's Destruction Beam weapon does full damage to secondary targets.",
     # Warp Ray
     # Dawnbringer
     item_names.SOA_CHRONO_SURGE: "The Spear of Adun increases a target structure's unit warp in and research speeds by +1000% for 20 seconds.",

--- a/worlds/sc2/item_groups.py
+++ b/worlds/sc2/item_groups.py
@@ -618,5 +618,6 @@ item_name_groups[ItemGroupNames.VANILLA_ITEMS] = vanilla_items = (
 )
 
 item_name_groups[ItemGroupNames.WAR_COUNCIL] = [
-    item_name for item_name, item_data in items.item_table.items() if item_data.type == items.ProtossItemType.War_Council
+    item_name for item_name, item_data in items.item_table.items()
+    if item_data.type in (items.ProtossItemType.War_Council, items.ProtossItemType.War_Council_2)
 ]

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -643,7 +643,7 @@ ARBITER_ENHANCED_CLOAK_FIELD                            = "Enhanced Cloak Field 
 CARRIER_SKYLORD_PURGER_GRAVITON_CATAPULT                = "Graviton Catapult (Carrier/Skylord/Purger)"
 CARRIER_SKYLORD_PURGER_HULL_OF_PAST_GLORIES             = "Hull of Past Glories (Carrier/Skylord/Purger)"
 VOID_RAY_DESTROYER_WARP_RAY_DAWNBRINGER_FLUX_VANES      = "Flux Vanes (Void Ray/Destroyer/Warp Ray/Dawnbringer)"
-DESTROYER_REFORGED_BLOODSHARD_CORE                      = "Reforged Bloodshard Core (Destroyer)"
+DESTROYER_RESOURCE_EFFICIENCY                           = "Resource Efficiency (Destroyer)"
 WARP_PRISM_GRAVITIC_DRIVE                               = "Gravitic Drive (Warp Prism)"
 WARP_PRISM_PHASE_BLASTER                                = "Phase Blaster (Warp Prism)"
 WARP_PRISM_WAR_CONFIGURATION                            = "War Configuration (Warp Prism)"
@@ -723,7 +723,7 @@ VANGUARD_FUSION_MORTARS                                 = "Fusion Mortars (Vangu
 # Mirage
 SKIRMISHER_PEER_CONTEMPT                                = "Peer Contempt (Skirmisher)"
 # Void Ray
-# Destroyer
+DESTROYER_REFORGED_BLOODSHARD_CORE                      = "Reforged Bloodshard Core (Destroyer)"
 # Warp Ray
 # Dawnbringer
 

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1679,9 +1679,7 @@ item_table = {
     item_names.VOID_RAY_DESTROYER_WARP_RAY_DAWNBRINGER_FLUX_VANES:
         ItemData(335 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 5, SC2Race.PROTOSS, classification=ItemClassification.filler,
                  origin={"ext"}),
-    item_names.DESTROYER_REFORGED_BLOODSHARD_CORE:
-        ItemData(336 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 6, SC2Race.PROTOSS, origin={"ext"},
-                 parent_item=item_names.DESTROYER),
+    item_names.DESTROYER_RESOURCE_EFFICIENCY: ItemData(535 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 6, SC2Race.PROTOSS, parent_item=item_names.DESTROYER),
     item_names.WARP_PRISM_GRAVITIC_DRIVE:
         ItemData(337 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 7, SC2Race.PROTOSS, classification=ItemClassification.filler,
                  origin={"ext"}, parent_item=item_names.WARP_PRISM),
@@ -1767,7 +1765,7 @@ item_table = {
     # 532 reserved for Mirage
     item_names.SKIRMISHER_PEER_CONTEMPT: ItemData(533 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 3, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.SKIRMISHER),
     # 534 reserved for Void Ray
-    # 535 reserved for Destroyer
+    item_names.DESTROYER_REFORGED_BLOODSHARD_CORE: ItemData(336 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 5, SC2Race.PROTOSS, parent_item=item_names.DESTROYER),
     # 536 reserved for Warp Ray
     # 537 reserved for Dawnbringer
 

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -472,7 +472,7 @@ class TestItemFiltering(Sc2SetupTestBase):
         self.assertIn(item_names.PLANETARY_FORTRESS, itempool)
         self.assertNotIn(item_names.PLANETARY_FORTRESS_ORBITAL_MODULE, itempool)
 
-    def test_disabling_unit_nerfs_removes_war_council_upgrades(self) -> None:
+    def test_disabling_unit_nerfs_start_inventories_war_council_upgrades(self) -> None:
         world_options = {
             'enable_wol_missions': False,
             'enable_prophecy_missions': True,
@@ -489,6 +489,9 @@ class TestItemFiltering(Sc2SetupTestBase):
         itempool = [item.name for item in self.multiworld.itempool]
         war_council_item_names = set(item_groups.item_name_groups[item_groups.ItemGroupNames.WAR_COUNCIL])
         present_war_council_items = war_council_item_names.intersection(itempool)
+        starting_inventory = [item.name for item in self.multiworld.precollected_items[self.player]]
+        starting_war_council_items = war_council_item_names.intersection(starting_inventory)
 
         self.assertTrue(itempool)
         self.assertFalse(present_war_council_items, f'Found war council upgrades when nerf_unit_baselines is false: {present_war_council_items}')
+        self.assertEqual(war_council_item_names, starting_war_council_items)


### PR DESCRIPTION
## What is this fixing or adding?
* Moved Reforged Bloodshard Core to be the Destroyer war council upgrade
* Added Destroyer Resource Efficiency (not war council, claims category slot left by RBC)
* War council upgrades are no longer given at map-init time, they come from generation time as starting inventory
* Removed `/option unit_nerfs`
* Added war council upgrades except RBC to API3 -> 4 compat items
* Updated war council unit test to account for start inventory status

Pairs with [data PR #223](https://github.com/Ziktofel/Archipelago-SC2-data/pull/223)

## How was this tested?
For RBC and RE, the usual: gen'd a new world, started a map `/send` to make sure the IDs lined up and the changes took correctly.

For starting inventory, updated the unit test.

## If this makes graphical changes, please attach screenshots.
See data PR