### PR TITLE
sc2: Adding stalwart war council upgrade

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -892,7 +892,7 @@ item_descriptions = {
     item_names.VANGUARD_RAPIDFIRE_CANNON: "Vanguard War Council upgrade. Vanguards attack 38% faster.",
     item_names.VANGUARD_FUSION_MORTARS: "Vanguard War Council upgrade. Vanguards deal +7 damage to armored targets per attack.",
     item_names.ANNIHILATOR_AERIAL_TRACKING: "Annihilator War Council upgrade. The Annihilator's Shadow Cannon ability can now target air units.",
-    # Stalwart
+    item_names.STALWART_DUALITY_CHARGE: "Stalwart War Council upgrade. Stalwarts gain +4 range.",
     # Colossus
     # Wrathwalker
     item_names.REAVER_KHALAI_REPLICATORS: "Reaver War Council upgrade. Reaver Scarabs no longer cost minerals.",

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -723,7 +723,7 @@ IMMORTAL_IMPROVED_BARRIER                               = "Improved Barrier (Imm
 VANGUARD_RAPIDFIRE_CANNON                               = "Rapid-Fire Cannon (Vanguard)"
 VANGUARD_FUSION_MORTARS                                 = "Fusion Mortars (Vanguard)"
 ANNIHILATOR_AERIAL_TRACKING                             = "Aerial Tracking (Annihilator)"
-# Stalwart
+STALWART_DUALITY_CHARGE                                 = "Duality Charge (Stalwart)"
 # Colossus
 # Wrathwalker
 REAVER_KHALAI_REPLICATORS                               = "Khalai Replicators (Reaver)"

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1785,7 +1785,7 @@ item_table = {
     item_names.VANGUARD_RAPIDFIRE_CANNON: ItemData(520 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 20, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
     item_names.VANGUARD_FUSION_MORTARS: ItemData(521 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 21, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
     item_names.ANNIHILATOR_AERIAL_TRACKING: ItemData(522 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 22, SC2Race.PROTOSS, parent_item=item_names.ANNIHILATOR),
-    # 523 reserved for Stalwart
+    item_names.STALWART_DUALITY_CHARGE: ItemData(523 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 23, SC2Race.PROTOSS, parent_item=item_names.STALWART),
     # 524 reserved for Colossus
     # 525 reserved for Wrathwalker
     item_names.REAVER_KHALAI_REPLICATORS: ItemData(526 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 26, SC2Race.PROTOSS, parent_item=item_names.REAVER),

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1785,7 +1785,7 @@ item_table = {
     item_names.VANGUARD_RAPIDFIRE_CANNON: ItemData(520 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 20, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
     item_names.VANGUARD_FUSION_MORTARS: ItemData(521 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 21, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
     item_names.ANNIHILATOR_AERIAL_TRACKING: ItemData(522 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 22, SC2Race.PROTOSS, parent_item=item_names.ANNIHILATOR),
-    item_names.STALWART_DUALITY_CHARGE: ItemData(523 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 23, SC2Race.PROTOSS, parent_item=item_names.STALWART),
+    item_names.STALWART_DUALITY_CHARGE: ItemData(523 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 23, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.STALWART),
     # 524 reserved for Colossus
     # 525 reserved for Wrathwalker
     item_names.REAVER_KHALAI_REPLICATORS: ItemData(526 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 26, SC2Race.PROTOSS, parent_item=item_names.REAVER),

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -600,10 +600,17 @@ class SC2Logic:
                  item_names.SENTRY, item_names.ENERGIZER}, self.player)
 
     def protoss_anti_armor_anti_air(self, state: CollectionState) -> bool:
-        return self.protoss_competent_anti_air(state) \
-            or state.has_any({item_names.SCOUT, item_names.WRATHWALKER, item_names.WARP_RAY}, self.player) \
-            or (state.has_any({item_names.IMMORTAL, item_names.ANNIHILATOR, item_names.STALWART}, self.player)
+        return (
+            self.protoss_competent_anti_air(state)
+            or state.has_any({item_names.SCOUT, item_names.WRATHWALKER, item_names.WARP_RAY}, self.player)
+            or (state.has_any({item_names.IMMORTAL, item_names.ANNIHILATOR}, self.player)
                 and state.has(item_names.IMMORTAL_ANNIHILATOR_STALWART_ADVANCED_TARGETING_MECHANICS, self.player))
+            or state.has_all({
+                item_names.STALWART,
+                item_names.STALWART_DUALITY_CHARGE,
+                item_names.IMMORTAL_ANNIHILATOR_STALWART_ADVANCED_TARGETING_MECHANICS
+            }, self.player)
+        )
 
     def protoss_anti_light_anti_air(self, state: CollectionState) -> bool:
         return (
@@ -631,8 +638,15 @@ class SC2Logic:
                 }, self.player)
             )
             or (self.advanced_tactics
-                and state.has_any({item_names.IMMORTAL, item_names.ANNIHILATOR, item_names.STALWART}, self.player)
+                and state.has_any({item_names.IMMORTAL, item_names.ANNIHILATOR}, self.player)
                 and state.has(item_names.IMMORTAL_ANNIHILATOR_STALWART_ADVANCED_TARGETING_MECHANICS, self.player))
+            or (self.advanced_tactics
+                and state.has_all({
+                    item_names.STALWART,
+                    item_names.STALWART_DUALITY_CHARGE,
+                    item_names.IMMORTAL_ANNIHILATOR_STALWART_ADVANCED_TARGETING_MECHANICS,
+                }, self.player)
+            )
         )
 
     def protoss_has_blink(self, state: CollectionState) -> bool:


### PR DESCRIPTION
## What is this fixing or adding?
Adding the stalwart war council upgrade -- Duality Charge.

Pairs with [data PR #239](https://github.com/Ziktofel/Archipelago-SC2-data/pull/239)

## How was this tested?
The usual: gen, start, `/send`, observe.

## If this makes graphical changes, please attach screenshots.
See data PR.