### PR TITLE
sc2: Tempest war council upgrade -- disintegration

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -911,7 +911,7 @@ item_descriptions = {
     # Carrier
     # Skylord
     # Trireme
-    item_names.TEMPEST_DISINTEGRATION: "Tempest War Council upgrade. " + _ability_desc("Tempests", "Disintegration", "deals massive damage to enemy structures over time"),
+    item_names.TEMPEST_DISINTEGRATION: "Tempest War Council upgrade. " + _ability_desc("Tempests", "Disintegration", "deals 500 damage to a target unit or structure over 20 seconds"),
     # Scout
     # Arbiter
     # Oracle

--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -807,7 +807,8 @@ item_descriptions = {
     item_names.SCOUT_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(item_names.SCOUT),
     item_names.TEMPEST_TECTONIC_DESTABILIZERS: "Tempests deal increased damage to buildings.",
     item_names.TEMPEST_QUANTIC_REACTOR: "Tempests deal increased damage to massive units.",
-    item_names.TEMPEST_GRAVITY_SLING: "Tempests gain +8 range against air targets.",
+    item_names.TEMPEST_GRAVITY_SLING: "Tempests gain +8 range against air targets and +8 cast range.",
+    item_names.TEMPEST_INTERPLANETARY_RANGE: "Tempests gain +8 weapon range against all targets.",
     item_names.PHOENIX_CLASS_IONIC_WAVELENGTH_FLUX: "Increases Phoenix, Mirage, and Skirmisher weapon damage by +2.",
     item_names.PHOENIX_CLASS_ANION_PULSE_CRYSTALS: "Increases Phoenix, Mirage, and Skirmiser range by +2.",
     item_names.CORSAIR_STEALTH_DRIVE: "Corsairs become permanently cloaked.",
@@ -907,6 +908,14 @@ item_descriptions = {
     item_names.DESTROYER_REFORGED_BLOODSHARD_CORE: "Destroyer War Council upgrade. When fully charged, the Destroyer's Destruction Beam weapon does full damage to secondary targets.",
     # Warp Ray
     # Dawnbringer
+    # Carrier
+    # Skylord
+    # Trireme
+    item_names.TEMPEST_DISINTEGRATION: "Tempest War Council upgrade. " + _ability_desc("Tempests", "Disintegration", "deals massive damage to enemy structures over time"),
+    # Scout
+    # Arbiter
+    # Oracle
+    # Mothership
     item_names.SOA_CHRONO_SURGE: "The Spear of Adun increases a target structure's unit warp in and research speeds by +1000% for 20 seconds.",
     item_names.SOA_PROGRESSIVE_PROXY_PYLON: inspect.cleandoc("""
         Level 1: The Spear of Adun quickly warps in a Pylon to a target location.

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -637,6 +637,7 @@ SCOUT_RESOURCE_EFFICIENCY                               = "Resource Efficiency (
 TEMPEST_TECTONIC_DESTABILIZERS                          = "Tectonic Destabilizers (Tempest)"
 TEMPEST_QUANTIC_REACTOR                                 = "Quantic Reactor (Tempest)"
 TEMPEST_GRAVITY_SLING                                   = "Gravity Sling (Tempest)"
+TEMPEST_INTERPLANETARY_RANGE                            = "Interplanetary Range (Tempest)"
 PHOENIX_CLASS_IONIC_WAVELENGTH_FLUX                     = "Ionic Wavelength Flux (Phoenix/Mirage/Skirmisher)"
 PHOENIX_CLASS_ANION_PULSE_CRYSTALS                      = "Anion Pulse-Crystals (Phoenix/Mirage/Skirmisher)"
 CORSAIR_STEALTH_DRIVE                                   = "Stealth Drive (Corsair)"
@@ -738,6 +739,14 @@ SKIRMISHER_PEER_CONTEMPT                                = "Peer Contempt (Skirmi
 DESTROYER_REFORGED_BLOODSHARD_CORE                      = "Reforged Bloodshard Core (Destroyer)"
 # Warp Ray
 # Dawnbringer
+# Carrier
+# Skylord
+# Trireme
+TEMPEST_DISINTEGRATION                                  = "Disintegration (Tempest)"
+# Scout
+# Arbiter
+# Oracle
+# Mothership
 
 # Spear Of Adun
 SOA_CHRONO_SURGE            = "Chrono Surge (Spear of Adun Calldown)"

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1760,6 +1760,7 @@ item_table = {
     item_names.ORACLE_BOSONIC_CORE: ItemData(378 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 18, SC2Race.PROTOSS, origin={"ext"}, parent_item=item_names.ORACLE),
     item_names.SCOUT_RESOURCE_EFFICIENCY: ItemData(379 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 19, SC2Race.PROTOSS, origin={"ext"}, parent_item=item_names.SCOUT),
     item_names.IMMORTAL_ANNIHILATOR_STALWART_DISRUPTOR_DISPERSION: ItemData(380 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 20, SC2Race.PROTOSS, origin={"ext"}),
+    item_names.TEMPEST_INTERPLANETARY_RANGE: ItemData(384 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 24, SC2Race.PROTOSS, parent_item=item_names.TEMPEST),
 
     # War Council
     item_names.ZEALOT_WHIRLWIND: ItemData(500 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 0, SC2Race.PROTOSS, parent_item=item_names.ZEALOT),
@@ -1800,6 +1801,14 @@ item_table = {
     item_names.DESTROYER_REFORGED_BLOODSHARD_CORE: ItemData(336 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 5, SC2Race.PROTOSS, parent_item=item_names.DESTROYER),
     # 536 reserved for Warp Ray
     # 537 reserved for Dawnbringer
+    # 538 reserved for Carrier
+    # 539 reserved for Skylord
+    # 540 reserved for Trireme
+    item_names.TEMPEST_DISINTEGRATION: ItemData(541 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 11, SC2Race.PROTOSS, parent_item=item_names.TEMPEST),
+    # 542 reserved for Scout
+    # 543 reserved for Arbiter
+    # 544 reserved for Oracle
+    # 545 reserved for Mothership
 
     # SoA Calldown powers
     item_names.SOA_CHRONO_SURGE: ItemData(700 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Spear_Of_Adun, 0, SC2Race.PROTOSS, origin={"lotv"}),


### PR DESCRIPTION
## What is this fixing or adding?
* Tempest War council upgrade -- Disintegration
* Tempest Interplanetary Range

Pairs with [data PR #258](https://github.com/Ziktofel/Archipelago-SC2-data/pull/258)
I skipped some IDs on interplanetary range for the disruptor PR #283

## How was this tested?
The usual: gen, start, `/send`, check.

## If this makes graphical changes, please attach screenshots.
See data PR.