### PR TITLE
sc2: Adding Reaver and Immortal war council upgrades -- Khalai Replic…

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -879,14 +879,14 @@ item_descriptions = {
     # Signifier
     # Ascendant
     item_names.DARK_ARCHON_INDOMITABLE_WILL: "Dark Archon War Council upgrade. Casting Mind Control will no longer deplete the Dark Archon's shields.",
-    # Immortal
+    item_names.IMMORTAL_IMPROVED_BARRIER: "Immortal War Council upgrade. The Immortal's Barrier ability absorbs an additional +100 damage.",
     # Annihilator
     item_names.VANGUARD_RAPIDFIRE_CANNON: "Vanguard War Council upgrade. Vanguards attack 38% faster.",
     item_names.VANGUARD_FUSION_MORTARS: "Vanguard War Council upgrade. Vanguards deal +7 damage to armored targets per attack.",
     # Stalwart
     # Colossus
     # Wrathwalker
-    # Reaver
+    item_names.REAVER_KHALAI_REPLICATORS: "Reaver War Council upgrade. Reaver Scarabs no longer cost minerals.",
     # Disruptor
     # Warp Prism
     # Observer

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -712,14 +712,14 @@ HIGH_TEMPLAR_PLASMA_SURGE                               = "Plasma Surge (High Te
 # Signifier
 # Ascendant
 DARK_ARCHON_INDOMITABLE_WILL                            = "Indomitable Will (Dark Archon)"
-# IMMORTAL_IMPROVED_BARRIER                               = "Improved Barrier (Immortal)"
+IMMORTAL_IMPROVED_BARRIER                               = "Improved Barrier (Immortal)"
 # Annihilator
 VANGUARD_RAPIDFIRE_CANNON                               = "Rapid-Fire Cannon (Vanguard)"
 VANGUARD_FUSION_MORTARS                                 = "Fusion Mortars (Vanguard)"
 # Stalwart
 # Colossus
 # Wrathwalker
-# Reaver
+REAVER_KHALAI_REPLICATORS                               = "Khalai Replicators (Reaver)"
 # Disruptor
 # Warp Prism
 # Observer

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1763,17 +1763,17 @@ item_table = {
     # 516 reserved for Signifier
     # 517 reserved for Ascendant
     item_names.DARK_ARCHON_INDOMITABLE_WILL: ItemData(518 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 18, SC2Race.PROTOSS),
-    # 518 reserved for Immortal
-    # 519 reserved for Annihilator
+    item_names.IMMORTAL_IMPROVED_BARRIER: ItemData(519 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 19, SC2Race.PROTOSS, parent_item=item_names.IMMORTAL),
     item_names.VANGUARD_RAPIDFIRE_CANNON: ItemData(520 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 20, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
     item_names.VANGUARD_FUSION_MORTARS: ItemData(521 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 21, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
-    # 522 reserved for Stalwart
-    # 523 reserved for Colossus
-    # 524 reserved for Wrathwalker
-    # 525 reserved for Reaver
-    # 526 reserved for Disruptor
-    # 527 reserved for Warp Prism
-    # 528 reserved for Observer
+    # 522 reserved for Annihilator
+    # 523 reserved for Stalwart
+    # 524 reserved for Colossus
+    # 525 reserved for Wrathwalker
+    item_names.REAVER_KHALAI_REPLICATORS: ItemData(526 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 26, SC2Race.PROTOSS, parent_item=item_names.REAVER),
+    # 527 reserved for Disruptor
+    # 528 reserved for Warp Prism
+    # 529 reserved for Observer
     # 530 reserved for Phoenix
     # 531 reserved for Corsair
     # 532 reserved for Mirage


### PR DESCRIPTION
## What is this fixing or adding?
Added Reaver and Immortal war council upgrades. See data PR for details.

Pairs with [data PR #226](https://github.com/Ziktofel/Archipelago-SC2-data/pull/226)

## How was this tested?
The usual. Gen, load, check, `/send`, check.

## If this makes graphical changes, please attach screenshots.
See data PR.