### PR TITLE
Improve mission fill error messages

### DIFF
--- a/worlds/sc2/mission_order/mission_pools.py
+++ b/worlds/sc2/mission_order/mission_pools.py
@@ -105,11 +105,12 @@ class SC2MOGenMissionPools:
     def pull_specific_mission(self, mission: SC2Mission) -> None:
         """Marks the given mission as present in the mission order."""
         # Remove the mission from the master list and whichever difficulty pool it is in
-        self.master_list.remove(mission.id)
-        for diff in self.difficulty_pools:
-            if mission.id in self.difficulty_pools[diff]:
-                self.difficulty_pools[diff].remove(mission.id)
-                break
+        if mission.id in self.master_list:
+            self.master_list.remove(mission.id)
+            for diff in self.difficulty_pools:
+                if mission.id in self.difficulty_pools[diff]:
+                    self.difficulty_pools[diff].remove(mission.id)
+                    break
         self._add_mission_stats(mission)
     
     def _add_mission_stats(self, mission: SC2Mission) -> None:

--- a/worlds/sc2/mission_order/mission_pools.py
+++ b/worlds/sc2/mission_order/mission_pools.py
@@ -105,12 +105,11 @@ class SC2MOGenMissionPools:
     def pull_specific_mission(self, mission: SC2Mission) -> None:
         """Marks the given mission as present in the mission order."""
         # Remove the mission from the master list and whichever difficulty pool it is in
-        if mission.id in self.master_list:
-            self.master_list.remove(mission.id)
-            for diff in self.difficulty_pools:
-                if mission.id in self.difficulty_pools[diff]:
-                    self.difficulty_pools[diff].remove(mission.id)
-                    break
+        self.master_list.remove(mission.id)
+        for diff in self.difficulty_pools:
+            if mission.id in self.difficulty_pools[diff]:
+                self.difficulty_pools[diff].remove(mission.id)
+                break
         self._add_mission_stats(mission)
     
     def _add_mission_stats(self, mission: SC2Mission) -> None:
@@ -149,7 +148,7 @@ class SC2MOGenMissionPools:
                 if len(final_pool) > 0:
                     break
                 if lower_diff == Difficulty.STARTER and higher_diff == Difficulty.VERY_HARD:
-                    raise Exception(f"Slot in layout \"{slot.parent().get_visual_requirement()}\" ran out of possible missions to place.")
+                    raise IndexError()
                 difficulty_offset += 1
         
         else:
@@ -164,7 +163,7 @@ class SC2MOGenMissionPools:
             while len(final_pool) == 0:
                 higher_difficulty = desired_difficulty + difficulty_offset
                 if higher_difficulty > Difficulty.VERY_HARD:
-                    raise Exception(f"Slot in layout \"{slot.parent().get_visual_requirement()}\" ran out of possible missions to place.")
+                    raise IndexError()
                 final_pool = difficulty_pools[higher_difficulty]
                 difficulty_offset += 1
 

--- a/worlds/sc2/mission_order/structs.py
+++ b/worlds/sc2/mission_order/structs.py
@@ -405,10 +405,9 @@ class SC2MissionOrder(MissionOrderNode):
             # Remove set mission from locked missions
             locked_ids = [locked for locked in locked_ids if locked != mission_id]
             mission = lookup_id_to_mission[mission_id]
-            try:
-                self.mission_pools.pull_specific_mission(mission)
-            except KeyError:
+            if mission in self.mission_pools.get_used_missions():
                 raise ValueError(f"Mission slot at address \"{mission_slot.get_address_to_mission()}\" tried to plando an already plando'd mission.")
+            self.mission_pools.pull_specific_mission(mission)
             mission_slot.set_mission(world, mission, locations_per_region, location_cache)
             regions.append(mission_slot.region)
 

--- a/worlds/sc2/mission_order/structs.py
+++ b/worlds/sc2/mission_order/structs.py
@@ -405,7 +405,10 @@ class SC2MissionOrder(MissionOrderNode):
             # Remove set mission from locked missions
             locked_ids = [locked for locked in locked_ids if locked != mission_id]
             mission = lookup_id_to_mission[mission_id]
-            self.mission_pools.pull_specific_mission(mission)
+            try:
+                self.mission_pools.pull_specific_mission(mission)
+            except KeyError:
+                raise ValueError(f"Mission slot at address \"{mission_slot.get_address_to_mission()}\" tried to plando an already plando'd mission.")
             mission_slot.set_mission(world, mission, locations_per_region, location_cache)
             regions.append(mission_slot.region)
 
@@ -445,16 +448,30 @@ class SC2MissionOrder(MissionOrderNode):
 
         # Pick goal missions first with stricter difficulty matching, and starting with harder goals
         for goal_slot in sorted_goals:
-            mission = self.mission_pools.pull_random_mission(world, goal_slot, prefer_close_difficulty=True)
-            goal_slot.set_mission(world, mission, locations_per_region, location_cache)
-            regions.append(goal_slot.region)
-            all_slots.remove(goal_slot)
+            try:
+                mission = self.mission_pools.pull_random_mission(world, goal_slot, prefer_close_difficulty=True)
+                goal_slot.set_mission(world, mission, locations_per_region, location_cache)
+                regions.append(goal_slot.region)
+                all_slots.remove(goal_slot)
+            except IndexError:
+                raise IndexError(
+                    f"Slot at address \"{goal_slot.get_address_to_mission()}\" ran out of possible missions to place "
+                    f"with {len(all_slots)} empty slots remaining."
+                )
 
         # Pick random missions
+        remaining_count = len(all_slots)
         for mission_slot in all_slots:
-            mission = self.mission_pools.pull_random_mission(world, mission_slot)
-            mission_slot.set_mission(world, mission, locations_per_region, location_cache)
-            regions.append(mission_slot.region)
+            try:
+                mission = self.mission_pools.pull_random_mission(world, mission_slot)
+                mission_slot.set_mission(world, mission, locations_per_region, location_cache)
+                regions.append(mission_slot.region)
+                remaining_count -= 1
+            except IndexError:
+                raise IndexError(
+                    f"Slot at address \"{goal_slot.get_address_to_mission()}\" ran out of possible missions to place "
+                    f"with {remaining_count} empty slots remaining."
+                )
 
         world.multiworld.regions += regions
 
@@ -938,6 +955,14 @@ class SC2MOGenMission(MissionOrderNode):
     
     def get_key_name(self) -> str:
         return item_names._TEMPLATE_MISSION_KEY.format(self.mission.mission_name)
+    
+    def get_address_to_mission(self) -> str:
+        layout = self.parent()
+        index = layout.missions.index(self)
+        campaign = layout.parent()
+        if campaign.option_single_layout_campaign:
+            return f"{layout.option_name}/{index}"
+        return f"{campaign.option_name}/{layout.option_name}/{index}"
     
     def make_connections(self, world: World, used_names: Dict[str, int]):
         player = world.player


### PR DESCRIPTION
## What is this fixing or adding?
- Adds a more descriptive error message to plando'd slots with duplicate missions
- Changes the error on running out of missions to accurately name the slot and give the amount of empty slots remaining
  - This error is currently bugged due to a missing function argument, so this is also a bugfix

## How was this tested?
Generating with a mission order with too many slots and checking the generator output.
