### PR TITLE
Fix typo in docs

### DIFF
--- a/worlds/sc2/docs/en_Custom Mission Orders.md
+++ b/worlds/sc2/docs/en_Custom Mission Orders.md
@@ -668,7 +668,7 @@ The following example shows ways to access and modify missions:
         # Available functions depend on the layout's type
         # In this case the function will return the indices 1 and 3
         # and then mark those two slots as empty
-        - index: rect(1, 0, 1, 1)
+        - index: rect(1, 0, 1, 2)
           empty: true
         # Indices can be a list of valid values
         # This takes all entrances as well as the mission at index 2


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a typo left over from an earlier design iteration of index functions.

## How was this tested?
I've generated the example the typo was in and checked in the client that the result is what it's supposed to be.