### PR TITLE
sc2: Fixing a bug where the goal location would never send

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1111,6 +1111,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
         'can_read_game',
         'last_received_update',
     ]
+    ctx: SC2Context
 
     def __init__(self, ctx: SC2Context, mission_id: int):
         self.game_running = False
@@ -1245,8 +1246,14 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                     await self.chat_send("?SendMessage LostConnection - Lost connection to game.")
 
     def get_uncollected_objectives(self) -> typing.List[int]:
-        return [location % VICTORY_MODULO for location in
-                self.ctx.uncollected_locations_in_mission(lookup_id_to_mission[self.mission_id])]
+        result = [
+            location % VICTORY_MODULO for location in
+            self.ctx.uncollected_locations_in_mission(lookup_id_to_mission[self.mission_id])
+        ]
+        if self.mission_id == self.ctx.final_mission:
+            # Always make the final mission's victory location collectable
+            result.append(0)
+        return result
 
     def missions_beaten_count(self):
         return len([location for location in self.ctx.checked_locations if location % VICTORY_MODULO == 0])


### PR DESCRIPTION
## What is this fixing or adding?
The issue was that because victory on the final mission wasn't a location, but rather an event, it wasn't getting included in the `?UncollectedLocations` message and thus the game would never mark it as checked. Fixed it by adding it back in manually in the `get_uncollected_objectives()` function, specifically for the final mission.

## How was this tested?
`/disable_mission_check`, started a non-final mission, verified the extra `0` didn't send in the `?UncollectedLocations` message. Started a final mission (Into the Void in my case), used cheats to rush to the end, verified the goal was marked as achieved in the log. Auto-collect triggered to make it extra obvious.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/d1036979-4b81-4d7c-bbb1-a6b165513994)
