### PR TITLE
sc2: Adding fusion reactors upgrade for the fusion core

### DIFF
--- a/worlds/sc2/item_descriptions.py
+++ b/worlds/sc2/item_descriptions.py
@@ -515,6 +515,7 @@ item_descriptions = {
     item_names.MERCENARY_MUNITIONS: "Increases attack speed of all combat units by 15%.",
     item_names.FAST_DELIVERY: "Mercenary calldowns can be deployed right at the mission start.",
     item_names.RAPID_REINFORCEMENT: "Reduces cooldowns of mercenary calldowns by 60s.",
+    item_names.FUSION_CORE_FUSION_REACTOR: "Fusion Cores increase the energy regeneration of nearby units by +1 energy per second.",
     item_names.ZEALOT: "Powerful melee warrior. Can use the charge ability.",
     item_names.STALKER: "Ranged attack strider. Can use the Blink ability.",
     item_names.HIGH_TEMPLAR: "Potent psionic master. Can use the Feedback and Psionic Storm abilities. Can merge into an Archon.",

--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -108,6 +108,7 @@ MECHANICAL_KNOW_HOW                   = "Mechanical Know-how (Terran)"
 MERCENARY_MUNITIONS                   = "Mercenary Munitions (Terran)"
 FAST_DELIVERY                         = "Fast Delivery (Terran/Zerg)"
 RAPID_REINFORCEMENT                   = "Rapid Reinforcement (Terran/Zerg)"
+FUSION_CORE_FUSION_REACTOR            = "Fusion Reactor (Fusion Core)"
 
 # Terran Unit Upgrades
 BANSHEE_HYPERFLIGHT_ROTORS                         = "Hyperflight Rotors (Banshee)"

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -949,15 +949,17 @@ item_table = {
     item_names.ADVANCED_OPTICS:
         ItemData(622 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 11, SC2Race.TERRAN),
     item_names.ROGUE_FORCES:
-        ItemData(623 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 12, SC2Race.TERRAN, origin={"ext"}),
+        ItemData(623 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 12, SC2Race.TERRAN),
     item_names.MECHANICAL_KNOW_HOW:
-        ItemData(624 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 13, SC2Race.TERRAN, origin={"ext"}),
+        ItemData(624 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 13, SC2Race.TERRAN),
     item_names.MERCENARY_MUNITIONS:
-        ItemData(625 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 14, SC2Race.TERRAN, origin={"ext"}),
+        ItemData(625 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 14, SC2Race.TERRAN),
     item_names.FAST_DELIVERY:
-        ItemData(626 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 15, SC2Race.TERRAN, origin={"ext"}),
+        ItemData(626 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 15, SC2Race.TERRAN),
     item_names.RAPID_REINFORCEMENT:
-        ItemData(627 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 16, SC2Race.TERRAN, origin={"ext"}),
+        ItemData(627 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 16, SC2Race.TERRAN),
+    item_names.FUSION_CORE_FUSION_REACTOR:
+        ItemData(628 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 17, SC2Race.TERRAN),
 
     # WoL Protoss
     item_names.ZEALOT:


### PR DESCRIPTION
## What is this fixing or adding?
Adding Fusion Core upgrade -- Fusion Reactor. Gives an energy-regen aura around fusion cores.

Pairs with [data PR #290https://github.com/Ziktofel/Archipelago-SC2-data/pull/290)

## How was this tested?
The usual -- generated a new game, started a mission, did a `/send`, verified I had the item (and could build fusion cores).

## If this makes graphical changes, please attach screenshots.
See data PR