### PR TITLE
 Wording update to Omega Worm, stating it can create Drones

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -65,7 +65,7 @@ resource_efficiency_cost_reduction = {
     DISPLAY_NAME_CLOAKED_ASSASSIN: (0, 50, 0),
     item_names.SCOUT:         (125, 25, 1),
     item_names.DESTROYER:     (50, 25, 1),
-    DISPLAY_NAME_WORMS:       (75, 75, 0),
+    DISPLAY_NAME_WORMS:       (50, 75, 0),
 
     # War Council
     item_names.CENTURION:     (0, 50, 0),

--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -737,7 +737,7 @@ item_descriptions = {
     item_names.ROACH_RAVAGER_ASPECT: "Ranged artillery. Can use Corrosive Bile. Can attack ground units. Morphed from the Roach.",
     item_names.ROACH_PRIMAL_IGNITER_ASPECT: "Assault unit. Has an area-damage attack. Regenerates life quickly when burrowed. Can attack ground units. Morphed by merging two Roaches.",
     item_names.NYDUS_WORM: "Long-range transport network. Nydus Worms and Nydus Networks can load friendly ground units to be unloaded to any other Nydus structure on the map.",
-    item_names.OMEGA_WORM: "Long-range deployable base. Can't load and unload units, but can generate creep and Creep Tumors. Can also serve as a dropoff point for resources, like a Hatchery.",
+    item_names.OMEGA_WORM: "Long-range deployable base. Unable to load and unload units, but can generate Creep and Creep Tumors. Can also serve as a dropoff point for resources and can create Drones.",
     item_names.ULTRALISK_TYRANNOZOR_ASPECT: "Heavy assault beast. Has a ground-area attack, and powerful anti-air attack.  Morphed by merging two Ultralisks.",
     item_names.OBSERVER: "Flying spy. Cloak renders the unit invisible to enemies without detection.",
     item_names.CENTURION: "Powerful melee warrior. Has the Shadow Charge and Darkcoil abilities.",


### PR DESCRIPTION
Follows pull request from: https://github.com/Ziktofel/Archipelago-SC2-data/pull/252 .
Meant to state how Omega Worms are able to create drones baseline, and includes tooltip change for nydus worm/omega worm resource efficiency.