### PR TITLE
sc2: Fixed client startup size; removed client remembering maximize state

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -806,10 +806,8 @@ class SC2Context(CommonContext):
         super(SC2Context, self).on_print_json(args)
 
     def run_gui(self) -> None:
-        from .gui_config import apply_window_defaults
-        warnings = apply_window_defaults()
         from .client_gui import start_gui
-        start_gui(self, warnings)
+        start_gui(self)
 
     async def shutdown(self) -> None:
         await super(SC2Context, self).shutdown()

--- a/worlds/sc2/gui_config.py
+++ b/worlds/sc2/gui_config.py
@@ -4,23 +4,12 @@ Import this before importing client_gui.py to set window defaults from world set
 from .settings import Starcraft2Settings
 from typing import List
 
-def apply_window_defaults() -> List[str]:
+def get_window_defaults() -> List[str]:
     """
-    Set the kivy config keys from the sc2world user settings.
-    Returns a list of warnings to be printed once the GUI is started.
+    Gets the window size options from the sc2 settings.
+    Returns a list of warnings to be printed once the GUI is started, followed by the window width and height
     """
     from . import SC2World
-    # This is necessary to prevent kivy from failing because it got invalid command-line args,
-    # or from spamming the logs.
-    # Must happen before importing kivy.config
-    import os
-    import Utils
-    os.environ["KIVY_NO_CONSOLELOG"] = "1"
-    os.environ["KIVY_NO_FILELOG"] = "1"
-    os.environ["KIVY_NO_ARGS"] = "1"
-    os.environ["KIVY_LOG_ENABLE"] = "0"
-    if Utils.is_frozen():
-        os.environ["KIVY_DATA_DIR"] = Utils.local_path("data")
 
     # validate settings
     warnings: List[str] = []
@@ -35,9 +24,4 @@ def apply_window_defaults() -> List[str]:
         warnings.append(f"Invalid value for options.yaml key sc2_options.window_width: '{SC2World.settings.window_width}'. Expected a positive integer.")
         window_width = Starcraft2Settings.window_width
 
-    # from kivy.config import Config
-    # Config.set('graphics', 'width', str(window_width))
-    # Config.set('graphics', 'height', str(window_height))
-    # if SC2World.settings.window_maximized:
-    #     Config.set('graphics', 'window_state', 'maximized')
-    return warnings
+    return warnings, window_width, window_height

--- a/worlds/sc2/settings.py
+++ b/worlds/sc2/settings.py
@@ -7,12 +7,9 @@ class Starcraft2Settings(settings.Group):
         """The starting width the client window in pixels"""
     class WindowHeight(int):
         """The starting height the client window in pixels"""
-    class StartMaximized(settings.Bool):
-        """Controls whether the client window should start maximized"""
     class GameWindowedMode(settings.Bool):
         """Controls whether the game should start in windowed mode"""
 
     window_width = WindowWidth(1080)
     window_height = WindowHeight(720)
-    window_maximized: Union[StartMaximized, bool] = False
     game_windowed_mode: Union[GameWindowedMode, bool] = False


### PR DESCRIPTION
## What is this fixing or adding?
Broken client resizing after merging stuff in from main. Big thanks to Berserker in the core-dev chat for helping me get a handle on how kivy wants you adjusting these parameters.

Getting the client to start with the right maximize state was being too much of a hassle so I dropped that part.

## How was this tested?
Set the window_height and window_width parameters in options.yaml a few different times, and verified the window started with roughly the correct size and aspect. Verified that a warning message was displayed if an invalid value was input for the setting (and that dimension fell back to default).

## If this makes graphical changes, please attach screenshots.
None