### PR TITLE
sc2: Fixing an exception on client startup that prevented the launcher from rendering

### DIFF
--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -159,6 +159,7 @@ class SC2Manager(GameManager):
         container = super().build()
 
         panel = self.add_client_tab("Starcraft 2 Launcher", CampaignScroll())
+        self.campaign_scroll_panel = panel.content
         self.campaign_panel = MultiCampaignLayout()
         panel.content.add_widget(self.campaign_panel)
 

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -90,7 +90,7 @@ class FactionlessItemType(ItemTypeEnum):
     Supply = "Supply", 2
     Nothing = "Nothing Group", 4
     Deprecated = "Deprecated", 5
-    Keys = "Keys", 6
+    Keys = "Keys", -1
 
 
 ItemType = Union[TerranItemType, ZergItemType, ProtossItemType, FactionlessItemType]


### PR DESCRIPTION
## What is this fixing or adding?
Fixing an exception on client startup.

```
Base: Start application main loop
Uncaught Exception:
Traceback (most recent call last):
  File "kivy\\_clock.pyx", line 649, in kivy._clock.CyClockBase._process_events
  File "kivy\\_clock.pyx", line 218, in kivy._clock.ClockEvent.tick
  File "D:\Archipelago\matthew\Archipelago\worlds\sc2\client_gui.py", line 204, in build_mission_table
    self.campaign_scroll_panel.border_on = False
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'border_on'
```

This was introduced by a change on AP main that was pulled in by a recent merge-from-main.

### Update
Found another crash -- getting a key or starting a mission with a key in your inventory crashed the game. Setting the key category to have an accumulator index of -1 fixed it.

## How was this tested?
Started the client, verified everything started correctly. Checked out AP main / current RC, started client, verified there was no error and no action necessary.

## If this makes graphical changes, please attach screenshots.
None