### PR TITLE
sc2: Adding protoss bases as locations on the dig

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -642,7 +642,7 @@ class SC2Context(CommonContext):
                 
             self.mission_order = args["slot_data"].get("mission_order", MissionOrder.option_vanilla)
             if self.slot_data_version < 4:
-                self.final_mission = args["slot_data"].get("final_mission", SC2Mission.ALL_IN.id)
+                self.final_mission_ids = [args["slot_data"].get("final_mission", SC2Mission.ALL_IN.id)]
             else:
                 self.final_mission_ids = args["slot_data"].get("final_mission_ids", [SC2Mission.ALL_IN.id])
                 self.final_locations = [get_location_id(mission_id, 0) for mission_id in self.final_mission_ids]
@@ -1334,9 +1334,6 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             location % VICTORY_MODULO for location in
             self.ctx.uncollected_locations_in_mission(lookup_id_to_mission[self.mission_id])
         ]
-        if self.mission_id == self.ctx.final_mission:
-            # Always make the final mission's victory location collectable
-            result.append(0)
         return result
 
     def missions_beaten_count(self):

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -419,6 +419,33 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and logic.terran_common_unit(state)
                 and (logic.marine_medic_upgrade(state) or adv_tactics))
         ),
+        make_location_data(SC2Mission.THE_DIG.mission_name, "Northwestern Protoss Base", SC2WOL_LOC_ID_OFFSET + 909, LocationType.MASTERY,
+            lambda state: (
+                logic.terran_basic_anti_air(state)
+                and logic.terran_defense_rating(state, False, True) >= 8
+                and logic.terran_defense_rating(state, False, False) >= 6
+                and logic.terran_common_unit(state)
+                and (logic.marine_medic_upgrade(state) or adv_tactics)
+                and (logic.terran_base_trasher(state) or state.has(item_names.COMMAND_CENTER_SCANNER_SWEEP, player)))
+        ),
+        make_location_data(SC2Mission.THE_DIG.mission_name, "Northeastern Protoss Base", SC2WOL_LOC_ID_OFFSET + 910, LocationType.MASTERY,
+            lambda state: (
+                logic.terran_basic_anti_air(state)
+                and logic.terran_defense_rating(state, False, True) >= 8
+                and logic.terran_defense_rating(state, False, False) >= 6
+                and logic.terran_common_unit(state)
+                and (logic.marine_medic_upgrade(state) or adv_tactics)
+                and (logic.terran_base_trasher(state) or state.has(item_names.COMMAND_CENTER_SCANNER_SWEEP, player)))
+        ),
+        make_location_data(SC2Mission.THE_DIG.mission_name, "Eastern Protoss Base", SC2WOL_LOC_ID_OFFSET + 911, LocationType.MASTERY,
+            lambda state: (
+                logic.terran_basic_anti_air(state)
+                and logic.terran_defense_rating(state, False, True) >= 8
+                and logic.terran_defense_rating(state, False, False) >= 6
+                and logic.terran_common_unit(state)
+                and (logic.marine_medic_upgrade(state) or adv_tactics)
+                and (logic.terran_base_trasher(state) or state.has(item_names.COMMAND_CENTER_SCANNER_SWEEP, player)))
+        ),
         make_location_data(SC2Mission.THE_MOEBIUS_FACTOR.mission_name, "Victory", SC2WOL_LOC_ID_OFFSET + 1000, LocationType.VICTORY,
             lambda state: (
                 logic.terran_basic_anti_air(state)


### PR DESCRIPTION
## What is this fixing or adding?
The Dig protoss bases as locations.

Pairs with [data PR #270](https://github.com/Ziktofel/Archipelago-SC2-data/pull/270)

## How was this tested?
Generated a new world, loaded into the mission, verified the objectives showed up and were sent when clearing the bases.

## If this makes graphical changes, please attach screenshots.
See data PR.