### PR TITLE
sc2: Adding an overpowered items group

### DIFF
--- a/worlds/sc2/item_groups.py
+++ b/worlds/sc2/item_groups.py
@@ -182,7 +182,7 @@ item_name_groups[ItemGroupNames.TERRAN_ITEMS] = terran_items = [
 ]
 item_name_groups[ItemGroupNames.TERRAN_UNITS] = terran_units = [
     item_name for item_name, item_data in items.item_table.items()
-    if item_data.type in (items.TerranItemType.Unit, items.TerranItemType.Mercenary)
+    if item_data.type in (items.TerranItemType.Unit, items.TerranItemType.Unit_2, items.TerranItemType.Mercenary)
 ]
 item_name_groups[ItemGroupNames.TERRAN_GENERIC_UPGRADES] = terran_generic_upgrades = [
     item_name for item_name, item_data in items.item_table.items()

--- a/worlds/sc2/item_groups.py
+++ b/worlds/sc2/item_groups.py
@@ -164,6 +164,7 @@ class ItemGroupNames:
     PURIFIER_UNITS = "Purifier"
 
     VANILLA_ITEMS = "Vanilla Items"
+    OVERPOWERED_ITEMS = "Overpowered Items"
 
     @classmethod
     def get_all_group_names(cls) -> typing.Set[str]:
@@ -627,4 +628,18 @@ item_name_groups[ItemGroupNames.VANILLA_ITEMS] = vanilla_items = (
 item_name_groups[ItemGroupNames.WAR_COUNCIL] = [
     item_name for item_name, item_data in items.item_table.items()
     if item_data.type in (items.ProtossItemType.War_Council, items.ProtossItemType.War_Council_2)
+]
+
+item_name_groups[ItemGroupNames.OVERPOWERED_ITEMS] = [
+    item_names.SIEGE_TANK_GRADUATING_RANGE,
+    item_names.SIEGE_TANK_RESOURCE_EFFICIENCY,
+    item_names.BATTLECRUISER_ATX_LASER_BATTERY,
+    item_names.PROGRESSIVE_REGENERATIVE_BIO_STEEL,
+    item_names.MECHANICAL_KNOW_HOW,
+    item_names.MERCENARY_MUNITIONS,
+
+    item_names.REAVER_RESOURCE_EFFICIENCY,
+    item_names.SOA_TIME_STOP,
+    item_names.SOA_SOLAR_LANCE,
+    item_names.MOTHERSHIP,
 ]

--- a/worlds/sc2/item_groups.py
+++ b/worlds/sc2/item_groups.py
@@ -1,7 +1,6 @@
 import typing
 from . import item_names, items
 from .mission_tables import campaign_mission_table, SC2Campaign, SC2Mission, SC2Race
-from ..hk import item_table
 
 """
 Item name groups, given to Archipelago and used in YAMLs and /received filtering.

--- a/worlds/sc2/item_groups.py
+++ b/worlds/sc2/item_groups.py
@@ -637,8 +637,15 @@ item_name_groups[ItemGroupNames.OVERPOWERED_ITEMS] = [
     item_names.MECHANICAL_KNOW_HOW,
     item_names.MERCENARY_MUNITIONS,
 
+    item_names.KERRIGAN_APOCALYPSE,
+    item_names.KERRIGAN_DROP_PODS,
+    item_names.KERRIGAN_SPAWN_LEVIATHAN,
+
     item_names.REAVER_RESOURCE_EFFICIENCY,
     item_names.SOA_TIME_STOP,
     item_names.SOA_SOLAR_LANCE,
+    # Note: This is more an issue of having multiple ults at the same time, rather than solar bombardment in particular.
+    # Can be removed from the list if we get an SOA ult combined cooldown or energy cost on it.
+    item_names.SOA_SOLAR_BOMBARDMENT,
     item_names.MOTHERSHIP,
 ]


### PR DESCRIPTION
## What is this fixing or adding?
A new item group for overpowered items.

Also fixed a broken unit test caused by not including the new unit_2 category in the terran units item group.

## How was this tested?
Unit tests.

## If this makes graphical changes, please attach screenshots.
None