### PR TITLE
sc2: Add Annihilator war council upgrade -- aerial tracking

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -880,9 +880,9 @@ item_descriptions = {
     # Ascendant
     item_names.DARK_ARCHON_INDOMITABLE_WILL: "Dark Archon War Council upgrade. Casting Mind Control will no longer deplete the Dark Archon's shields.",
     item_names.IMMORTAL_IMPROVED_BARRIER: "Immortal War Council upgrade. The Immortal's Barrier ability absorbs an additional +100 damage.",
-    # Annihilator
     item_names.VANGUARD_RAPIDFIRE_CANNON: "Vanguard War Council upgrade. Vanguards attack 38% faster.",
     item_names.VANGUARD_FUSION_MORTARS: "Vanguard War Council upgrade. Vanguards deal +7 damage to armored targets per attack.",
+    item_names.ANNIHILATOR_AERIAL_TRACKING: "Annihilator War Council upgrade. The Annihilator's Shadow Cannon ability can now target air units.",
     # Stalwart
     # Colossus
     # Wrathwalker

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -713,9 +713,9 @@ HIGH_TEMPLAR_PLASMA_SURGE                               = "Plasma Surge (High Te
 # Ascendant
 DARK_ARCHON_INDOMITABLE_WILL                            = "Indomitable Will (Dark Archon)"
 IMMORTAL_IMPROVED_BARRIER                               = "Improved Barrier (Immortal)"
-# Annihilator
 VANGUARD_RAPIDFIRE_CANNON                               = "Rapid-Fire Cannon (Vanguard)"
 VANGUARD_FUSION_MORTARS                                 = "Fusion Mortars (Vanguard)"
+ANNIHILATOR_AERIAL_TRACKING                             = "Aerial Tracking (Annihilator)"
 # Stalwart
 # Colossus
 # Wrathwalker

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1766,7 +1766,7 @@ item_table = {
     item_names.IMMORTAL_IMPROVED_BARRIER: ItemData(519 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 19, SC2Race.PROTOSS, parent_item=item_names.IMMORTAL),
     item_names.VANGUARD_RAPIDFIRE_CANNON: ItemData(520 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 20, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
     item_names.VANGUARD_FUSION_MORTARS: ItemData(521 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 21, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
-    # 522 reserved for Annihilator
+    item_names.ANNIHILATOR_AERIAL_TRACKING: ItemData(522 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 22, SC2Race.PROTOSS, parent_item=item_names.ANNIHILATOR),
     # 523 reserved for Stalwart
     # 524 reserved for Colossus
     # 525 reserved for Wrathwalker


### PR DESCRIPTION
## What is this fixing or adding?
Annihilator war council upgrade -- Aerial tracking.

Pairs with [data PR #238](https://github.com/Ziktofel/Archipelago-SC2-data/pull/238)

I glanced through the logic, and shadow cannon didn't seem used for an AA requirement anywhere; Annihilator only showed up paired with general immortal-class AA upgrade or for the anti-hybrid/anti-armour role.

## How was this tested?
The usual: gen, start mission, verify, `/send`, verify.

## If this makes graphical changes, please attach screenshots.
See data PR.