### PR TITLE
sc2: Adding corsair war council upgrade -- network disruption

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -900,7 +900,7 @@ item_descriptions = {
     # Warp Prism
     # Observer
     item_names.PHOENIX_DOUBLE_GRAVITON_BEAM: "Phoenix War Council upgrade. Phoenixes can now use Graviton Beam to lift two targets at once.",
-    # Corsair
+    item_names.CORSAIR_NETWORK_DISRUPTION: "Corsair War Council upgrade. Doubles the radius of Disruption Web.",
     item_names.MIRAGE_GRAVITON_BEAM: "Mirage War Council upgrade. Allows Mirages to use Graviton Beam.",
     item_names.SKIRMISHER_PEER_CONTEMPT: "Skirmisher War Council upgrade. Allows Skirmishers to target air units.",
     # Void Ray

--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -900,7 +900,7 @@ item_descriptions = {
     # Warp Prism
     # Observer
     item_names.PHOENIX_DOUBLE_GRAVITON_BEAM: "Phoenix War Council upgrade. Phoenixes can now use Graviton Beam to lift two targets at once.",
-    item_names.CORSAIR_NETWORK_DISRUPTION: "Corsair War Council upgrade. Doubles the radius of Disruption Web.",
+    item_names.CORSAIR_NETWORK_DISRUPTION: "Corsair War Council upgrade. Triples the radius of Disruption Web.",
     item_names.MIRAGE_GRAVITON_BEAM: "Mirage War Council upgrade. Allows Mirages to use Graviton Beam.",
     item_names.SKIRMISHER_PEER_CONTEMPT: "Skirmisher War Council upgrade. Allows Skirmishers to target air units.",
     # Void Ray

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -731,7 +731,7 @@ REAVER_KHALAI_REPLICATORS                               = "Khalai Replicators (R
 # Warp Prism
 # Observer
 PHOENIX_DOUBLE_GRAVITON_BEAM                            = "Double Graviton Beam (Phoenix)"
-# Corsair
+CORSAIR_NETWORK_DISRUPTION                              = "Network Disruption (Corsair)"
 MIRAGE_GRAVITON_BEAM                                    = "Graviton Beam (Mirage)"
 SKIRMISHER_PEER_CONTEMPT                                = "Peer Contempt (Skirmisher)"
 # Void Ray

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1793,7 +1793,7 @@ item_table = {
     # 528 reserved for Warp Prism
     # 529 reserved for Observer
     item_names.PHOENIX_DOUBLE_GRAVITON_BEAM: ItemData(530 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 0, SC2Race.PROTOSS, parent_item=item_names.PHOENIX),
-    # 531 reserved for Corsair
+    item_names.CORSAIR_NETWORK_DISRUPTION: ItemData(531 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 1, SC2Race.PROTOSS, parent_item=item_names.CORSAIR),
     item_names.MIRAGE_GRAVITON_BEAM: ItemData(532 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 2, SC2Race.PROTOSS, parent_item=item_names.MIRAGE),
     item_names.SKIRMISHER_PEER_CONTEMPT: ItemData(533 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 3, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.SKIRMISHER),
     # 534 reserved for Void Ray


### PR DESCRIPTION
## What is this fixing or adding?
Adding Corsair war council upgrade -- Network Disruption.

Pairs with [data PR #255](https://github.com/Ziktofel/Archipelago-SC2-data/pull/255)

## How was this tested?
The usual: gen, start, `/send`, check.

## If this makes graphical changes, please attach screenshots.
See data PR.