### PR TITLE
Cutthroat and Great Train Robbery Raceswap Locations

### DIFF
--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1148,7 +1148,7 @@ item_table = {
                  origin={"hots"}),
     item_names.BANELING_CORROSIVE_ACID:
         ItemData(209 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 9, SC2Race.ZERG,
-                 parent_item=item_names.ZERGLING_BANELING_ASPECT, origin={"hots"}),
+                 parent_item=item_names.ZERGLING_BANELING_ASPECT, origin={"hots"}, classification=ItemClassification.progression),
     item_names.BANELING_RUPTURE:
         ItemData(210 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 10, SC2Race.ZERG,
                  parent_item=item_names.ZERGLING_BANELING_ASPECT, origin={"hots"},
@@ -1204,7 +1204,7 @@ item_table = {
                  origin={"ext"}),
     item_names.ROACH_GLIAL_RECONSTITUTION:
         ItemData(227 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 27, SC2Race.ZERG, parent_item=item_names.ROACH,
-                 origin={"ext"}),
+                 origin={"ext"}, classification=ItemClassification.progression),
     item_names.ROACH_ORGANIC_CARAPACE:
         ItemData(228 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 28, SC2Race.ZERG, parent_item=item_names.ROACH,
                  origin={"ext"}),
@@ -1225,7 +1225,7 @@ item_table = {
                  parent_item=item_names.ZERGLING_BANELING_ASPECT, origin={"ext"}),
     item_names.MUTALISK_SEVERING_GLAIVE:
         ItemData(234 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 4, SC2Race.ZERG, parent_item=item_names.MUTALISK,
-                 origin={"ext"}),
+                 origin={"ext"}, classification=ItemClassification.progression),
     item_names.MUTALISK_AERODYNAMIC_GLAIVE_SHAPE:
         ItemData(235 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 5, SC2Race.ZERG, parent_item=item_names.MUTALISK,
                  origin={"ext"}),
