### PR TITLE
SC2: Adding Shatter the Sky and All-In raceswaps

### DIFF
--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1139,7 +1139,7 @@ item_table = {
                  classification=ItemClassification.useful, origin={"ext"}),
     item_names.INFESTED_BANSHEE:
         ItemData(22 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 21, SC2Race.ZERG,
-                 classification=ItemClassification.useful, origin={"ext"}),
+                 classification=ItemClassification.progression, origin={"ext"}),
     item_names.INFESTED_LIBERATOR:
         ItemData(23 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 22, SC2Race.ZERG,
                  classification=ItemClassification.useful, origin={"ext"}),
@@ -1275,7 +1275,7 @@ item_table = {
                  origin={"ext"}),
     item_names.SWARM_HOST_RESOURCE_EFFICIENCY:
         ItemData(239 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 9, SC2Race.ZERG, parent_item=item_names.SWARM_HOST,
-                 origin={"ext"}),
+                 origin={"ext"}, classification=ItemClassification.progression),
     item_names.ULTRALISK_ANABOLIC_SYNTHESIS:
         ItemData(240 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 10, SC2Race.ZERG, parent_item=item_names.ULTRALISK,
                  origin={"bw"}, classification=ItemClassification.filler),
@@ -1579,7 +1579,7 @@ item_table = {
     # Zerg Mercs
     item_names.INFESTED_MEDICS: ItemData(600 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 0, SC2Race.ZERG, origin={"ext"}),
     item_names.INFESTED_SIEGE_BREAKERS: ItemData(601 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 1, SC2Race.ZERG, origin={"ext"}, classification=ItemClassification.progression),
-    item_names.INFESTED_DUSK_WINGS: ItemData(602 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 2, SC2Race.ZERG, origin={"ext"}),
+    item_names.INFESTED_DUSK_WINGS: ItemData(602 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 2, SC2Race.ZERG, origin={"ext"}, classification=ItemClassification.progression),
     item_names.DEVOURING_ONES: ItemData(603 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 3, SC2Race.ZERG, origin={"ext"}),
     item_names.HUNTER_KILLERS: ItemData(604 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 4, SC2Race.ZERG, origin={"ext"}),
     item_names.TORRASQUE_MERC: ItemData(605 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 5, SC2Race.ZERG, origin={"ext"}),

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -3011,6 +3011,96 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and logic.protoss_repair_odin(state))
         ),
         make_location_data(SC2Mission.MEDIA_BLITZ_P.mission_name, "Surprise Attack Ends", SC2_RACESWAP_LOC_ID_OFFSET + 4009, LocationType.EXTRA),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 5500, LocationType.VICTORY,
