### PR TITLE
sc2: Fixing crash on startup with Python <=3.10

### DIFF
--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -386,7 +386,7 @@ class SC2Manager(GameManager):
             if (self.ctx.location_inclusions[location_type] == LocationInclusion.option_enabled
                 and all(
                     self.ctx.location_inclusions_by_flag[flag] == LocationInclusion.option_enabled
-                    for flag in lookup_location_id_to_flags[location_id]
+                    for flag in lookup_location_id_to_flags[location_id].values()
                 )
             ):
                 return True

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -40,6 +40,14 @@ class LocationFlag(enum.IntFlag):
     PREVENTATIVE = enum.auto()
     """Locations that are about preventing something from happening"""
 
+    def values(self):
+        """Hacky iterator for backwards-compatibility with Python <= 3.10. Not necessary on Python 3.11+"""
+        return tuple(
+            val for val in (
+                LocationFlag.SPEEDRUN, LocationFlag.PREVENTATIVE,
+            ) if val in self
+        )
+
 
 class LocationData(NamedTuple):
     region: str


### PR DESCRIPTION
## What is this fixing or adding?
Fixing a crash on startup [reported by Alice today](https://discord.com/channels/731205301247803413/1154164338769268859/1270176444470923355)

Apparently `IntFlag` only became iterable in Python 3.11: 

![image](https://github.com/user-attachments/assets/8c70ac00-5689-41bf-9707-6de0310a97b2)
-- https://docs.python.org/3/library/enum.html#enum.Flag

I made a hacky helper function that would require manual updating whenever a new flag is added. I think it should be okay because I don't see us adding very many new values at all, and if we do the necessary code to update is very local to where you will add the value.

## How was this tested?
Ran the client under Python 3.10. Checked that I could connect and hover over mission table tooltips correctly. Didn't start a mission, though.

Also did a quick Generation under Python 3.10. Generated fine.

## If this makes graphical changes, please attach screenshots.
None, aside from not crashing.