@@ -1774,7 +1774,7 @@ item_table = {
     item_names.DRAGOON_PHALANX_SUIT: ItemData(504 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 4, SC2Race.PROTOSS, parent_item=item_names.DRAGOON),
     item_names.INSTIGATOR_RESOURCE_EFFICIENCY: ItemData(505 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 5, SC2Race.PROTOSS, parent_item=item_names.INSTIGATOR),
     item_names.ADEPT_DISRUPTIVE_TRANSFER: ItemData(506 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 6, SC2Race.PROTOSS, parent_item=item_names.ADEPT),
-    item_names.SLAYER_PHASE_BLINK: ItemData(507 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 7, SC2Race.PROTOSS, parent_item=item_names.SLAYER),
+    item_names.SLAYER_PHASE_BLINK: ItemData(507 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 7, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.SLAYER),
     item_names.AVENGER_KRYHAS_CLOAK: ItemData(508 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 8, SC2Race.PROTOSS, parent_item=item_names.AVENGER),
     item_names.DARK_TEMPLAR_LESSER_SHADOW_FURY: ItemData(509 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 9, SC2Race.PROTOSS, parent_item=item_names.DARK_TEMPLAR),
     item_names.DARK_TEMPLAR_GREATER_SHADOW_FURY: ItemData(510 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 10, SC2Race.PROTOSS, parent_item=item_names.DARK_TEMPLAR),
@@ -1802,7 +1802,7 @@ item_table = {
     item_names.MIRAGE_GRAVITON_BEAM: ItemData(532 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 2, SC2Race.PROTOSS, parent_item=item_names.MIRAGE),
     item_names.SKIRMISHER_PEER_CONTEMPT: ItemData(533 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 3, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.SKIRMISHER),
     item_names.VOID_RAY_PRISMATIC_RANGE: ItemData(534 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 4, SC2Race.PROTOSS, parent_item=item_names.VOID_RAY),
-    item_names.DESTROYER_REFORGED_BLOODSHARD_CORE: ItemData(336 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 5, SC2Race.PROTOSS, parent_item=item_names.DESTROYER),
+    item_names.DESTROYER_REFORGED_BLOODSHARD_CORE: ItemData(336 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 5, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.DESTROYER),
     # 536 reserved for Warp Ray
     # 537 reserved for Dawnbringer
     # 538 reserved for Carrier

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1731,7 +1731,7 @@ item_table = {
     item_names.IMMORTAL_ANNIHILATOR_STALWART_SINGULARITY_CHARGE: ItemData(348 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 18, SC2Race.PROTOSS, origin={"ext"}),
     item_names.IMMORTAL_ANNIHILATOR_STALWART_ADVANCED_TARGETING_MECHANICS: ItemData(349 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 19, SC2Race.PROTOSS, classification=ItemClassification.progression, origin={"ext"}),
     item_names.COLOSSUS_PACIFICATION_PROTOCOL: ItemData(350 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 20, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.COLOSSUS),
-    item_names.WRATHWALKER_RAPID_POWER_CYCLING: ItemData(351 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 21, SC2Race.PROTOSS, origin={"ext"}, parent_item=item_names.WRATHWALKER),
+    item_names.WRATHWALKER_RAPID_POWER_CYCLING: ItemData(351 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 21, SC2Race.PROTOSS, classification=ItemClassification.progression, origin={"ext"}, parent_item=item_names.WRATHWALKER),
     item_names.WRATHWALKER_EYE_OF_WRATH: ItemData(352 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 22, SC2Race.PROTOSS, classification=ItemClassification.filler, origin={"ext"}, parent_item=item_names.WRATHWALKER),
     item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_SHROUD_OF_ADUN: ItemData(353 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 23, SC2Race.PROTOSS, origin={"ext"}),
     item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_SHADOW_GUARD_TRAINING: ItemData(354 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 24, SC2Race.PROTOSS, origin={"bw"}),

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2742,6 +2742,54 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                     or logic.protoss_competent_anti_air(state)
                 ))
         ),
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1607, LocationType.VICTORY,
+            lambda state: (
+                logic.zerg_common_unit(state)
+                and (adv_tactics or logic.zerg_basic_anti_air(state)))
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Mira Han", SC2_RACESWAP_LOC_ID_OFFSET + 1608, LocationType.EXTRA,
+            logic.zerg_common_unit
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "North Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1609, LocationType.VANILLA,
+            logic.zerg_common_unit
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Mid Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1610, LocationType.VANILLA),
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Southwest Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1611, LocationType.VANILLA,
+            logic.zerg_common_unit
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "North Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1612, LocationType.EXTRA,
+            logic.zerg_common_unit
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "South Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1613, LocationType.EXTRA,
+            logic.zerg_common_unit
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "West Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1614, LocationType.EXTRA,
+            logic.zerg_common_unit
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1615, LocationType.VICTORY,
+            lambda state: (
+                logic.protoss_common_unit(state)
+                and (adv_tactics or logic.protoss_basic_anti_air(state)))
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Mira Han", SC2_RACESWAP_LOC_ID_OFFSET + 1616, LocationType.EXTRA,
+            logic.protoss_common_unit
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "North Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1617, LocationType.VANILLA,
+            logic.protoss_common_unit
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Mid Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1618, LocationType.VANILLA),
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Southwest Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1619, LocationType.VANILLA,
+            logic.protoss_common_unit
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "North Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1620, LocationType.EXTRA,
+            logic.protoss_common_unit
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "South Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1621, LocationType.EXTRA,
+            logic.protoss_common_unit
+        ),
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "West Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1622, LocationType.EXTRA,
+            logic.protoss_common_unit
+        ),
     ]
 
     beat_events = []

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2742,52 +2742,52 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                     or logic.protoss_competent_anti_air(state)
                 ))
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1700, LocationType.VICTORY,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 3500, LocationType.VICTORY,
             lambda state: (
                 logic.zerg_common_unit(state)
                 and (adv_tactics or logic.zerg_basic_anti_air(state)))
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Mira Han", SC2_RACESWAP_LOC_ID_OFFSET + 1701, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Mira Han", SC2_RACESWAP_LOC_ID_OFFSET + 3501, LocationType.EXTRA,
             logic.zerg_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "North Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1702, LocationType.VANILLA,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "North Relic", SC2_RACESWAP_LOC_ID_OFFSET + 3502, LocationType.VANILLA,
             logic.zerg_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Mid Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1703, LocationType.VANILLA),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Southwest Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1704, LocationType.VANILLA,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Mid Relic", SC2_RACESWAP_LOC_ID_OFFSET + 3503, LocationType.VANILLA),
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Southwest Relic", SC2_RACESWAP_LOC_ID_OFFSET + 3504, LocationType.VANILLA,
             logic.zerg_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "North Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1705, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "North Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 3505, LocationType.EXTRA,
             logic.zerg_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "South Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1706, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "South Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 3506, LocationType.EXTRA,
             logic.zerg_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "West Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1707, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "West Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 3507, LocationType.EXTRA,
             logic.zerg_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1800, LocationType.VICTORY,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 3600, LocationType.VICTORY,
             lambda state: (
                 logic.protoss_common_unit(state)
                 and (adv_tactics or logic.protoss_basic_anti_air(state)))
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Mira Han", SC2_RACESWAP_LOC_ID_OFFSET + 1801, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Mira Han", SC2_RACESWAP_LOC_ID_OFFSET + 3601, LocationType.EXTRA,
             logic.protoss_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "North Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1802, LocationType.VANILLA,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "North Relic", SC2_RACESWAP_LOC_ID_OFFSET + 3602, LocationType.VANILLA,
             logic.protoss_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Mid Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1803, LocationType.VANILLA),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Southwest Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1804, LocationType.VANILLA,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Mid Relic", SC2_RACESWAP_LOC_ID_OFFSET + 3603, LocationType.VANILLA),
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Southwest Relic", SC2_RACESWAP_LOC_ID_OFFSET + 3604, LocationType.VANILLA,
             logic.protoss_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "North Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1805, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "North Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 3605, LocationType.EXTRA,
             logic.protoss_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "South Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1806, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "South Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 3606, LocationType.EXTRA,
             logic.protoss_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "West Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1807, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "West Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 3607, LocationType.EXTRA,
             logic.protoss_common_unit
         ),
     ]

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2742,52 +2742,52 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                     or logic.protoss_competent_anti_air(state)
                 ))
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1607, LocationType.VICTORY,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1700, LocationType.VICTORY,
             lambda state: (
                 logic.zerg_common_unit(state)
                 and (adv_tactics or logic.zerg_basic_anti_air(state)))
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Mira Han", SC2_RACESWAP_LOC_ID_OFFSET + 1608, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Mira Han", SC2_RACESWAP_LOC_ID_OFFSET + 1701, LocationType.EXTRA,
             logic.zerg_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "North Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1609, LocationType.VANILLA,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "North Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1702, LocationType.VANILLA,
             logic.zerg_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Mid Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1610, LocationType.VANILLA),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Southwest Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1611, LocationType.VANILLA,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Mid Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1703, LocationType.VANILLA),
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Southwest Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1704, LocationType.VANILLA,
             logic.zerg_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "North Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1612, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "North Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1705, LocationType.EXTRA,
             logic.zerg_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "South Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1613, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "South Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1706, LocationType.EXTRA,
             logic.zerg_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "West Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1614, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "West Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1707, LocationType.EXTRA,
             logic.zerg_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1615, LocationType.VICTORY,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1800, LocationType.VICTORY,
             lambda state: (
                 logic.protoss_common_unit(state)
                 and (adv_tactics or logic.protoss_basic_anti_air(state)))
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Mira Han", SC2_RACESWAP_LOC_ID_OFFSET + 1616, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Mira Han", SC2_RACESWAP_LOC_ID_OFFSET + 1801, LocationType.EXTRA,
             logic.protoss_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "North Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1617, LocationType.VANILLA,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "North Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1802, LocationType.VANILLA,
             logic.protoss_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Mid Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1618, LocationType.VANILLA),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Southwest Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1619, LocationType.VANILLA,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Mid Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1803, LocationType.VANILLA),
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "Southwest Relic", SC2_RACESWAP_LOC_ID_OFFSET + 1804, LocationType.VANILLA,
             logic.protoss_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "North Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1620, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "North Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1805, LocationType.EXTRA,
             logic.protoss_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "South Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1621, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "South Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1806, LocationType.EXTRA,
             logic.protoss_common_unit
         ),
