### PR TITLE
SC2: Fixing Warp Relocate (progressive item bug)

### DIFF
--- a/worlds/sc2/item_names.py
+++ b/worlds/sc2/item_names.py
@@ -824,7 +824,7 @@ ENHANCED_TARGETING          = "Enhanced Targeting (Protoss)"
 OPTIMIZED_ORDNANCE          = "Optimized Ordnance (Protoss)"
 KHALAI_INGENUITY            = "Khalai Ingenuity (Protoss)"
 AMPLIFIED_ASSIMILATORS      = "Amplified Assimilators (Protoss)"
-PROGRESSIVE_WARP_RELOCATE   = "Warp Relocate (Protoss)"
+PROGRESSIVE_WARP_RELOCATE   = "Progressive Warp Relocate (Protoss)"
 
 # Filler items
 STARTING_MINERALS = "Additional Starting Minerals"

--- a/worlds/sc2/items.py
+++ b/worlds/sc2/items.py
@@ -1970,7 +1970,7 @@ item_table = {
     item_names.AMPLIFIED_ASSIMILATORS:
         ItemData(812 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 12, SC2Race.PROTOSS, origin={"ext"}),
     item_names.PROGRESSIVE_WARP_RELOCATE:
-        ItemData(813 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Progressive, 1, SC2Race.PROTOSS, origin={"ext"}, quantity=2,
+        ItemData(813 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Progressive, 2, SC2Race.PROTOSS, origin={"ext"}, quantity=2,
                  classification=ItemClassification.progression),
 }
 


### PR DESCRIPTION
## What is this fixing or adding?
Fixing the name so it starts with "Progressive," and fixes the slot number so it no longer overlaps with Progressive Proxy Pylon Lvl2.

## How was this tested?
Ran this fix on an existing world with lvl1 proxy pylon and lvl1 warp relocate; verified that I had warp relocate, and that I did NOT have pylon reinforcements