+            logic.zerg_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_Z.mission_name, "Close Coolant Tower", SC2_RACESWAP_LOC_ID_OFFSET + 5501, LocationType.VANILLA,
+            logic.zerg_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_Z.mission_name, "Northwest Coolant Tower", SC2_RACESWAP_LOC_ID_OFFSET + 5502, LocationType.VANILLA,
+            logic.zerg_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_Z.mission_name, "Southeast Coolant Tower", SC2_RACESWAP_LOC_ID_OFFSET + 5503, LocationType.VANILLA,
+            logic.zerg_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_Z.mission_name, "Southwest Coolant Tower", SC2_RACESWAP_LOC_ID_OFFSET + 5504, LocationType.VANILLA,
+            logic.zerg_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_Z.mission_name, "Leviathan", SC2_RACESWAP_LOC_ID_OFFSET + 5505, LocationType.VANILLA,
+            logic.zerg_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_Z.mission_name, "East Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 5506, LocationType.EXTRA,
+            logic.zerg_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_Z.mission_name, "North Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 5507, LocationType.EXTRA,
+            logic.zerg_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_Z.mission_name, "Mid Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 5508, LocationType.EXTRA,
+            logic.zerg_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 5600, LocationType.VICTORY,
+            logic.protoss_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_P.mission_name, "Close Coolant Tower", SC2_RACESWAP_LOC_ID_OFFSET + 5601, LocationType.VANILLA,
+            logic.protoss_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_P.mission_name, "Northwest Coolant Tower", SC2_RACESWAP_LOC_ID_OFFSET + 5602, LocationType.VANILLA,
+            logic.protoss_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_P.mission_name, "Southeast Coolant Tower", SC2_RACESWAP_LOC_ID_OFFSET + 5603, LocationType.VANILLA,
+            logic.protoss_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_P.mission_name, "Southwest Coolant Tower", SC2_RACESWAP_LOC_ID_OFFSET + 5604, LocationType.VANILLA,
+            logic.protoss_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_P.mission_name, "Leviathan", SC2_RACESWAP_LOC_ID_OFFSET + 5605, LocationType.VANILLA,
+            logic.protoss_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_P.mission_name, "East Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 5606, LocationType.EXTRA,
+            logic.protoss_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_P.mission_name, "North Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 5607, LocationType.EXTRA,
+            logic.protoss_competent_comp
+        ),
+        make_location_data(SC2Mission.SHATTER_THE_SKY_P.mission_name, "Mid Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 5608, LocationType.EXTRA,
+            logic.protoss_competent_comp
+        ),
+        make_location_data(SC2Mission.ALL_IN_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 5700, LocationType.VICTORY,
+            logic.all_in_z_requirement
+        ),
+        make_location_data(SC2Mission.ALL_IN_Z.mission_name, "First Kerrigan Attack", SC2_RACESWAP_LOC_ID_OFFSET + 5701, LocationType.EXTRA,
+            logic.all_in_z_requirement
+        ),
+        make_location_data(SC2Mission.ALL_IN_Z.mission_name, "Second Kerrigan Attack", SC2_RACESWAP_LOC_ID_OFFSET + 5702, LocationType.EXTRA,
+            logic.all_in_z_requirement
+        ),
+        make_location_data(SC2Mission.ALL_IN_Z.mission_name, "Third Kerrigan Attack", SC2_RACESWAP_LOC_ID_OFFSET + 5703, LocationType.EXTRA,
+            logic.all_in_z_requirement
+        ),
+        make_location_data(SC2Mission.ALL_IN_Z.mission_name, "Fourth Kerrigan Attack", SC2_RACESWAP_LOC_ID_OFFSET + 5704, LocationType.EXTRA,
+            logic.all_in_z_requirement
+        ),
+        make_location_data(SC2Mission.ALL_IN_Z.mission_name, "Fifth Kerrigan Attack", SC2_RACESWAP_LOC_ID_OFFSET + 5705, LocationType.EXTRA,
+            logic.all_in_z_requirement
+        ),
+        make_location_data(SC2Mission.ALL_IN_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 5800, LocationType.VICTORY,
+            logic.all_in_p_requirement
+        ),
+        make_location_data(SC2Mission.ALL_IN_P.mission_name, "First Kerrigan Attack", SC2_RACESWAP_LOC_ID_OFFSET + 5801, LocationType.EXTRA,
+            logic.all_in_p_requirement
+        ),
+        make_location_data(SC2Mission.ALL_IN_P.mission_name, "Second Kerrigan Attack", SC2_RACESWAP_LOC_ID_OFFSET + 5802, LocationType.EXTRA,
+            logic.all_in_p_requirement
+        ),
+        make_location_data(SC2Mission.ALL_IN_P.mission_name, "Third Kerrigan Attack", SC2_RACESWAP_LOC_ID_OFFSET + 5803, LocationType.EXTRA,
+            logic.all_in_p_requirement
+        ),
+        make_location_data(SC2Mission.ALL_IN_P.mission_name, "Fourth Kerrigan Attack", SC2_RACESWAP_LOC_ID_OFFSET + 5804, LocationType.EXTRA,
+            logic.all_in_p_requirement
+        ),
+        make_location_data(SC2Mission.ALL_IN_P.mission_name, "Fifth Kerrigan Attack", SC2_RACESWAP_LOC_ID_OFFSET + 5805, LocationType.EXTRA,
+            logic.all_in_p_requirement
+        ),
     ]
 
     beat_events = []

