### PR TITLE
sc2: Adding Mirage war council upgrade -- graviton beam

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -901,7 +901,7 @@ item_descriptions = {
     # Observer
     item_names.PHOENIX_DOUBLE_GRAVITON_BEAM: "Phoenix War Council upgrade. Phoenixes can now use Graviton Beam to lift two targets at once.",
     # Corsair
-    # Mirage
+    item_names.MIRAGE_GRAVITON_BEAM: "Mirage War Council upgrade. Allows Mirages to use Graviton Beam.",
     item_names.SKIRMISHER_PEER_CONTEMPT: "Skirmisher War Council upgrade. Allows Skirmishers to target air units.",
     # Void Ray
     item_names.DESTROYER_REFORGED_BLOODSHARD_CORE: "Destroyer War Council upgrade. When fully charged, the Destroyer's Destruction Beam weapon does full damage to secondary targets.",

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -732,7 +732,7 @@ REAVER_KHALAI_REPLICATORS                               = "Khalai Replicators (R
 # Observer
 PHOENIX_DOUBLE_GRAVITON_BEAM                            = "Double Graviton Beam (Phoenix)"
 # Corsair
-# Mirage
+MIRAGE_GRAVITON_BEAM                                    = "Graviton Beam (Mirage)"
 SKIRMISHER_PEER_CONTEMPT                                = "Peer Contempt (Skirmisher)"
 # Void Ray
 DESTROYER_REFORGED_BLOODSHARD_CORE                      = "Reforged Bloodshard Core (Destroyer)"

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1794,7 +1794,7 @@ item_table = {
     # 529 reserved for Observer
     item_names.PHOENIX_DOUBLE_GRAVITON_BEAM: ItemData(530 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 0, SC2Race.PROTOSS, parent_item=item_names.PHOENIX),
     # 531 reserved for Corsair
-    # 532 reserved for Mirage
+    item_names.MIRAGE_GRAVITON_BEAM: ItemData(532 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 2, SC2Race.PROTOSS, parent_item=item_names.MIRAGE),
     item_names.SKIRMISHER_PEER_CONTEMPT: ItemData(533 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 3, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.SKIRMISHER),
     # 534 reserved for Void Ray
     item_names.DESTROYER_REFORGED_BLOODSHARD_CORE: ItemData(336 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 5, SC2Race.PROTOSS, parent_item=item_names.DESTROYER),


### PR DESCRIPTION
## What is this fixing or adding?
Adding Mirage war council upgrade -- Graviton Beam.

Pairs with [data PR #250](https://github.com/Ziktofel/Archipelago-SC2-data/pull/250)

## How was this tested?
The usual: gen, start map, `/send`, check.

## If this makes graphical changes, please attach screenshots.
See data PR.