### PR TITLE
sc2: Adding Warp Prism war council upgrade -- Warp Refraction

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -901,7 +901,7 @@ item_descriptions = {
     item_names.WRATHWALKER_AERIAL_TRACKING: "Wrathwalker War Council upgrade. Wrathwalkers can now target air units.",
     item_names.REAVER_KHALAI_REPLICATORS: "Reaver War Council upgrade. Reaver Scarabs no longer cost minerals.",
     item_names.DISRUPTOR_RESTRUCTURED_THRUSTERS: "Disruptor War Council upgrade. Allows the Disruptor to move while casting Purification Nova. Also allows the Disruptor to Blink.",
-    # Warp Prism
+    item_names.WARP_PRISM_WARP_REFRACTION: "Warp Prism War Council upgrade. Warp Prisms gain +5 pickup range and unload units 10 times faster.",
     # Observer
     item_names.PHOENIX_DOUBLE_GRAVITON_BEAM: "Phoenix War Council upgrade. Phoenixes can now use Graviton Beam to lift two targets at once.",
     item_names.CORSAIR_NETWORK_DISRUPTION: "Corsair War Council upgrade. Triples the radius of Disruption Web.",

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -732,7 +732,7 @@ COLOSSUS_FIRE_LANCE                                     = "Fire Lance (Colossus)
 WRATHWALKER_AERIAL_TRACKING                             = "Aerial Tracking (Wrathwalker)"
 REAVER_KHALAI_REPLICATORS                               = "Khalai Replicators (Reaver)"
 DISRUPTOR_RESTRUCTURED_THRUSTERS                        = "Restructured Thrusters (Disruptor)"
-# Warp Prism
+WARP_PRISM_WARP_REFRACTION                              = "Warp Refraction (Warp Prism)"
 # Observer
 PHOENIX_DOUBLE_GRAVITON_BEAM                            = "Double Graviton Beam (Phoenix)"
 CORSAIR_NETWORK_DISRUPTION                              = "Network Disruption (Corsair)"

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1794,7 +1794,7 @@ item_table = {
     item_names.WRATHWALKER_AERIAL_TRACKING: ItemData(525 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 25, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.WRATHWALKER),
     item_names.REAVER_KHALAI_REPLICATORS: ItemData(526 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 26, SC2Race.PROTOSS, parent_item=item_names.REAVER),
     item_names.DISRUPTOR_RESTRUCTURED_THRUSTERS: ItemData(527 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 27, SC2Race.PROTOSS, parent_item=item_names.DISRUPTOR),
-    # 528 reserved for Warp Prism
+    item_names.WARP_PRISM_WARP_REFRACTION: ItemData(528 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 28, SC2Race.PROTOSS, parent_item=item_names.WARP_PRISM),
     # 529 reserved for Observer
     item_names.PHOENIX_DOUBLE_GRAVITON_BEAM: ItemData(530 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 0, SC2Race.PROTOSS, parent_item=item_names.PHOENIX),
     item_names.CORSAIR_NETWORK_DISRUPTION: ItemData(531 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 1, SC2Race.PROTOSS, parent_item=item_names.CORSAIR),


### PR DESCRIPTION
## What is this fixing or adding?
Warp Prism war council upgrade -- Warp Refraction

Pairs with [data PR #262](https://github.com/Ziktofel/Archipelago-SC2-data/pull/262)

## How was this tested?
The usual: gen, start, `/send`, check

## If this makes graphical changes, please attach screenshots.
See data PR