--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -123,8 +123,8 @@ class SC2Mission(Enum):
     PIERCING_OF_THE_SHROUD = 21, "Piercing the Shroud", SC2Campaign.WOL, "Rebellion", SC2Race.TERRAN, MissionPools.STARTER, "ap_piercing_the_shroud", MissionFlag.Terran|MissionFlag.NoBuild|MissionFlag.VsAll
     GATES_OF_HELL = 26, "Gates of Hell", SC2Campaign.WOL, "Char", SC2Race.TERRAN, MissionPools.HARD, "ap_gates_of_hell", MissionFlag.Terran|MissionFlag.VsZerg
     BELLY_OF_THE_BEAST = 27, "Belly of the Beast", SC2Campaign.WOL, "Char", SC2Race.ANY, MissionPools.STARTER, "ap_belly_of_the_beast", MissionFlag.Terran|MissionFlag.NoBuild|MissionFlag.VsZerg
-    SHATTER_THE_SKY = 28, "Shatter the Sky", SC2Campaign.WOL, "Char", SC2Race.TERRAN, MissionPools.HARD, "ap_shatter_the_sky", MissionFlag.Terran|MissionFlag.VsZerg
-    ALL_IN = 29, "All-In", SC2Campaign.WOL, "Char", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_all_in", MissionFlag.Terran|MissionFlag.TimedDefense|MissionFlag.VsZerg
+    SHATTER_THE_SKY = 28, "Shatter the Sky (Terran)", SC2Campaign.WOL, "Char", SC2Race.TERRAN, MissionPools.HARD, "ap_shatter_the_sky", MissionFlag.Terran|MissionFlag.VsZerg|MissionFlag.HasRaceSwap
+    ALL_IN = 29, "All-In (Terran)", SC2Campaign.WOL, "Char", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_all_in", MissionFlag.Terran|MissionFlag.TimedDefense|MissionFlag.VsZerg|MissionFlag.HasRaceSwap
 
     # Prophecy
     WHISPERS_OF_DOOM = 22, "Whispers of Doom", SC2Campaign.PROPHECY, "_1", SC2Race.ANY, MissionPools.STARTER, "ap_whispers_of_doom", MissionFlag.Protoss|MissionFlag.NoBuild|MissionFlag.VsZerg
@@ -235,8 +235,10 @@ class SC2Mission(Enum):
     # 132/133 - In Utter Darkness
     # 134/135 - Gates of Hell
     # 136/137 - Belly of the Beast
-    # 138/139 - Shatter the Sky
-    # 140/141 - All In
+    SHATTER_THE_SKY_Z = 138, "Shatter the Sky (Zerg)", SC2Campaign.WOL, "Char", SC2Race.ZERG, MissionPools.HARD, "ap_shatter_the_sky", MissionFlag.Zerg|MissionFlag.VsZerg|MissionFlag.RaceSwap
+    SHATTER_THE_SKY_P = 139, "Shatter the Sky (Protoss)", SC2Campaign.WOL, "Char", SC2Race.PROTOSS, MissionPools.HARD, "ap_shatter_the_sky", MissionFlag.Protoss|MissionFlag.VsZerg|MissionFlag.RaceSwap
+    ALL_IN_Z = 140, "All-In (Zerg)", SC2Campaign.WOL, "Char", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_all_in", MissionFlag.Zerg|MissionFlag.TimedDefense|MissionFlag.VsZerg|MissionFlag.RaceSwap
+    ALL_IN_P = 141, "All-In (Protoss)", SC2Campaign.WOL, "Char", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_all_in", MissionFlag.Protoss|MissionFlag.TimedDefense|MissionFlag.VsZerg|MissionFlag.RaceSwap
     # 142/143 - Lab Rat
     # 144/145 - Back in the Saddle
     # 146/147 - Rendezvous