-        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "West Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1622, LocationType.EXTRA,
+        make_location_data(SC2Mission.CUTTHROAT_P.mission_name, "West Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 1807, LocationType.EXTRA,
             logic.protoss_common_unit
         ),
     ]

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -622,7 +622,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.GHOST_OF_A_CHANCE.mission_name, "Third Island Spectres", SC2WOL_LOC_ID_OFFSET + 1605, LocationType.VANILLA),
         make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY.mission_name, "Victory", SC2WOL_LOC_ID_OFFSET + 1700, LocationType.VICTORY,
             lambda state: (
-                logic.great_train_robbery_train_stopper(state)
+                logic.terran_great_train_robbery_train_stopper(state)
                 and logic.terran_basic_anti_air(state))
         ),
         make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY.mission_name, "North Defiler", SC2WOL_LOC_ID_OFFSET + 1701, LocationType.VANILLA),
@@ -637,26 +637,26 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY.mission_name, "Kill Team", SC2WOL_LOC_ID_OFFSET + 1710, LocationType.CHALLENGE,
             lambda state: (
                 (adv_tactics or logic.terran_common_unit(state))
-                and logic.great_train_robbery_train_stopper(state)
+                and logic.terran_great_train_robbery_train_stopper(state)
                 and logic.terran_basic_anti_air(state))
         ),
         make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY.mission_name, "Flawless", SC2WOL_LOC_ID_OFFSET + 1711, LocationType.CHALLENGE,
             lambda state:(
-                logic.great_train_robbery_train_stopper(state)
+                logic.terran_great_train_robbery_train_stopper(state)
                 and logic.terran_basic_anti_air(state)),
             flags=LocationFlag.PREVENTATIVE
         ),
         make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY.mission_name, "2 Trains Destroyed", SC2WOL_LOC_ID_OFFSET + 1712, LocationType.EXTRA,
-            logic.great_train_robbery_train_stopper
+            logic.terran_great_train_robbery_train_stopper
         ),
         make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY.mission_name, "4 Trains Destroyed", SC2WOL_LOC_ID_OFFSET + 1713, LocationType.EXTRA,
             lambda state: (
-                logic.great_train_robbery_train_stopper(state)
+                logic.terran_great_train_robbery_train_stopper(state)
                 and logic.terran_basic_anti_air(state))
         ),
         make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY.mission_name, "6 Trains Destroyed", SC2WOL_LOC_ID_OFFSET + 1714, LocationType.EXTRA,
             lambda state: (
-                logic.great_train_robbery_train_stopper(state)
+                logic.terran_great_train_robbery_train_stopper(state)
                 and logic.terran_basic_anti_air(state))
         ),
         make_location_data(SC2Mission.CUTTHROAT.mission_name, "Victory", SC2WOL_LOC_ID_OFFSET + 1800, LocationType.VICTORY,
@@ -2741,6 +2741,84 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and ((adv_tactics and logic.protoss_basic_anti_air(state))
                     or logic.protoss_competent_anti_air(state)
                 ))
