### PR TITLE
sc2: Adding a description to /windowed_mode

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -419,8 +419,9 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             self.output(f"Color for {faction} set to " + player_colors[self.ctx.__dict__[var_names[faction]]])
 
     def _cmd_windowed_mode(self, value="") -> None:
+        """Controls whether sc2 will launch in Windowed mode. Persists across sessions."""
         if not value:
-            pass
+            sc2_logger.info("Use `/windowed_mode [true|false]` to set the windowed mode")
         elif value.casefold() in ('t', 'true', 'yes', 'y'):
             SC2World.settings.game_windowed_mode = True
             force_settings_save_on_close()


### PR DESCRIPTION
## What is this fixing or adding?
Adding the missing /help description someone pointed out a few weeks ago.

## How was this tested?
Ran the client, checked `/help` and ran `/windowed_mode`

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/f30388ec-17b4-4170-a940-d4f8f7983906)
![image](https://github.com/user-attachments/assets/7e2e4381-cd4a-4285-82be-67a6d08ea156)