--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -358,49 +358,49 @@ class SC2CampaignGoal(NamedTuple):
 
 
 campaign_final_mission_locations: Dict[SC2Campaign, Optional[SC2CampaignGoal]] = {
-    SC2Campaign.WOL: SC2CampaignGoal(SC2Mission.ALL_IN, "All-In: Victory"),
-    SC2Campaign.PROPHECY: SC2CampaignGoal(SC2Mission.IN_UTTER_DARKNESS, "In Utter Darkness: Kills"),
+    SC2Campaign.WOL: SC2CampaignGoal(SC2Mission.ALL_IN, f'{SC2Mission.ALL_IN.mission_name}: Victory'),
+    SC2Campaign.PROPHECY: SC2CampaignGoal(SC2Mission.IN_UTTER_DARKNESS, f'{SC2Mission.IN_UTTER_DARKNESS.mission_name}: Kills'),
     SC2Campaign.HOTS: None,
-    SC2Campaign.PROLOGUE: SC2CampaignGoal(SC2Mission.EVIL_AWOKEN, "Evil Awoken: Victory"),
-    SC2Campaign.LOTV: SC2CampaignGoal(SC2Mission.SALVATION, "Salvation: Victory"),
+    SC2Campaign.PROLOGUE: SC2CampaignGoal(SC2Mission.EVIL_AWOKEN, f'{SC2Mission.EVIL_AWOKEN.mission_name}: Victory'),
+    SC2Campaign.LOTV: SC2CampaignGoal(SC2Mission.SALVATION, f'{SC2Mission.SALVATION.mission_name}: Victory'),
     SC2Campaign.EPILOGUE: None,
-    SC2Campaign.NCO: SC2CampaignGoal(SC2Mission.END_GAME, "End Game: Victory"),
+    SC2Campaign.NCO: SC2CampaignGoal(SC2Mission.END_GAME, f'{SC2Mission.END_GAME.mission_name}: Victory'),
 }
 
 campaign_alt_final_mission_locations: Dict[SC2Campaign, Dict[SC2Mission, str]] = {
     SC2Campaign.WOL: {
-        SC2Mission.MAW_OF_THE_VOID: "Maw of the Void: Victory",
-        SC2Mission.ENGINE_OF_DESTRUCTION: "Engine of Destruction: Victory",
-        SC2Mission.SUPERNOVA: "Supernova: Victory",
-        SC2Mission.GATES_OF_HELL: "Gates of Hell: Victory",
-        SC2Mission.SHATTER_THE_SKY: "Shatter the Sky: Victory"
+        SC2Mission.MAW_OF_THE_VOID: f'{SC2Mission.MAW_OF_THE_VOID.mission_name}: Victory',
+        SC2Mission.ENGINE_OF_DESTRUCTION: f'{SC2Mission.ENGINE_OF_DESTRUCTION.mission_name}: Victory',
+        SC2Mission.SUPERNOVA: f'{SC2Mission.SUPERNOVA.mission_name}: Victory',
+        SC2Mission.GATES_OF_HELL: f'{SC2Mission.GATES_OF_HELL.mission_name}: Victory',
+        SC2Mission.SHATTER_THE_SKY: f'{SC2Mission.SHATTER_THE_SKY.mission_name}: Victory'
     },
     SC2Campaign.PROPHECY: None,
     SC2Campaign.HOTS: {
-        SC2Mission.THE_RECKONING: "The Reckoning: Victory",
-        SC2Mission.THE_CRUCIBLE: "The Crucible: Victory",
-        SC2Mission.HAND_OF_DARKNESS: "Hand of Darkness: Victory",
-        SC2Mission.PHANTOMS_OF_THE_VOID: "Phantoms of the Void: Victory",
-        SC2Mission.PLANETFALL: "Planetfall: Victory",
-        SC2Mission.DEATH_FROM_ABOVE: "Death From Above: Victory"
+        SC2Mission.THE_RECKONING: f'{SC2Mission.THE_RECKONING.mission_name}: Victory',
+        SC2Mission.THE_CRUCIBLE: f'{SC2Mission.THE_CRUCIBLE.mission_name}: Victory',
+        SC2Mission.HAND_OF_DARKNESS: f'{SC2Mission.HAND_OF_DARKNESS.mission_name}: Victory',
+        SC2Mission.PHANTOMS_OF_THE_VOID: f'{SC2Mission.PHANTOMS_OF_THE_VOID.mission_name}: Victory',
+        SC2Mission.PLANETFALL: f'{SC2Mission.PLANETFALL.mission_name}: Victory',
+        SC2Mission.DEATH_FROM_ABOVE: f'{SC2Mission.DEATH_FROM_ABOVE.mission_name}: Victory'
     },
     SC2Campaign.PROLOGUE: {
-        SC2Mission.GHOSTS_IN_THE_FOG: "Ghosts in the Fog: Victory"
+        SC2Mission.GHOSTS_IN_THE_FOG: f'{SC2Mission.GHOSTS_IN_THE_FOG.mission_name}: Victory'
     },
     SC2Campaign.LOTV: {
-        SC2Mission.THE_HOST: "The Host: Victory",
-        SC2Mission.TEMPLAR_S_CHARGE: "Templar's Charge: Victory"
+        SC2Mission.THE_HOST: f'{SC2Mission.THE_HOST.mission_name}: Victory',
+        SC2Mission.TEMPLAR_S_CHARGE: f'{SC2Mission.TEMPLAR_S_CHARGE.mission_name}: Victory'
     },
     SC2Campaign.EPILOGUE: {
-        SC2Mission.AMON_S_FALL: "Amon's Fall: Victory",
-        SC2Mission.INTO_THE_VOID: "Into the Void: Victory",
-        SC2Mission.THE_ESSENCE_OF_ETERNITY: "The Essence of Eternity: Victory",
+        SC2Mission.AMON_S_FALL: f'{SC2Mission.AMON_S_FALL.mission_name}: Victory',
+        SC2Mission.INTO_THE_VOID: f'{SC2Mission.INTO_THE_VOID.mission_name}: Victory',
+        SC2Mission.THE_ESSENCE_OF_ETERNITY: f'{SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name}: Victory',
     },
     SC2Campaign.NCO: {
-        SC2Mission.FLASHPOINT: "Flashpoint: Victory",
-        SC2Mission.DARK_SKIES: "Dark Skies: Victory",
-        SC2Mission.NIGHT_TERRORS: "Night Terrors: Victory",
-        SC2Mission.TROUBLE_IN_PARADISE: "Trouble In Paradise: Victory"
+        SC2Mission.FLASHPOINT: f'{SC2Mission.FLASHPOINT.mission_name}: Victory',
+        SC2Mission.DARK_SKIES: f'{SC2Mission.DARK_SKIES.mission_name}: Victory',
+        SC2Mission.NIGHT_TERRORS: f'{SC2Mission.NIGHT_TERRORS.mission_name}: Victory',
+        SC2Mission.TROUBLE_IN_PARADISE: f'{SC2Mission.TROUBLE_IN_PARADISE.mission_name}: Victory'
     }
 }
 

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -151,7 +151,7 @@ class MaximumCampaignSize(Range):
     """
     display_name = "Maximum Campaign Size"
     range_start = 1
-    range_end = 105
+    range_end = 109
     default = 83
 
 

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -487,6 +487,63 @@ class SC2Logic:
                 and state.has_any({item_names.HIVE_MIND_EMULATOR, item_names.PSI_DISRUPTER, item_names.MISSILE_TURRET}, self.player)
             )
 
+    def all_in_z_requirement(self, state: CollectionState):
+        """
+        All-in (Zerg)
+        :param state:
+        :return:
+        """
+        beats_kerrigan = (
+                state.has_any({item_names.ZERGLING, item_names.MUTALISK, item_names.INFESTED_MARINE}, self.player)
+                or state.has_all({item_names.SWARM_HOST, item_names.SWARM_HOST_RESOURCE_EFFICIENCY}, self.player)
+                or self.morph_brood_lord(state)
+                or self.advanced_tactics
+        )
+        if get_option_value(self.world, 'all_in_map') == AllInMap.option_ground:
+            # Ground
+            defense_rating = self.zerg_defense_rating(state, True, False)
+            if state.has_any({item_names.MUTALISK, item_names.INFESTED_BANSHEE, item_names.INFESTED_DUSK_WINGS}, self.player) or self.morph_brood_lord(state):
+                defense_rating += 2
+            return defense_rating >= 13 and beats_kerrigan
+        else:
+            # Air
+            defense_rating = self.zerg_defense_rating(state, True, True)
+            return (
+                    defense_rating >= 9 and beats_kerrigan
+                    and state.has_any({item_names.MUTALISK, item_names.CORRUPTOR}, self.player)
+                    and state.has(item_names.SPORE_CRAWLER, self.player)
+            )
+
+    def all_in_p_requirement(self, state: CollectionState):
+        """
+        All-in (Protoss)
+        :param state:
+        :return:
+        """
+        beats_kerrigan = (
+                state.has_any({item_names.CENTURION, item_names.SENTINEL, item_names.SKIRMISHER,
+                               item_names.CARRIER, item_names.TRIREME, item_names.VANGUARD}, self.player)
+                or self.advanced_tactics
+        )
+        if get_option_value(self.world, 'all_in_map') == AllInMap.option_ground:
+            # Ground
+            defense_rating = self.protoss_defense_rating(state, True)
+            if state.has_any({item_names.SKIRMISHER, item_names.DARK_TEMPLAR, item_names.TEMPEST, item_names.TRIREME}, self.player):
+                defense_rating += 2
+            return defense_rating >= 13 and beats_kerrigan
+        else:
+            # Air
+            defense_rating = self.protoss_defense_rating(state, True)
+            if state.has(item_names.KHAYDARIN_MONOLITH, self.player):
+                defense_rating += 2
+            return (
+                    defense_rating >= 9 and beats_kerrigan
+                    and self.protoss_anti_light_anti_air(state)
+                    and state.has_any(
+                {item_names.TEMPEST, item_names.SKYLORD, item_names.VOID_RAY},
+                self.player)
+            )
+
     # HotS
 
     def zerg_defense_rating(self, state: CollectionState, zerg_enemy: bool, air_enemy: bool = True) -> int:

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -521,8 +521,12 @@ class SC2Logic:
         :return:
         """
         beats_kerrigan = (
+                # cheap units with multiple small attacks, or anything with Feedback
                 state.has_any({item_names.CENTURION, item_names.SENTINEL, item_names.SKIRMISHER,
-                               item_names.CARRIER, item_names.TRIREME, item_names.VANGUARD}, self.player)
+                               item_names.HIGH_TEMPLAR}, self.player)
+                or state.has_all({item_names.SIGNIFIER, item_names.SIGNIFIER_FEEDBACK}, self.player)
+                or (self.protoss_can_merge_archon(state) and state.has(item_names.ARCHON_HIGH_ARCHON, self.player))
+                or (self.protoss_can_merge_dark_archon(state) and state.has(item_names.DARK_ARCHON_FEEDBACK, self.player))
                 or self.advanced_tactics
         )
         if get_option_value(self.world, 'all_in_map') == AllInMap.option_ground:
@@ -1072,6 +1076,12 @@ class SC2Logic:
 
     def protoss_static_defense(self, state: CollectionState) -> bool:
         return state.has_any({item_names.PHOTON_CANNON, item_names.KHAYDARIN_MONOLITH}, self.player)
+
+    def protoss_can_merge_archon(self, state: CollectionState) -> bool:
+        return state.has_any({item_names.HIGH_TEMPLAR, item_names.DARK_TEMPLAR, item_names.SIGNIFIER, item_names.ASCENDANT}, self.player)
+
+    def protoss_can_merge_dark_archon(self, state: CollectionState) -> bool:
+        return state.has(item_names.DARK_ARCHON, self.player) or state.has_all({item_names.DARK_TEMPLAR, item_names.DARK_TEMPLAR_DARK_ARCHON_MELD}, self.player)
 
     def last_stand_requirement(self, state: CollectionState) -> bool:
         return (


### PR DESCRIPTION
## What is this fixing or adding?
Adding Zerg and Protoss variants of Shatter the Sky and All-In

## How was this tested?
Ran all the tests, generated a few worlds, everything seemed fine