+        ),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 3300, LocationType.VICTORY,
+            lambda state: (
+                logic.zerg_great_train_robbery_train_stopper(state)
+                and logic.zerg_basic_anti_air(state))
+        ),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "North Defiler", SC2_RACESWAP_LOC_ID_OFFSET + 3301, LocationType.VANILLA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "Mid Defiler", SC2_RACESWAP_LOC_ID_OFFSET + 3302, LocationType.VANILLA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "South Defiler", SC2_RACESWAP_LOC_ID_OFFSET + 3303, LocationType.VANILLA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "Close Diamondback", SC2_RACESWAP_LOC_ID_OFFSET + 3304, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "Northwest Diamondback", SC2_RACESWAP_LOC_ID_OFFSET + 3305, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "North Diamondback", SC2_RACESWAP_LOC_ID_OFFSET + 3306, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "Northeast Diamondback", SC2_RACESWAP_LOC_ID_OFFSET + 3307, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "Southwest Diamondback", SC2_RACESWAP_LOC_ID_OFFSET + 3308, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "Southeast Diamondback", SC2_RACESWAP_LOC_ID_OFFSET + 3309, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "Kill Team", SC2_RACESWAP_LOC_ID_OFFSET + 3310, LocationType.CHALLENGE,
+            lambda state: (
+                (adv_tactics or logic.zerg_common_unit(state))
+                and logic.zerg_great_train_robbery_train_stopper(state)
+                and logic.zerg_basic_anti_air(state))
+        ),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "Flawless", SC2_RACESWAP_LOC_ID_OFFSET + 3311, LocationType.CHALLENGE,
+            lambda state:(
+                logic.zerg_great_train_robbery_train_stopper(state)
+                and logic.zerg_basic_anti_air(state)),
+            flags=LocationFlag.PREVENTATIVE
+        ),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "2 Trains Destroyed", SC2_RACESWAP_LOC_ID_OFFSET + 3312, LocationType.EXTRA,
+            logic.zerg_great_train_robbery_train_stopper
+        ),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "4 Trains Destroyed", SC2_RACESWAP_LOC_ID_OFFSET + 3313, LocationType.EXTRA,
+            lambda state: (
+                logic.zerg_great_train_robbery_train_stopper(state)
+                and logic.zerg_basic_anti_air(state))
+        ),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z.mission_name, "6 Trains Destroyed", SC2_RACESWAP_LOC_ID_OFFSET + 3314, LocationType.EXTRA,
+            lambda state: (
+                logic.zerg_great_train_robbery_train_stopper(state)
+                and logic.zerg_basic_anti_air(state))
+        ),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 3400, LocationType.VICTORY,
+            lambda state: (
+                logic.protoss_great_train_robbery_train_stopper(state)
+                and logic.protoss_basic_anti_air(state))
+        ),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "North Defiler", SC2_RACESWAP_LOC_ID_OFFSET + 3401, LocationType.VANILLA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "Mid Defiler", SC2_RACESWAP_LOC_ID_OFFSET + 3402, LocationType.VANILLA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "South Defiler", SC2_RACESWAP_LOC_ID_OFFSET + 3403, LocationType.VANILLA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "Close Diamondback", SC2_RACESWAP_LOC_ID_OFFSET + 3404, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "Northwest Diamondback", SC2_RACESWAP_LOC_ID_OFFSET + 3405, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "North Diamondback", SC2_RACESWAP_LOC_ID_OFFSET + 3406, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "Northeast Diamondback", SC2_RACESWAP_LOC_ID_OFFSET + 3407, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "Southwest Diamondback", SC2_RACESWAP_LOC_ID_OFFSET + 3408, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "Southeast Diamondback", SC2_RACESWAP_LOC_ID_OFFSET + 3409, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "Kill Team", SC2_RACESWAP_LOC_ID_OFFSET + 3410, LocationType.CHALLENGE,
+            lambda state: (
+                (adv_tactics or logic.protoss_common_unit(state))
+                and logic.protoss_great_train_robbery_train_stopper(state)
+                and logic.protoss_basic_anti_air(state))
+        ),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "Flawless", SC2_RACESWAP_LOC_ID_OFFSET + 3411, LocationType.CHALLENGE,
+            lambda state:(
+                logic.protoss_great_train_robbery_train_stopper(state)
+                and logic.protoss_basic_anti_air(state)),
+            flags=LocationFlag.PREVENTATIVE
+        ),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "2 Trains Destroyed", SC2_RACESWAP_LOC_ID_OFFSET + 3412, LocationType.EXTRA,
+            logic.protoss_great_train_robbery_train_stopper
+        ),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "4 Trains Destroyed", SC2_RACESWAP_LOC_ID_OFFSET + 3413, LocationType.EXTRA,
+            lambda state: (
+                logic.protoss_great_train_robbery_train_stopper(state)
+                and logic.protoss_basic_anti_air(state))
+        ),
+        make_location_data(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P.mission_name, "6 Trains Destroyed", SC2_RACESWAP_LOC_ID_OFFSET + 3414, LocationType.EXTRA,
+            lambda state: (
+                logic.protoss_great_train_robbery_train_stopper(state)
+                and logic.protoss_basic_anti_air(state))
         ),
         make_location_data(SC2Mission.CUTTHROAT_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 3500, LocationType.VICTORY,
             lambda state: (

--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -116,7 +116,7 @@ class SC2Mission(Enum):
     WELCOME_TO_THE_JUNGLE = 14, "Welcome to the Jungle", SC2Campaign.WOL, "Covert", SC2Race.TERRAN, MissionPools.MEDIUM, "ap_welcome_to_the_jungle", MissionFlag.Terran|MissionFlag.VsProtoss
     BREAKOUT = 15, "Breakout", SC2Campaign.WOL, "Covert", SC2Race.ANY, MissionPools.STARTER, "ap_breakout", MissionFlag.Terran|MissionFlag.NoBuild|MissionFlag.VsTerran
     GHOST_OF_A_CHANCE = 16, "Ghost of a Chance", SC2Campaign.WOL, "Covert", SC2Race.ANY, MissionPools.STARTER, "ap_ghost_of_a_chance", MissionFlag.Terran|MissionFlag.NoBuild|MissionFlag.VsTerran
-    THE_GREAT_TRAIN_ROBBERY = 17, "The Great Train Robbery", SC2Campaign.WOL, "Rebellion", SC2Race.TERRAN, MissionPools.MEDIUM, "ap_the_great_train_robbery", MissionFlag.Terran|MissionFlag.AutoScroller|MissionFlag.VsTerran
+    THE_GREAT_TRAIN_ROBBERY = 17, "The Great Train Robbery (Terran)", SC2Campaign.WOL, "Rebellion", SC2Race.TERRAN, MissionPools.MEDIUM, "ap_the_great_train_robbery", MissionFlag.Terran|MissionFlag.AutoScroller|MissionFlag.VsTerran|MissionFlag.HasRaceSwap
     CUTTHROAT = 18, "Cutthroat (Terran)", SC2Campaign.WOL, "Rebellion", SC2Race.TERRAN, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Terran|MissionFlag.Countdown|MissionFlag.VsTerran|MissionFlag.HasRaceSwap
     ENGINE_OF_DESTRUCTION = 19, "Engine of Destruction", SC2Campaign.WOL, "Rebellion", SC2Race.TERRAN, MissionPools.HARD, "ap_engine_of_destruction", MissionFlag.Terran|MissionFlag.AutoScroller|MissionFlag.VsTerran
     MEDIA_BLITZ = 20, "Media Blitz", SC2Campaign.WOL, "Rebellion", SC2Race.TERRAN, MissionPools.MEDIUM, "ap_media_blitz", MissionFlag.Terran|MissionFlag.VsTerran
@@ -220,8 +220,8 @@ class SC2Mission(Enum):
     # 110/111 - Welcome to the Jungle
     # 112/113 - Breakout
     # 114/115 - Ghost of a Chance
-    THE_GREAT_TRAIN_ROBBERY_Z = 116, "The Great Train Robbery (Zerg)", SC2Campaign.WOL, "Rebellion", SC2Race.ZERG, MissionPools.MEDIUM, "ap_the_great_train_robbery", MissionFlag.Zerg|MissionFlag.AutoScroller|MissionFlag.VsTerran
-    THE_GREAT_TRAIN_ROBBERY_P = 117, "The Great Train Robbery (Protoss)", SC2Campaign.WOL, "Rebellion", SC2Race.PROTOSS, MissionPools.MEDIUM, "ap_the_great_train_robbery", MissionFlag.Protoss|MissionFlag.AutoScroller|MissionFlag.VsTerran
+    THE_GREAT_TRAIN_ROBBERY_Z = 116, "The Great Train Robbery (Zerg)", SC2Campaign.WOL, "Rebellion", SC2Race.ZERG, MissionPools.MEDIUM, "ap_the_great_train_robbery", MissionFlag.Zerg|MissionFlag.AutoScroller|MissionFlag.VsTerran|MissionFlag.RaceSwap
+    THE_GREAT_TRAIN_ROBBERY_P = 117, "The Great Train Robbery (Protoss)", SC2Campaign.WOL, "Rebellion", SC2Race.PROTOSS, MissionPools.MEDIUM, "ap_the_great_train_robbery", MissionFlag.Protoss|MissionFlag.AutoScroller|MissionFlag.VsTerran|MissionFlag.RaceSwap
     CUTTHROAT_Z = 118, "Cutthroat (Zerg)", SC2Campaign.WOL, "Rebellion", SC2Race.ZERG, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Zerg|MissionFlag.Countdown|MissionFlag.VsTerran|MissionFlag.RaceSwap
     CUTTHROAT_P = 119, "Cutthroat (Protoss)", SC2Campaign.WOL, "Rebellion", SC2Race.PROTOSS, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Protoss|MissionFlag.Countdown|MissionFlag.VsTerran|MissionFlag.RaceSwap
     # 120/121 - Engine of Destruction

--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -117,7 +117,7 @@ class SC2Mission(Enum):
     BREAKOUT = 15, "Breakout", SC2Campaign.WOL, "Covert", SC2Race.ANY, MissionPools.STARTER, "ap_breakout", MissionFlag.Terran|MissionFlag.NoBuild|MissionFlag.VsTerran
     GHOST_OF_A_CHANCE = 16, "Ghost of a Chance", SC2Campaign.WOL, "Covert", SC2Race.ANY, MissionPools.STARTER, "ap_ghost_of_a_chance", MissionFlag.Terran|MissionFlag.NoBuild|MissionFlag.VsTerran
     THE_GREAT_TRAIN_ROBBERY = 17, "The Great Train Robbery", SC2Campaign.WOL, "Rebellion", SC2Race.TERRAN, MissionPools.MEDIUM, "ap_the_great_train_robbery", MissionFlag.Terran|MissionFlag.AutoScroller|MissionFlag.VsTerran
-    CUTTHROAT = 18, "Cutthroat", SC2Campaign.WOL, "Rebellion", SC2Race.TERRAN, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Terran|MissionFlag.Countdown|MissionFlag.VsTerran
+    CUTTHROAT = 18, "Cutthroat (Terran)", SC2Campaign.WOL, "Rebellion", SC2Race.TERRAN, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Terran|MissionFlag.Countdown|MissionFlag.VsTerran|MissionFlag.HasRaceSwap
     ENGINE_OF_DESTRUCTION = 19, "Engine of Destruction", SC2Campaign.WOL, "Rebellion", SC2Race.TERRAN, MissionPools.HARD, "ap_engine_of_destruction", MissionFlag.Terran|MissionFlag.AutoScroller|MissionFlag.VsTerran
     MEDIA_BLITZ = 20, "Media Blitz", SC2Campaign.WOL, "Rebellion", SC2Race.TERRAN, MissionPools.MEDIUM, "ap_media_blitz", MissionFlag.Terran|MissionFlag.VsTerran
     PIERCING_OF_THE_SHROUD = 21, "Piercing the Shroud", SC2Campaign.WOL, "Rebellion", SC2Race.TERRAN, MissionPools.STARTER, "ap_piercing_the_shroud", MissionFlag.Terran|MissionFlag.NoBuild|MissionFlag.VsAll
@@ -221,7 +221,8 @@ class SC2Mission(Enum):
     # 112/113 - Breakout
     # 114/115 - Ghost of a Chance
     # 116/117 - Great Train Robbery
-    # 118/119 - Cutthroat
+    CUTTHROAT = 118, "Cutthroat (Zerg)", SC2Campaign.WOL, "Rebellion", SC2Race.ZERG, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Zerg|MissionFlag.Countdown|MissionFlag.VsTerran|MissionFlag.RaceSwap
+    CUTTHROAT = 119, "Cutthroat (Protoss)", SC2Campaign.WOL, "Rebellion", SC2Race.PROTOSS, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Protoss|MissionFlag.Countdown|MissionFlag.VsTerran|MissionFlag.RaceSwap
     # 120/121 - Engine of Destruction
     # 122/123 - Media Blitz
     # 124/125 - Piercing the Shroud

--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -221,8 +221,8 @@ class SC2Mission(Enum):
     # 112/113 - Breakout
     # 114/115 - Ghost of a Chance
     # 116/117 - Great Train Robbery
-    CUTTHROAT = 118, "Cutthroat (Zerg)", SC2Campaign.WOL, "Rebellion", SC2Race.ZERG, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Zerg|MissionFlag.Countdown|MissionFlag.VsTerran|MissionFlag.RaceSwap
-    CUTTHROAT = 119, "Cutthroat (Protoss)", SC2Campaign.WOL, "Rebellion", SC2Race.PROTOSS, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Protoss|MissionFlag.Countdown|MissionFlag.VsTerran|MissionFlag.RaceSwap
+    CUTTHROAT_Z = 118, "Cutthroat (Zerg)", SC2Campaign.WOL, "Rebellion", SC2Race.ZERG, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Zerg|MissionFlag.Countdown|MissionFlag.VsTerran|MissionFlag.RaceSwap
+    CUTTHROAT_P = 119, "Cutthroat (Protoss)", SC2Campaign.WOL, "Rebellion", SC2Race.PROTOSS, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Protoss|MissionFlag.Countdown|MissionFlag.VsTerran|MissionFlag.RaceSwap
     # 120/121 - Engine of Destruction
     # 122/123 - Media Blitz
     # 124/125 - Piercing the Shroud

--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -220,7 +220,8 @@ class SC2Mission(Enum):
     # 110/111 - Welcome to the Jungle
     # 112/113 - Breakout
     # 114/115 - Ghost of a Chance
-    # 116/117 - Great Train Robbery
+    THE_GREAT_TRAIN_ROBBERY_Z = 116, "The Great Train Robbery (Zerg)", SC2Campaign.WOL, "Rebellion", SC2Race.ZERG, MissionPools.MEDIUM, "ap_the_great_train_robbery", MissionFlag.Zerg|MissionFlag.AutoScroller|MissionFlag.VsTerran
+    THE_GREAT_TRAIN_ROBBERY_P = 117, "The Great Train Robbery (Protoss)", SC2Campaign.WOL, "Rebellion", SC2Race.PROTOSS, MissionPools.MEDIUM, "ap_the_great_train_robbery", MissionFlag.Protoss|MissionFlag.AutoScroller|MissionFlag.VsTerran
     CUTTHROAT_Z = 118, "Cutthroat (Zerg)", SC2Campaign.WOL, "Rebellion", SC2Race.ZERG, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Zerg|MissionFlag.Countdown|MissionFlag.VsTerran|MissionFlag.RaceSwap
     CUTTHROAT_P = 119, "Cutthroat (Protoss)", SC2Campaign.WOL, "Rebellion", SC2Race.PROTOSS, MissionPools.MEDIUM, "ap_cutthroat", MissionFlag.Protoss|MissionFlag.Countdown|MissionFlag.VsTerran|MissionFlag.RaceSwap
     # 120/121 - Engine of Destruction

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -148,7 +148,7 @@ class MaximumCampaignSize(Range):
     """
     display_name = "Maximum Campaign Size"
     range_start = 1
-    range_end = 97
+    range_end = 99
     default = 83
 
 

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -148,7 +148,7 @@ class MaximumCampaignSize(Range):
     """
     display_name = "Maximum Campaign Size"
     range_start = 1
-    range_end = 99
+    range_end = 101
     default = 83
 
 

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -247,7 +247,7 @@ class SC2Logic:
         return (
             state.has_any({item_names.ANNIHILATOR, item_names.INSTIGATOR, item_names.STALKER}, self.player)
             or state.has_all({item_names.SLAYER, item_names.SLAYER_PHASE_BLINK}, self.player)
-            or state.has(item_name.MATRIX_OVERLOAD, self.player)
+            or state.has(item_names.MATRIX_OVERLOAD, self.player)
             or self.advanced_tactics
             and  (
                 state.has_all({item_names.WRATHWALKER, item_names.WRATHWALKER_RAPID_POWER_CYCLING}, self.player)

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -228,11 +228,12 @@ class SC2Logic:
         """
         return (
             self.morph_impaler_or_lurker(state)
-            or state.has_any({item_names.ABERRATION, item_names.MUTALISK}, self.player)
+            or state.has_all({item_names.MUTALISK_SEVERING_GLAIVE, item_names.MUTALISK}, self.player)
+            or state.has(item_names.ABERRATION, self.player)
+            or state.has(item_names.MALIGNANT_CREEP, self.player)
             or self.advanced_tactics
             and (
                 state.has_all({item_names.ZERGLING_BANELING_ASPECT, item_names.BANELING_CORROSIVE_ACID}, self.player)
-                or state.has_all({item_names.ZERGLING, item_names.ZERGLING_METABOLIC_BOOST}, self.player)
                 or state.has_all({item_names.ROACH, item_names.ROACH_GLIAL_RECONSTITUTION}, self.player)
             )
         )
@@ -246,15 +247,15 @@ class SC2Logic:
         return (
             state.has_any({item_names.ANNIHILATOR, item_names.INSTIGATOR, item_names.STALKER}, self.player)
             or state.has_all({item_names.SLAYER, item_names.SLAYER_PHASE_BLINK}, self.player)
+            or state.has(item_name.MATRIX_OVERLOAD, self.player)
             or self.advanced_tactics
             and  (
                 state.has_all({item_names.WRATHWALKER, item_names.WRATHWALKER_RAPID_POWER_CYCLING}, self.player)
-                or state.has_all({item_names.VANGUARD, item_names.VANGUARD_RAPIDFIRE_CANNON, item_names.VANGUARD_FUSION_MORTARS}, self.player)
-                or state.has_all({item_names.DESTROYER, item_names.DESTROYER_REFORGED_BLOODSHARD_CORE, VOID_RAY_DESTROYER_WARP_RAY_DAWNBRINGER_FLUX_VANES}, self.player)
+                or state.has_all({item_names.VANGUARD, item_names.VANGUARD_RAPIDFIRE_CANNON}, self.player)
                 or (
-                    state.has(item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_BLINK, self.player)
-                    and state.has_any({item_names.DARK_TEMPLAR, item_names.BLOOD_HUNTER, item_names.AVENGER}, self.player)
-                ) 
+                    state.has_any({item_names.VOID_RAY, item_names.DAWNBRINGER}, self.player)
+                    and state.has_all({item_names.DESTROYER, item_names.DESTROYER_REFORGED_BLOODSHARD_CORE}, self.player)
+                )
             )
 
         )

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -212,11 +212,12 @@ class SC2Logic:
         """
         return (
             state.has_any({item_names.SIEGE_TANK, item_names.DIAMONDBACK, item_names.MARAUDER, item_names.CYCLONE, item_names.BANSHEE}, self.player)
-            or self.advanced_tactics
-            and (
-                state.has_all({item_names.REAPER, item_names.REAPER_G4_CLUSTERBOMB}, self.player)
-                or state.has_all({item_names.SPECTRE, item_names.SPECTRE_PSIONIC_LASH}, self.player)
-                or state.has_any({item_names.VULTURE, item_names.LIBERATOR}, self.player)
+            or (self.advanced_tactics
+                and (
+                    state.has_all({item_names.REAPER, item_names.REAPER_G4_CLUSTERBOMB}, self.player)
+                    or state.has_all({item_names.SPECTRE, item_names.SPECTRE_PSIONIC_LASH}, self.player)
+                    or state.has_any({item_names.VULTURE, item_names.LIBERATOR}, self.player)
+                )
             )
         )
     
@@ -230,10 +231,11 @@ class SC2Logic:
             self.morph_impaler_or_lurker(state)
             or state.has_all({item_names.MUTALISK_SEVERING_GLAIVE, item_names.MUTALISK}, self.player)
             or state.has(item_names.ABERRATION, self.player)
-            or self.advanced_tactics
-            and (
-                state.has_all({item_names.ZERGLING_BANELING_ASPECT, item_names.BANELING_CORROSIVE_ACID}, self.player)
-                or state.has_all({item_names.ROACH, item_names.ROACH_GLIAL_RECONSTITUTION}, self.player)
+            or (self.advanced_tactics
+                and (
+                    state.has_all({item_names.ZERGLING_BANELING_ASPECT, item_names.BANELING_CORROSIVE_ACID}, self.player)
+                    or state.has_all({item_names.ROACH, item_names.ROACH_GLIAL_RECONSTITUTION}, self.player)
+                )
             )
         )
     
@@ -246,15 +248,15 @@ class SC2Logic:
         return (
             state.has_any({item_names.ANNIHILATOR, item_names.INSTIGATOR, item_names.STALKER}, self.player)
             or state.has_all({item_names.SLAYER, item_names.SLAYER_PHASE_BLINK}, self.player)
-            or self.advanced_tactics
-            and  (
-                state.has_all({item_names.WRATHWALKER, item_names.WRATHWALKER_RAPID_POWER_CYCLING}, self.player)
-                or state.has_all({item_names.VANGUARD, item_names.VANGUARD_RAPIDFIRE_CANNON}, self.player)
-                or (
-                    state.has_any({item_names.VOID_RAY, item_names.DAWNBRINGER}, self.player)
-                    and state.has_all({item_names.DESTROYER, item_names.DESTROYER_REFORGED_BLOODSHARD_CORE}, self.player)
-                )
-            )
+            or (self.advanced_tactics
+                and  (
+                    state.has_all({item_names.WRATHWALKER, item_names.WRATHWALKER_RAPID_POWER_CYCLING}, self.player)
+                    or state.has_all({item_names.VANGUARD, item_names.VANGUARD_RAPIDFIRE_CANNON}, self.player)
+                    or (
+                        state.has_any({item_names.VOID_RAY, item_names.DAWNBRINGER}, self.player)
+                        and state.has_all({item_names.DESTROYER, item_names.DESTROYER_REFORGED_BLOODSHARD_CORE}, self.player)
+                    )
+            ) )
 
         )
 

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -227,13 +227,16 @@ class SC2Logic:
         :return:
         """
         return (
-            state.has_any({item_names.HYDRALISK_IMPALER_ASPECT, item_names.ABERRATION, item_names.MUTALISK}, self.player)
-            or state.has_all({item_names.HYDRALISK_LURKER_ASPECT, item_names.LURKER_SEISMIC_SPINES}, self.player)
+            self.morph_impaler_or_lurker(state)
+            or state.has(item_names.ABERRATION, self.player)
+            or (
+                state.has(item_names.MUTALISK, self.player)
+                and state.has_any({item_names.MUTALISK_SUNDERING_GLAIVE, item_names.MUTALISK_VICIOUS_GLAIVE, item_names.MUTALISK_SEVERING_GLAIVE}, self.player)
+            )
             or self.advanced_tactics
             and (
                 state.has_all({item_names.ZERGLING_BANELING_ASPECT, item_names.BANELING_CORROSIVE_ACID}, self.player)
                 or state.has_all({item_names.ZERGLING, item_names.ZERGLING_METABOLIC_BOOST}, self.player)
-                or state.has_all({item_names.HYDRALISK, item_names.HYDRALISK_MUSCULAR_AUGMENTS}, self.player)
                 or state.has_all({item_names.ROACH, item_names.ROACH_GLIAL_RECONSTITUTION}, self.player)
             )
         )

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -228,11 +228,7 @@ class SC2Logic:
         """
         return (
             self.morph_impaler_or_lurker(state)
-            or state.has(item_names.ABERRATION, self.player)
-            or (
-                state.has(item_names.MUTALISK, self.player)
-                and state.has_any({item_names.MUTALISK_SUNDERING_GLAIVE, item_names.MUTALISK_VICIOUS_GLAIVE, item_names.MUTALISK_SEVERING_GLAIVE}, self.player)
-            )
+            or state.has_any({item_names.ABERRATION, item_names.MUTALISK}, self.player)
             or self.advanced_tactics
             and (
                 state.has_all({item_names.ZERGLING_BANELING_ASPECT, item_names.BANELING_CORROSIVE_ACID}, self.player)

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -230,7 +230,6 @@ class SC2Logic:
             self.morph_impaler_or_lurker(state)
             or state.has_all({item_names.MUTALISK_SEVERING_GLAIVE, item_names.MUTALISK}, self.player)
             or state.has(item_names.ABERRATION, self.player)
-            or state.has(item_names.MALIGNANT_CREEP, self.player)
             or self.advanced_tactics
             and (
                 state.has_all({item_names.ZERGLING_BANELING_ASPECT, item_names.BANELING_CORROSIVE_ACID}, self.player)
@@ -247,7 +246,6 @@ class SC2Logic:
         return (
             state.has_any({item_names.ANNIHILATOR, item_names.INSTIGATOR, item_names.STALKER}, self.player)
             or state.has_all({item_names.SLAYER, item_names.SLAYER_PHASE_BLINK}, self.player)
-            or state.has(item_names.MATRIX_OVERLOAD, self.player)
             or self.advanced_tactics
             and  (
                 state.has_all({item_names.WRATHWALKER, item_names.WRATHWALKER_RAPID_POWER_CYCLING}, self.player)

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -256,7 +256,8 @@ class SC2Logic:
                         state.has_any({item_names.VOID_RAY, item_names.DAWNBRINGER}, self.player)
                         and state.has_all({item_names.DESTROYER, item_names.DESTROYER_REFORGED_BLOODSHARD_CORE}, self.player)
                     )
-            ) )
+                ) 
+            )
 
         )
 

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -204,7 +204,7 @@ class SC2Logic:
             state.has(item_names.BATTLECRUISER, self.player) and self.terran_common_unit(state)
         )
 
-    def great_train_robbery_train_stopper(self, state: CollectionState) -> bool:
+    def terran_great_train_robbery_train_stopper(self, state: CollectionState) -> bool:
         """
         Ability to deal with trains (moving target with a lot of HP)
         :param state:
@@ -218,6 +218,46 @@ class SC2Logic:
                 or state.has_all({item_names.SPECTRE, item_names.SPECTRE_PSIONIC_LASH}, self.player)
                 or state.has_any({item_names.VULTURE, item_names.LIBERATOR}, self.player)
             )
+        )
+    
+    def zerg_great_train_robbery_train_stopper(self, state: CollectionState) -> bool:
+        """
+        Ability to deal with trains (moving target with a lot of HP)
+        :param state:
+        :return:
+        """
+        return (
+            state.has_any({item_names.HYDRALISK_IMPALER_ASPECT, item_names.ABERRATION, item_names.MUTALISK}, self.player)
+            or state.has_all({item_names.HYDRALISK_LURKER_ASPECT, item_names.LURKER_SEISMIC_SPINES}, self.player)
+            or self.advanced_tactics
+            and (
+                state.has_all({item_names.ZERGLING_BANELING_ASPECT, item_names.BANELING_CORROSIVE_ACID}, self.player)
+                or state.has_all({item_names.ZERGLING, item_names.ZERGLING_METABOLIC_BOOST}, self.player)
+                or state.has_all({item_names.HYDRALISK, item_names.HYDRALISK_MUSCULAR_AUGMENTS}, self.player)
+                or state.has_all({item_names.ROACH, item_names.ROACH_GLIAL_RECONSTITUTION}, self.player)
+            )
+        )
+    
+    def protoss_great_train_robbery_train_stopper(self, state: CollectionState) -> bool:
+        """
+        Ability to deal with trains (moving target with a lot of HP)
+        :param state:
+        :return:
+        """
+        return (
+            state.has_any({item_names.ANNIHILATOR, item_names.INSTIGATOR, item_names.STALKER}, self.player)
+            or state.has_all({item_names.SLAYER, item_names.SLAYER_PHASE_BLINK}, self.player)
+            or self.advanced_tactics
+            and  (
+                state.has_all({item_names.WRATHWALKER, item_names.WRATHWALKER_RAPID_POWER_CYCLING}, self.player)
+                or state.has_all({item_names.VANGUARD, item_names.VANGUARD_RAPIDFIRE_CANNON, item_names.VANGUARD_FUSION_MORTARS}, self.player)
+                or state.has_all({item_names.DESTROYER, item_names.DESTROYER_REFORGED_BLOODSHARD_CORE, VOID_RAY_DESTROYER_WARP_RAY_DAWNBRINGER_FLUX_VANES}, self.player)
+                or (
+                    state.has(item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_BLINK, self.player)
+                    and state.has_any({item_names.DARK_TEMPLAR, item_names.BLOOD_HUNTER, item_names.AVENGER}, self.player)
+                ) 
+            )
+
         )
 
     def terran_can_rescue(self, state) -> bool:
@@ -759,7 +799,8 @@ class SC2Logic:
 
     def protoss_has_blink(self, state: CollectionState) -> bool:
         return (
-            state.has_any({item_names.STALKER, item_names.INSTIGATOR, item_names.SLAYER}, self.player)
+            state.has_any({item_names.STALKER, item_names.INSTIGATOR}, self.player)
+            or state.has_all({item_names.SLAYER, item_names.SLAYER_PHASE_BLINK}, self.player)
             or (
                 state.has(item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_BLINK, self.player)
                 and state.has_any({item_names.DARK_TEMPLAR, item_names.BLOOD_HUNTER, item_names.AVENGER}, self.player)


### PR DESCRIPTION
Added Raceswap locations for Cutthroat and The Great Train Robbery, both Zerg and Protoss editions.
Also added specific logic pretaining to The Great Train Robbery for Protoss and Zerg to be able to efficiently destroy the trains, both on normal logic and advanced tactics.
