### PR TITLE
sc2: Adding colossus war council upgrade -- fire lance

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -893,7 +893,7 @@ item_descriptions = {
     item_names.VANGUARD_FUSION_MORTARS: "Vanguard War Council upgrade. Vanguards deal +7 damage to armored targets per attack.",
     item_names.ANNIHILATOR_AERIAL_TRACKING: "Annihilator War Council upgrade. The Annihilator's Shadow Cannon ability can now target air units.",
     item_names.STALWART_DUALITY_CHARGE: "Stalwart War Council upgrade. Stalwarts gain +4 range.",
-    # Colossus
+    item_names.COLOSSUS_FIRE_LANCE: "Colossus War Council upgrade. Colossi set the ground on fire with their attacks, dealing damage to enemies over time.",
     item_names.WRATHWALKER_AERIAL_TRACKING: "Wrathwalker War Council upgrade. Wrathwalkers can now target air units.",
     item_names.REAVER_KHALAI_REPLICATORS: "Reaver War Council upgrade. Reaver Scarabs no longer cost minerals.",
     # Disruptor

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -724,7 +724,7 @@ VANGUARD_RAPIDFIRE_CANNON                               = "Rapid-Fire Cannon (Va
 VANGUARD_FUSION_MORTARS                                 = "Fusion Mortars (Vanguard)"
 ANNIHILATOR_AERIAL_TRACKING                             = "Aerial Tracking (Annihilator)"
 STALWART_DUALITY_CHARGE                                 = "Duality Charge (Stalwart)"
-# Colossus
+COLOSSUS_FIRE_LANCE                                     = "Fire Lance (Colossus)"
 WRATHWALKER_AERIAL_TRACKING                             = "Aerial Tracking (Wrathwalker)"
 REAVER_KHALAI_REPLICATORS                               = "Khalai Replicators (Reaver)"
 # Disruptor

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1786,7 +1786,7 @@ item_table = {
     item_names.VANGUARD_FUSION_MORTARS: ItemData(521 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 21, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
     item_names.ANNIHILATOR_AERIAL_TRACKING: ItemData(522 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 22, SC2Race.PROTOSS, parent_item=item_names.ANNIHILATOR),
     item_names.STALWART_DUALITY_CHARGE: ItemData(523 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 23, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.STALWART),
-    # 524 reserved for Colossus
+    item_names.COLOSSUS_FIRE_LANCE: ItemData(524 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 24, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.COLOSSUS),
     item_names.WRATHWALKER_AERIAL_TRACKING: ItemData(525 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 25, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.WRATHWALKER),
     item_names.REAVER_KHALAI_REPLICATORS: ItemData(526 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 26, SC2Race.PROTOSS, parent_item=item_names.REAVER),
     # 527 reserved for Disruptor


### PR DESCRIPTION
## What is this fixing or adding?
Adding colossus war council upgrade -- fire lance.

Pairs with [data PR #256](https://github.com/Ziktofel/Archipelago-SC2-data/pull/256)

## How was this tested?
The usual: gen, start, `/send`, verify.

Most of the testing is done without needing the client changes using `upgrade AP_ColossusFireLance` chat commands

## If this makes graphical changes, please attach screenshots.
See data PR