### PR TITLE
Add Item entry rule to custom mission orders

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -11,7 +11,7 @@ from worlds.AutoWorld import WebWorld, World
 from . import item_names
 from .items import (
     StarcraftItem, filler_items, get_full_item_list, ProtossItemType,
-    get_basic_units, ItemData, upgrade_included_names, kerrigan_actives, kerrigan_passives,
+    ItemData, kerrigan_actives, kerrigan_passives,
     not_balanced_starting_units,
 )
 from . import items
@@ -23,7 +23,9 @@ from .options import (
     KerriganPresence, KerriganPrimalStatus, kerrigan_unit_available, StarterUnit, SpearOfAdunPresence,
     get_enabled_campaigns, SpearOfAdunAutonomouslyCastAbilityPresence, Starcraft2Options,
     GrantStoryTech, GenericUpgradeResearch, GenericUpgradeItems, RequiredTactics,
+    upgrade_included_names
 )
+from .rules import get_basic_units
 from . import settings
 from .pool_filter import filter_items
 from .mission_tables import (
@@ -45,6 +47,8 @@ class ItemFilterFlags(enum.IntFlag):
     Excluded = enum.auto()
     AllowedOrphan = enum.auto()
     """Used to flag items that shouldn't be filtered out with their parents"""
+    ForceProgression = enum.auto()
+    """Used to flag items that aren't classified as progression by default"""
 
     Unremovable = Locked|StartInventory|Plando
 
@@ -145,6 +149,7 @@ class SC2World(World):
         flag_user_excluded_item_sets(self, item_list)
         flag_war_council_items(self, item_list)
         flag_and_add_resource_locations(self, item_list)
+        flag_mission_order_required_items(self, item_list)
         pool: List[Item] = prune_item_pool(self, item_list)
         pad_item_pool_with_filler(self, len(self.location_cache) - len(self.locked_locations) - len(pool), pool)
 
@@ -156,7 +161,10 @@ class SC2World(World):
         if self.options.required_tactics == RequiredTactics.option_no_logic:
             # Forcing completed goal and minimal accessibility on no logic
             self.options.accessibility.value = Accessibility.option_minimal
-            self.multiworld.completion_condition[self.player] = lambda state: True
+            required_items = self.custom_mission_order.get_items_to_lock()
+            self.multiworld.completion_condition[self.player] = lambda state, required_items=required_items: all(
+                state.has(item, self.player, amount) for (item, amount) in required_items.items()
+            )
         else:
             self.multiworld.completion_condition[self.player] = self.custom_mission_order.get_completion_condition(self.player)
 
@@ -631,6 +639,17 @@ def flag_and_add_resource_locations(world: SC2World, item_list: List[FilterItem]
                 world.locked_locations.append(location.name)
 
 
+def flag_mission_order_required_items(world: SC2World, item_list: List[FilterItem]) -> None:
+    """Locks items that are required by item rules in the mission order and forces them to be progression."""
+    locks_required = world.custom_mission_order.get_items_to_lock()
+    locks_done = {item: 0 for item in locks_required}
+    for item in item_list:
+        if item.name in locks_required and locks_done[item.name] < locks_required[item.name]:
+            item.flags |= ItemFilterFlags.Locked
+            item.flags |= ItemFilterFlags.ForceProgression
+            locks_done[item.name] += 1
+
+
 def prune_item_pool(world: SC2World, item_list: List[FilterItem]) -> List[Item]:
     """Prunes the item pool size to be less than the number of available locations"""
 
@@ -650,6 +669,8 @@ def prune_item_pool(world: SC2World, item_list: List[FilterItem]) -> List[Item]:
     existing_items: List[Item] = []
     for item in item_list:
         ap_item = create_item_with_correct_settings(world.player, item.name)
+        if ItemFilterFlags.ForceProgression in item.flags:
+            ap_item.classification = ItemClassification.progression
         if ItemFilterFlags.StartInventory in item.flags:
             existing_items.append(ap_item)
         elif ItemFilterFlags.Locked in item.flags:

--- a/worlds/sc2/docs/en_Custom Mission Orders.md
+++ b/worlds/sc2/docs/en_Custom Mission Orders.md
@@ -262,7 +262,7 @@ entry_rules: []
 ```
 This defines access restrictions for parts of the mission order.
 
-There are three available rules:
+These are the available rules:
 ```yaml
 entry_rules:
   # Beat these things ("Beat rule")
@@ -270,10 +270,14 @@ entry_rules:
   # Beat X amount of missions from these things ("Count rule")
   - scope: []
     amount: -1
+  # Find these items ("Item rule")
+  - items: {}
   # Fulfill X amount of other conditions ("Subrule rule")
   - rules: []
     amount: -1
 ```
+Note that Item rules take both a name and amount for each item (see the example below). In general this rule treats items like the `locked_items` option, but as a notable difference all items required for Item rules are marked as progression. If multiple Item rules require the same item, the largest required amount will be locked, **not** the sum of all amounts.
+
 The Beat and Count rules both require a list of scopes. This list accepts addresses towards other parts of the mission order.
 
 The basic form of an address is `<Campaign>/<Layout>/<Mission>`, where `<Campaign>` and `<Layout>` are the definition names (not `display_names`!) of a campaign and a layout within that campaign, and `<Mission>` is the index of a mission slot in that layout. The indices of mission slots are determined by the layout's type.
@@ -296,6 +300,12 @@ Below are examples of the available entry rules:
     Some Missions:
       type: grid
       size: 9
+      entry_rules:
+        # Item rule:
+        # To access the Some Missions layout,
+        # you have to find or receive your Marine
+        - items:
+          Marine: 1
     
     Wings of Liberty:
       Mar Sara:

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -4,7 +4,6 @@ from BaseClasses import Item, ItemClassification, MultiWorld
 import typing
 import enum
 
-from .options import get_option_value, RequiredTactics, GenericUpgradeItems
 from .mission_tables import SC2Mission, SC2Race, SC2Campaign, campaign_mission_table
 from . import item_names
 from worlds.AutoWorld import World
@@ -1959,16 +1958,6 @@ not_balanced_starting_units = {
 }
 
 
-def get_basic_units(world: 'SC2World', race: SC2Race) -> typing.Set[str]:
-    logic_level = get_option_value(world, 'required_tactics')
-    if logic_level == RequiredTactics.option_no_logic:
-        return no_logic_basic_units[race]
-    elif logic_level == RequiredTactics.option_advanced:
-        return advanced_basic_units[race]
-    else:
-        return basic_units[race]
-
-
 # Items that can be placed before resources if not already in
 # General upgrades and Mercs
 second_pass_placeable_items: typing.Tuple[str, ...] = (
@@ -2282,50 +2271,6 @@ upgrade_bundles: Dict[str, List[str]] = {
             item_names.PROGRESSIVE_PROTOSS_AIR_WEAPON, item_names.PROGRESSIVE_PROTOSS_AIR_ARMOR,
             item_names.PROGRESSIVE_PROTOSS_SHIELDS
         ],
-}
-
-# Names of upgrades to be included for different options
-upgrade_included_names: Dict[GenericUpgradeItems, Set[str]] = {
-    GenericUpgradeItems.option_individual_items: {
-        item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON,
-        item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR,
-        item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON,
-        item_names.PROGRESSIVE_TERRAN_VEHICLE_ARMOR,
-        item_names.PROGRESSIVE_TERRAN_SHIP_WEAPON,
-        item_names.PROGRESSIVE_TERRAN_SHIP_ARMOR,
-        item_names.PROGRESSIVE_ZERG_MELEE_ATTACK,
-        item_names.PROGRESSIVE_ZERG_MISSILE_ATTACK,
-        item_names.PROGRESSIVE_ZERG_GROUND_CARAPACE,
-        item_names.PROGRESSIVE_ZERG_FLYER_ATTACK,
-        item_names.PROGRESSIVE_ZERG_FLYER_CARAPACE,
-        item_names.PROGRESSIVE_PROTOSS_GROUND_WEAPON,
-        item_names.PROGRESSIVE_PROTOSS_GROUND_ARMOR,
-        item_names.PROGRESSIVE_PROTOSS_SHIELDS,
-        item_names.PROGRESSIVE_PROTOSS_AIR_WEAPON,
-        item_names.PROGRESSIVE_PROTOSS_AIR_ARMOR,
-    },
-    GenericUpgradeItems.option_bundle_weapon_and_armor: {
-        item_names.PROGRESSIVE_TERRAN_WEAPON_UPGRADE,
-        item_names.PROGRESSIVE_TERRAN_ARMOR_UPGRADE,
-        item_names.PROGRESSIVE_ZERG_WEAPON_UPGRADE,
-        item_names.PROGRESSIVE_ZERG_ARMOR_UPGRADE,
-        item_names.PROGRESSIVE_PROTOSS_WEAPON_UPGRADE,
-        item_names.PROGRESSIVE_PROTOSS_ARMOR_UPGRADE,
-    },
-    GenericUpgradeItems.option_bundle_unit_class: {
-        item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE,
-        item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE,
-        item_names.PROGRESSIVE_TERRAN_SHIP_UPGRADE,
-        item_names.PROGRESSIVE_ZERG_GROUND_UPGRADE,
-        item_names.PROGRESSIVE_ZERG_FLYER_UPGRADE,
-        item_names.PROGRESSIVE_PROTOSS_GROUND_UPGRADE,
-        item_names.PROGRESSIVE_PROTOSS_AIR_UPGRADE,
-    },
-    GenericUpgradeItems.option_bundle_all: {
-        item_names.PROGRESSIVE_TERRAN_WEAPON_ARMOR_UPGRADE,
-        item_names.PROGRESSIVE_ZERG_WEAPON_ARMOR_UPGRADE,
-        item_names.PROGRESSIVE_PROTOSS_WEAPON_ARMOR_UPGRADE,
-    }
 }
 
 lookup_id_to_name: typing.Dict[int, str] = {data.code: item_name for item_name, data in get_full_item_list().items() if

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -9,6 +9,7 @@ from .mission_tables import SC2Campaign, SC2Mission, lookup_name_to_mission, Mis
     campaign_mission_table, SC2Race, MissionFlag
 from .mission_groups import mission_groups, MissionGroupNames
 from .mission_order.options import CustomMissionOrder
+from . import item_names
 
 if TYPE_CHECKING:
     from worlds.AutoWorld import World
@@ -1151,3 +1152,47 @@ LEGACY_GRID_ORDERS = {3, 4, 8}  # Medium Grid, Mini Grid, and Tiny Grid respecti
 kerrigan_unit_available = [
     KerriganPresence.option_vanilla,
 ]
+
+# Names of upgrades to be included for different options
+upgrade_included_names: Dict[GenericUpgradeItems, Set[str]] = {
+    GenericUpgradeItems.option_individual_items: {
+        item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON,
+        item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR,
+        item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON,
+        item_names.PROGRESSIVE_TERRAN_VEHICLE_ARMOR,
+        item_names.PROGRESSIVE_TERRAN_SHIP_WEAPON,
+        item_names.PROGRESSIVE_TERRAN_SHIP_ARMOR,
+        item_names.PROGRESSIVE_ZERG_MELEE_ATTACK,
+        item_names.PROGRESSIVE_ZERG_MISSILE_ATTACK,
+        item_names.PROGRESSIVE_ZERG_GROUND_CARAPACE,
+        item_names.PROGRESSIVE_ZERG_FLYER_ATTACK,
+        item_names.PROGRESSIVE_ZERG_FLYER_CARAPACE,
+        item_names.PROGRESSIVE_PROTOSS_GROUND_WEAPON,
+        item_names.PROGRESSIVE_PROTOSS_GROUND_ARMOR,
+        item_names.PROGRESSIVE_PROTOSS_SHIELDS,
+        item_names.PROGRESSIVE_PROTOSS_AIR_WEAPON,
+        item_names.PROGRESSIVE_PROTOSS_AIR_ARMOR,
+    },
+    GenericUpgradeItems.option_bundle_weapon_and_armor: {
+        item_names.PROGRESSIVE_TERRAN_WEAPON_UPGRADE,
+        item_names.PROGRESSIVE_TERRAN_ARMOR_UPGRADE,
+        item_names.PROGRESSIVE_ZERG_WEAPON_UPGRADE,
+        item_names.PROGRESSIVE_ZERG_ARMOR_UPGRADE,
+        item_names.PROGRESSIVE_PROTOSS_WEAPON_UPGRADE,
+        item_names.PROGRESSIVE_PROTOSS_ARMOR_UPGRADE,
+    },
+    GenericUpgradeItems.option_bundle_unit_class: {
+        item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE,
+        item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE,
+        item_names.PROGRESSIVE_TERRAN_SHIP_UPGRADE,
+        item_names.PROGRESSIVE_ZERG_GROUND_UPGRADE,
+        item_names.PROGRESSIVE_ZERG_FLYER_UPGRADE,
+        item_names.PROGRESSIVE_PROTOSS_GROUND_UPGRADE,
+        item_names.PROGRESSIVE_PROTOSS_AIR_UPGRADE,
+    },
+    GenericUpgradeItems.option_bundle_all: {
+        item_names.PROGRESSIVE_TERRAN_WEAPON_ARMOR_UPGRADE,
+        item_names.PROGRESSIVE_ZERG_WEAPON_ARMOR_UPGRADE,
+        item_names.PROGRESSIVE_PROTOSS_WEAPON_ARMOR_UPGRADE,
+    }
+}

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -245,16 +245,12 @@ class ValidInventory:
         if not {item_names.MEDIVAC, item_names.HERCULES} & logical_inventory_set:
             inventory = [item for item in inventory if item.name != item_names.SIEGE_TANK_PROGRESSIVE_TRANSPORT_HOOK]
             unused_items = [item_name for item_name in unused_items if item_name != item_names.SIEGE_TANK_PROGRESSIVE_TRANSPORT_HOOK]
-            locked_items = [item for item in locked_items if item.name != item_names.SIEGE_TANK_PROGRESSIVE_TRANSPORT_HOOK]
         if item_names.MEDIVAC not in logical_inventory_set:
             # Don't allow L2 Siege Tank Transport Hook without Medivac
             inventory_transport_hooks = [item for item in inventory if item.name == item_names.SIEGE_TANK_PROGRESSIVE_TRANSPORT_HOOK]
             locked_transport_hooks = [item for item in locked_items if item.name == item_names.SIEGE_TANK_PROGRESSIVE_TRANSPORT_HOOK]
-            if len(inventory_transport_hooks) + len(locked_transport_hooks) > 1:
-                if len(inventory_transport_hooks) > 1:
-                    inventory.remove(inventory_transport_hooks[0])
-                else:
-                    locked_items.remove(locked_transport_hooks[0])
+            if len(inventory_transport_hooks) > 1:
+                inventory.remove(inventory_transport_hooks[0])
             if len(inventory_transport_hooks) + len(locked_transport_hooks) > 0:
                 # Transport Hook is in inventory, remove from unused_items
                 unused_items = [item_name for item_name in unused_items if item_name != item_names.SIEGE_TANK_PROGRESSIVE_TRANSPORT_HOOK]
@@ -267,7 +263,6 @@ class ValidInventory:
             # No orbital Command Spells
             inventory = [item for item in inventory if item.name != item_names.PLANETARY_FORTRESS_ORBITAL_MODULE]
             unused_items = [item_name for item_name in unused_items if item_name !=item_names.PLANETARY_FORTRESS_ORBITAL_MODULE]
-            locked_items = [item for item in locked_items if item.name != item_names.PLANETARY_FORTRESS_ORBITAL_MODULE]
 
         # HotS
         # Baneling without sources => remove Baneling and upgrades
@@ -292,7 +287,6 @@ class ValidInventory:
             unused_items = [item_name for item_name in unused_items if item_name != item_names.BANELING_RAPID_METAMORPH]
         if not {item_names.MUTALISK, item_names.CORRUPTOR, item_names.SCOURGE} & logical_inventory_set:
             inventory = [item for item in inventory if not item.name.startswith(item_names.ZERG_FLYER_UPGRADE_PREFIX)]
-            locked_items = [item for item in locked_items if not item.name.startswith(item_names.ZERG_FLYER_UPGRADE_PREFIX)]
             unused_items = [item_name for item_name in unused_items if not item_name.startswith(item_names.ZERG_FLYER_UPGRADE_PREFIX)]
         # T3 items removal rules - remove morph and its upgrades if the basic unit isn't in and morphling is unavailable
         if not {item_names.MUTALISK, item_names.CORRUPTOR} & logical_inventory_set and not enable_morphling:

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Set
 
 from BaseClasses import  CollectionState
 from .options import (
@@ -7,9 +7,9 @@ from .options import (
     get_enabled_campaigns, MissionOrder, EnableMorphling, get_enabled_races
 )
 from .items import (
-    get_basic_units, tvx_defense_ratings, tvz_defense_ratings, kerrigan_actives, tvx_air_defense_ratings,
+    tvx_defense_ratings, tvz_defense_ratings, kerrigan_actives, tvx_air_defense_ratings,
     kerrigan_levels, get_full_item_list, zvx_air_defense_ratings, zvx_defense_ratings, pvx_defense_ratings,
-    pvz_defense_ratings
+    pvz_defense_ratings, no_logic_basic_units, advanced_basic_units, basic_units
 )
 from .mission_tables import SC2Race, SC2Campaign
 from . import item_names
@@ -1349,3 +1349,12 @@ class SC2Logic:
         self.spear_of_adun_autonomously_cast_presence = get_option_value(world, "spear_of_adun_autonomously_cast_ability_presence")
         self.enabled_campaigns = get_enabled_campaigns(world)
         self.mission_order = get_option_value(world, "mission_order")
+
+def get_basic_units(world: 'SC2World', race: SC2Race) -> Set[str]:
+    logic_level = get_option_value(world, 'required_tactics')
+    if logic_level == RequiredTactics.option_no_logic:
+        return no_logic_basic_units[race]
+    elif logic_level == RequiredTactics.option_advanced:
+        return advanced_basic_units[race]
+    else:
+        return basic_units[race]

--- a/worlds/sc2/test/test_custom_mission_orders.py
+++ b/worlds/sc2/test/test_custom_mission_orders.py
@@ -5,6 +5,7 @@ Unit tests for custom mission orders
 from .test_base import Sc2SetupTestBase
 from .. import MissionFlag
 from .. import item_names
+from .. import items
 from BaseClasses import ItemClassification
 
 class TestCustomMissionOrders(Sc2SetupTestBase):
@@ -125,6 +126,8 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
          }
       }
 
+      self.assertNotEqual(items.item_table[test_item].classification, ItemClassification.progression, f"Test item {test_item} won't change classification")
+
       self.generate_world(world_options)
       test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
       self.assertEqual(len(test_items_in_pool), 1)
@@ -156,8 +159,6 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
       self.assertEqual(len(test_items_in_pool), 0)
       test_items_in_start_inventory = [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
       self.assertEqual(len(test_items_in_start_inventory), 1)
-      # Start inventory gets a new item so the classification is no longer progression
-      self.assertEqual(test_items_in_start_inventory[0].classification, ItemClassification.filler)
 
    def test_start_inventory_and_locked_and_necessary_item_appears_once(self):
       # This is a filler upgrade with a parent
@@ -186,5 +187,3 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
       self.assertEqual(len(test_items_in_pool), 0)
       test_items_in_start_inventory = [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
       self.assertEqual(len(test_items_in_start_inventory), 1)
-      # Start inventory gets a new item so the classification is no longer progression
-      self.assertEqual(test_items_in_start_inventory[0].classification, ItemClassification.filler)

--- a/worlds/sc2/test/test_custom_mission_orders.py
+++ b/worlds/sc2/test/test_custom_mission_orders.py
@@ -5,7 +5,7 @@ Unit tests for custom mission orders
 from .test_base import Sc2SetupTestBase
 from .. import MissionFlag
 from .. import item_names
-from ....BaseClasses import ItemClassification
+from BaseClasses import ItemClassification
 
 class TestCustomMissionOrders(Sc2SetupTestBase):
    

--- a/worlds/sc2/test/test_custom_mission_orders.py
+++ b/worlds/sc2/test/test_custom_mission_orders.py
@@ -4,9 +4,11 @@ Unit tests for custom mission orders
 
 from .test_base import Sc2SetupTestBase
 from .. import MissionFlag
+from .. import item_names
+from ....BaseClasses import ItemClassification
 
 class TestCustomMissionOrders(Sc2SetupTestBase):
-    
+   
    def test_mini_wol_generates(self):
       world_options = {
          'mission_order': 'custom',
@@ -101,3 +103,86 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
       self.assertEqual(flags.get(MissionFlag.Zerg, 0), 0)
       sc2_regions = set(self.multiworld.regions.region_cache[self.player]) - {"Menu"}
       self.assertEqual(len(self.world.custom_mission_order.get_used_missions()), len(sc2_regions))
+
+   def test_locked_and_necessary_item_appears_once(self):
+      # This is a filler upgrade with a parent
+      test_item = item_names.ZERGLING_METABOLIC_BOOST
+      world_options = {
+         'mission_order': 'custom',
+         'locked_items': { test_item: 1 },
+         'custom_mission_order': {
+            'test': {
+               'type': 'column',
+               'size': 5, # Give the generator some space to place the key
+               'max_difficulty': 'easy',
+               'missions': [{
+                  'index': 4,
+                  'entry_rules': [{
+                     'items': { test_item: 1 }
+                  }]
+               }]
+            }
+         }
+      }
+
+      self.generate_world(world_options)
+      test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
+      self.assertEqual(len(test_items_in_pool), 1)
+      self.assertEqual(test_items_in_pool[0].classification == ItemClassification.progression)
+
+   def test_start_inventory_and_necessary_item_appears_once(self):
+      # This is a filler upgrade with a parent
+      test_item = item_names.ZERGLING_METABOLIC_BOOST
+      world_options = {
+         'mission_order': 'custom',
+         'start_inventory': { test_item: 1 },
+         'custom_mission_order': {
+            'test': {
+               'type': 'column',
+               'size': 5, # Give the generator some space to place the key
+               'max_difficulty': 'easy',
+               'missions': [{
+                  'index': 4,
+                  'entry_rules': [{
+                     'items': { test_item: 1 }
+                  }]
+               }]
+            }
+         }
+      }
+
+      self.generate_world(world_options)
+      test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
+      self.assertEqual(len(test_items_in_pool), 0)
+      test_items_in_start_inventory = [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
+      self.assertEqual(len(test_items_in_start_inventory), 1)
+      self.assertEqual(test_items_in_start_inventory[0].classification == ItemClassification.progression)
+
+   def test_start_inventory_and_locked_and_necessary_item_appears_once(self):
+      # This is a filler upgrade with a parent
+      test_item = item_names.ZERGLING_METABOLIC_BOOST
+      world_options = {
+         'mission_order': 'custom',
+         'start_inventory': { test_item: 1 },
+         'locked_items': { test_item: 1 },
+         'custom_mission_order': {
+            'test': {
+               'type': 'column',
+               'size': 5, # Give the generator some space to place the key
+               'max_difficulty': 'easy',
+               'missions': [{
+                  'index': 4,
+                  'entry_rules': [{
+                     'items': { test_item: 1 }
+                  }]
+               }]
+            }
+         }
+      }
+
+      self.generate_world(world_options)
+      test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
+      self.assertEqual(len(test_items_in_pool), 0)
+      test_items_in_start_inventory = [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
+      self.assertEqual(len(test_items_in_start_inventory), 1)
+      self.assertEqual(test_items_in_start_inventory[0].classification == ItemClassification.progression)

--- a/worlds/sc2/test/test_custom_mission_orders.py
+++ b/worlds/sc2/test/test_custom_mission_orders.py
@@ -156,7 +156,8 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
       self.assertEqual(len(test_items_in_pool), 0)
       test_items_in_start_inventory = [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
       self.assertEqual(len(test_items_in_start_inventory), 1)
-      self.assertEqual(test_items_in_start_inventory[0].classification, ItemClassification.progression)
+      # Start inventory gets a new item so the classification is no longer progression
+      self.assertEqual(test_items_in_start_inventory[0].classification, ItemClassification.filler)
 
    def test_start_inventory_and_locked_and_necessary_item_appears_once(self):
       # This is a filler upgrade with a parent
@@ -185,4 +186,5 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
       self.assertEqual(len(test_items_in_pool), 0)
       test_items_in_start_inventory = [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
       self.assertEqual(len(test_items_in_start_inventory), 1)
-      self.assertEqual(test_items_in_start_inventory[0].classification, ItemClassification.progression)
+      # Start inventory gets a new item so the classification is no longer progression
+      self.assertEqual(test_items_in_start_inventory[0].classification, ItemClassification.filler)

--- a/worlds/sc2/test/test_custom_mission_orders.py
+++ b/worlds/sc2/test/test_custom_mission_orders.py
@@ -128,7 +128,7 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
       self.generate_world(world_options)
       test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
       self.assertEqual(len(test_items_in_pool), 1)
-      self.assertEqual(test_items_in_pool[0].classification == ItemClassification.progression)
+      self.assertEqual(test_items_in_pool[0].classification, ItemClassification.progression)
 
    def test_start_inventory_and_necessary_item_appears_once(self):
       # This is a filler upgrade with a parent
@@ -156,7 +156,7 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
       self.assertEqual(len(test_items_in_pool), 0)
       test_items_in_start_inventory = [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
       self.assertEqual(len(test_items_in_start_inventory), 1)
-      self.assertEqual(test_items_in_start_inventory[0].classification == ItemClassification.progression)
+      self.assertEqual(test_items_in_start_inventory[0].classification, ItemClassification.progression)
 
    def test_start_inventory_and_locked_and_necessary_item_appears_once(self):
       # This is a filler upgrade with a parent
@@ -185,4 +185,4 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
       self.assertEqual(len(test_items_in_pool), 0)
       test_items_in_start_inventory = [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
       self.assertEqual(len(test_items_in_start_inventory), 1)
-      self.assertEqual(test_items_in_start_inventory[0].classification == ItemClassification.progression)
+      self.assertEqual(test_items_in_start_inventory[0].classification, ItemClassification.progression)


### PR DESCRIPTION
## What is this fixing or adding?
This adds a rule to custom mission orders to require certain items. The required items are locked and forcibly marked as progression so the generator will always try to place them.

This also makes a handful of supporting changes:
- `items.py` has received a minor refactor to remove the `options` import as it was causing a circular import. The affected bits of code have been moved to `rules.py` and `options.py`.
- The goal condition for No Logic has been updated to require all items from item rules so that Archipelago will place them correctly.
- `ItemFilterFlags` has received a `ForceProgression` flag that sets an item's classification to progression and a `Necessary` flag to mark items that can never be culled.

## How was this tested?
Lots of generations, and by sending locations in the client.

## If this makes graphical changes, please attach screenshots.
Single required item:
![python_SZLZPhgG53](https://github.com/user-attachments/assets/b119840f-b7d6-4320-a83b-6b088c4a787a)

Multiple required items:
![python_ZWsq0Vqf2d](https://github.com/user-attachments/assets/b398ee52-b894-44d9-8fa7-87b18b31d110)

Non-progression item lifted to progression to satisfy an item rule:
![python_J5GtVXnLq2](https://github.com/user-attachments/assets/e1f2a536-ab17-49da-885c-3a39b6fdfe72)
