### PR TITLE
Mm/new custom colours

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -383,7 +383,8 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             "Purple", "Yellow", "Orange", "Green",
             "LightPink", "Violet", "LightGrey", "DarkGreen",
             "Brown", "LightGreen", "DarkGrey", "Pink",
-            "Rainbow", "Random", "Default"
+            "Rainbow", "Mengsk", "BrightLime", "Arcane", "Ember", "HotPink",
+            "Random", "Default"
         ]
         var_names = {
             'raynor': 'player_color_raynor',
@@ -414,7 +415,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
                 self.output(color + " is not a valid color.  Available colors: " + ', '.join(player_colors))
                 return
             if color.lower() == "random":
-                color = random.choice(player_colors[:16])
+                color = random.choice(player_colors[:-2])
             self.ctx.__dict__[var_names[faction]] = match_colors.index(color.lower())
             self.ctx.pending_color_update = True
             self.output(f"Color for {faction} set to " + player_colors[self.ctx.__dict__[var_names[faction]]])

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -95,6 +95,13 @@ def get_metadata_file() -> str:
     return os.environ["SC2PATH"] + os.sep + "ArchipelagoSC2Metadata.txt"
 
 
+def _remap_color_option(slot_data_version: int, color: int) -> int:
+    """Remap colour options for backwards compatibility with older slot data"""
+    if slot_data_version < 4 and color == ColorChoice.option_mengsk:
+        return ColorChoice.option_default
+    return color
+
+
 class ConfigurableOptionType(enum.Enum):
     INTEGER = enum.auto()
     ENUM = enum.auto()
@@ -614,6 +621,7 @@ class SC2Context(CommonContext):
                     }
                 
                 self.custom_mission_order = self.parse_mission_req_table(mission_req_table)
+                
             if self.slot_data_version >= 4:
                 self.custom_mission_order = [
                     CampaignSlotData(
@@ -647,11 +655,27 @@ class SC2Context(CommonContext):
             else:
                 self.final_mission_ids = args["slot_data"].get("final_mission_ids", [SC2Mission.ALL_IN.id])
                 self.final_locations = [get_location_id(mission_id, 0) for mission_id in self.final_mission_ids]
-            self.player_color_raynor = args["slot_data"].get("player_color_terran_raynor", ColorChoice.option_blue)
-            self.player_color_zerg = args["slot_data"].get("player_color_zerg", ColorChoice.option_orange)
-            self.player_color_zerg_primal = args["slot_data"].get("player_color_zerg_primal", ColorChoice.option_purple)
-            self.player_color_protoss = args["slot_data"].get("player_color_protoss", ColorChoice.option_blue)
-            self.player_color_nova = args["slot_data"].get("player_color_nova", ColorChoice.option_dark_grey)
+
+            self.player_color_raynor = _remap_color_option(
+                self.slot_data_version,
+                args["slot_data"].get("player_color_terran_raynor", ColorChoice.option_blue)
+            )
+            self.player_color_zerg = _remap_color_option(
+                self.slot_data_version,
+                args["slot_data"].get("player_color_zerg", ColorChoice.option_orange)
+            )
+            self.player_color_zerg_primal = _remap_color_option(
+                self.slot_data_version,
+                args["slot_data"].get("player_color_zerg_primal", ColorChoice.option_purple)
+            )
+            self.player_color_protoss = _remap_color_option(
+                self.slot_data_version,
+                args["slot_data"].get("player_color_protoss", ColorChoice.option_blue)
+            )
+            self.player_color_nova = _remap_color_option(
+                self.slot_data_version,
+                args["slot_data"].get("player_color_nova", ColorChoice.option_dark_grey)
+            )
             self.generic_upgrade_missions = args["slot_data"].get("generic_upgrade_missions", GenericUpgradeMissions.default)
             self.generic_upgrade_items = args["slot_data"].get("generic_upgrade_items", GenericUpgradeItems.option_individual_items)
             self.generic_upgrade_research = args["slot_data"].get("generic_upgrade_research", GenericUpgradeResearch.option_vanilla)

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -198,7 +198,12 @@ class ColorChoice(Choice):
     option_dark_grey = 14
     option_pink = 15
     option_rainbow = 16
-    option_default = 17
+    option_mengsk = 17
+    option_bright_lime = 18
+    option_arcane = 19
+    option_ember = 20
+    option_hot_pink = 21
+    option_default = 22
     default = option_default
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Added the client-side support for the new custom colours added in [data PR #291](https://github.com/Ziktofel/Archipelago-SC2-data/pull/291)

Note this change was tested on a branch off of PR #316; that PR should be merged first or merging this PR will include that change.

## How was this tested?
Sent a lot of `/color` commands to check that the colour switched. Sent some `/color protoss random` to check that the new colours were in the random rotation. 

## If this makes graphical changes, please attach screenshots.
See data PR.
![image](https://github.com/user-attachments/assets/33efab86-ba3c-4de1-83a6-3d1132e99d13)
