### PR TITLE
Healthier no logic behavior for multiworlds

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -6,6 +6,7 @@ from typing import *
 from math import floor, ceil
 from dataclasses import dataclass
 from BaseClasses import Item, MultiWorld, Location, Tutorial, ItemClassification, CollectionState
+from Options import Accessibility
 from worlds.AutoWorld import WebWorld, World
 from . import item_names
 from .items import (
@@ -22,7 +23,7 @@ from .options import (
     get_option_value, LocationInclusion, KerriganLevelItemDistribution,
     KerriganPresence, KerriganPrimalStatus, kerrigan_unit_available, StarterUnit, SpearOfAdunPresence,
     get_enabled_campaigns, SpearOfAdunAutonomouslyCastAbilityPresence, Starcraft2Options,
-    GrantStoryTech, GenericUpgradeResearch, GenericUpgradeItems,
+    GrantStoryTech, GenericUpgradeResearch, GenericUpgradeItems, RequiredTactics,
 )
 from . import settings
 from .pool_filter import filter_items
@@ -143,7 +144,12 @@ class SC2World(World):
         self.multiworld.itempool += pool
 
     def set_rules(self):
-        self.multiworld.completion_condition[self.player] = lambda state: state.has(self.victory_item, self.player)
+        if self.options.required_tactics == RequiredTactics.option_no_logic:
+            # Forcing completed goal and minimal accessibility on no logic
+            self.options.accessibility.value = Accessibility.option_minimal
+            self.multiworld.completion_condition[self.player] = lambda state: True
+        else:
+            self.multiworld.completion_condition[self.player] = lambda state: state.has(self.victory_item, self.player)
 
     def get_filler_item_name(self) -> str:
         return self.random.choice(filler_items)

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1904,7 +1904,7 @@ advanced_basic_units = {
     })
 }
 
-no_logic_starting_units = {
+no_logic_basic_units = {
     SC2Race.TERRAN: advanced_basic_units[SC2Race.TERRAN].union({
         item_names.FIREBAT,
         item_names.GHOST,
@@ -1949,7 +1949,7 @@ not_balanced_starting_units = {
 def get_basic_units(world: 'SC2World', race: SC2Race) -> typing.Set[str]:
     logic_level = get_option_value(world, 'required_tactics')
     if logic_level == RequiredTactics.option_no_logic:
-        return no_logic_starting_units[race]
+        return no_logic_basic_units[race]
     elif logic_level == RequiredTactics.option_advanced:
         return advanced_basic_units[race]
     else:

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2759,10 +2759,6 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             or location.name in plando_locations
         ]
     for i, location_data in enumerate(location_table):
-        # Removing all item-based logic on No Logic
-        if logic_level == RequiredTactics.option_no_logic:
-            location_data = location_data._replace(rule=Location.access_rule)
-            location_table[i] = location_data
         # Generating Beat event locations
         if location_data.name.endswith((": Victory", ": Defeat")):
             beat_events.append(

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -619,7 +619,10 @@ def filter_items(world: 'SC2World', mission_req_table: Dict[SC2Campaign, Dict[st
     """
     open_locations = [location for location in location_cache if location.item is None]
     inventory_size = len(open_locations)
-    mission_requirements = [(location.name, location.access_rule) for location in location_cache]
+    if world.options.required_tactics.value == RequiredTactics.option_no_logic:
+        mission_requirements = []
+    else:
+        mission_requirements = [(location.name, location.access_rule) for location in location_cache]
     valid_inventory = ValidInventory(world, item_pool, existing_items, locked_items)
 
     valid_items = valid_inventory.generate_reduced_inventory(inventory_size, mission_requirements)


### PR DESCRIPTION
## What is this fixing or adding?

This alters No Logic to behave somewhat similarly to the other No Logic games in AP.

- It forces SC2 to behave with minimal accessibility (items can be placed anywhere)
- It removes the goal condition by considering the game won from the start, allowing all game progress to be logically optional.
- Rather than removing logic from the locations, it temporarily ignores logic during the item cull and allows all locations to become impossible to reach.

This has no effect whatsoever on No Logic single worlds and multiworlds where all games are No Logic, but requires a minimal amount of logic to reach locations in multiworlds.  This solves the early locations issue and allows SC2 to have a few spheres.

Trends from testing this in standard multiworlds:

- This inevitably results in the SC2 player getting a common unit and anti air (often the same unit) in Sphere 1
- The SC2 player progresses through the spheres as usual for the first 4-7 spheres alongside the standard player
- After this point, the SC2 player tends to stop receiving items, but may progress through a few more spheres (picking the easier, lower-logic missions) to grab one or two more items for the other player
- The majority of the items in the SC2 lategame are either their own SC2 items or filler

## How was this tested?

Generated a single world game on Advanced and No Logic, generated a multiworld game on Advanced and No Logic, and tested several multiworld generations with varying size inventories on No Logic.
