### PR TITLE
sc2: Adding phoenix war council upgrade

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -899,7 +899,7 @@ item_descriptions = {
     # Disruptor
     # Warp Prism
     # Observer
-    # Phoenix
+    item_names.PHOENIX_DOUBLE_GRAVITON_BEAM: "Phoenix War Council upgrade. Phoenixes can now use Graviton Beam to lift two targets at once.",
     # Corsair
     # Mirage
     item_names.SKIRMISHER_PEER_CONTEMPT: "Skirmisher War Council upgrade. Allows Skirmishers to target air units.",

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -730,7 +730,7 @@ REAVER_KHALAI_REPLICATORS                               = "Khalai Replicators (R
 # Disruptor
 # Warp Prism
 # Observer
-# Phoenix
+PHOENIX_DOUBLE_GRAVITON_BEAM                            = "Double Graviton Beam (Phoenix)"
 # Corsair
 # Mirage
 SKIRMISHER_PEER_CONTEMPT                                = "Peer Contempt (Skirmisher)"

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1792,7 +1792,7 @@ item_table = {
     # 527 reserved for Disruptor
     # 528 reserved for Warp Prism
     # 529 reserved for Observer
-    # 530 reserved for Phoenix
+    item_names.PHOENIX_DOUBLE_GRAVITON_BEAM: ItemData(530 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 0, SC2Race.PROTOSS, parent_item=item_names.PHOENIX),
     # 531 reserved for Corsair
     # 532 reserved for Mirage
     item_names.SKIRMISHER_PEER_CONTEMPT: ItemData(533 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 3, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.SKIRMISHER),


### PR DESCRIPTION
## What is this fixing or adding?
Phoenix war council upgrade -- Double Graviton Beam.

Pairs with [data PR #247](https://github.com/Ziktofel/Archipelago-SC2-data/pull/247)

## How was this tested?
The usual - gen, start, `/send`, check.

## If this makes graphical changes, please attach screenshots.
See data PR.