### PR TITLE
Fix entry rules in client sometimes not resolving correctly due to recursion error

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1424,31 +1424,18 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
         received_items[network_item.item] += 1
 
     accessible_rules: typing.Set[int] = set()
-    # Determine accessibility from top to bottom to avoid a recursion problem from
-    # missions trying to access layouts & campaigns appearing later than themselves
-    # Campaigns
     for campaign_idx, campaign in enumerate(ctx.custom_mission_order):
         available_layouts[campaign_idx] = []
-        if campaign.entry_rule.is_accessible(beaten_missions, received_items, ctx.mission_id_to_entry_rules, accessible_rules, set()):
+        if campaign.entry_rule.is_accessible(beaten_missions, received_items, ctx.mission_id_to_entry_rules, accessible_rules, []):
             available_campaigns.append(campaign_idx)
-    
-    # Layouts
-    for campaign_idx, campaign in enumerate(ctx.custom_mission_order):
-        if campaign_idx in available_campaigns:
             for layout_idx, layout in enumerate(campaign.layouts):
-                if layout.entry_rule.is_accessible(beaten_missions, received_items, ctx.mission_id_to_entry_rules, accessible_rules, set()):
+                if layout.entry_rule.is_accessible(beaten_missions, received_items, ctx.mission_id_to_entry_rules, accessible_rules, []):
                     available_layouts[campaign_idx].append(layout_idx)
-    
-    # Missions
-    for campaign_idx, campaign in enumerate(ctx.custom_mission_order):
-        if campaign_idx in available_campaigns:
-            for layout_idx, layout in enumerate(campaign.layouts):
-                if layout_idx in available_layouts[campaign_idx]:
                     for column in layout.missions:
                         for mission in column:
                             if mission.mission_id == -1:
                                 continue
-                            if mission.entry_rule.is_accessible(beaten_missions, received_items, ctx.mission_id_to_entry_rules, accessible_rules, set()):
+                            if mission.entry_rule.is_accessible(beaten_missions, received_items, ctx.mission_id_to_entry_rules, accessible_rules, []):
                                 available_missions.append(mission.mission_id)
 
     return available_missions, available_layouts, available_campaigns

--- a/worlds/sc2/mission_order/entry_rules.py
+++ b/worlds/sc2/mission_order/entry_rules.py
@@ -70,7 +70,7 @@ class RuleData(ABC):
     def is_accessible(
         self, beaten_missions: Set[int], received_items: Dict[int, int],
         mission_id_to_entry_rules: Dict[int, MissionEntryRules],
-        accessible_rules: Set[int], seen_rules: Set[int]
+        accessible_rules: Set[int], seen_rules: List[int]
     ) -> bool:
         return False
 
@@ -121,7 +121,7 @@ class BeatMissionsRuleData(RuleData):
     def is_accessible(
         self, beaten_missions: Set[int], received_items: Dict[int, int],
         mission_id_to_entry_rules: Dict[int, MissionEntryRules],
-        accessible_rules: Set[int], seen_rules: Set[int]
+        accessible_rules: Set[int], seen_rules: List[int]
     ) -> bool:
         # Beat rules are accessible if all their missions are beaten and accessible
         if not beaten_missions.issuperset(self.mission_ids):
@@ -182,7 +182,9 @@ class CountMissionsRuleData(RuleData):
             req = self.visual_reqs[0]
             req_str = missions[req].mission_name if type(req) == int else req
             if self.amount == 1:
-                return f"Beat {req_str}"
+                if type(req) == int:
+                    return f"Beat {req_str}"
+                return f"Beat any mission from {req_str}"
             return f"Beat {amount} missions from {req_str}"
         if self.amount == 1:
             tooltip = f"Beat any mission from:\n{indent}- "
@@ -198,7 +200,7 @@ class CountMissionsRuleData(RuleData):
     def is_accessible(
         self, beaten_missions: Set[int], received_items: Dict[int, int],
         mission_id_to_entry_rules: Dict[int, MissionEntryRules],
-        accessible_rules: Set[int], seen_rules: Set[int]
+        accessible_rules: Set[int], seen_rules: List[int]
     ) -> bool:
         # Count rules are accessible if enough of their missions are beaten and accessible
         return self.amount <= sum(
@@ -279,11 +281,16 @@ class SubRuleRuleData(RuleData):
                     **{field: value for field, value in rule_data.items()}
                 )
             sub_rules.append(rule)
-        return SubRuleRuleData(
+        rule = SubRuleRuleData(
             rule_id,
             sub_rules,
             amount
         )
+        # Add an accessibility buffer for top level rules
+        # This is an optimization to make recalculations of large mission orders feel smoother
+        if rule.rule_id >= 0:
+            rule.buffer_accessible = False
+        return rule
     
     @staticmethod
     def empty() -> SubRuleRuleData:
@@ -309,26 +316,30 @@ class SubRuleRuleData(RuleData):
     def is_accessible(
         self, beaten_missions: Set[int], received_items: Dict[int, int],
         mission_id_to_entry_rules: Dict[int, MissionEntryRules],
-        accessible_rules: Set[int], seen_rules: Set[int]
+        accessible_rules: Set[int], seen_rules: List[int]
     ) -> bool:
         # Early exit check for top-level entry rules
         if self.rule_id >= 0:
-            if self.rule_id in accessible_rules:
+            if self.buffer_accessible or self.rule_id in accessible_rules:
                 return True
             # Never consider rules discovered via recursion to be accessible
             # (unless they succeeded, in which case they will be in accessible_rules)
             if self.rule_id in seen_rules:
                 return False
-            seen_rules.add(self.rule_id)
+            seen_rules.append(self.rule_id)
         # Sub-rule rules are accessible if enough of their child rules are accessible
-        if self.amount <= sum(
+        success = self.amount <= sum(
             rule.is_accessible(beaten_missions, received_items, mission_id_to_entry_rules, accessible_rules, seen_rules)
             for rule in self.sub_rules
-        ):
-            if self.rule_id >= 0:
+        )
+        if self.rule_id >= 0:
+            if success:
                 accessible_rules.add(self.rule_id)
-            return True
-        return False
+                self.buffer_accessible = True
+            # Rules that failed in the middle of calculating another rule
+            # should be allowed to try again at a later point
+            seen_rules.remove(self.rule_id)
+        return success
 
 class ItemEntryRule(EntryRule):
     items_to_check: Dict[str, int]
@@ -375,7 +386,7 @@ class ItemRuleData(RuleData):
     def is_accessible(
         self, beaten_missions: Set[int], received_items: Dict[int, int],
         mission_id_to_entry_rules: Dict[int, MissionEntryRules],
-        accessible_rules: Set[int], seen_rules: Set[int]
+        accessible_rules: Set[int], seen_rules: List[int]
     ) -> bool:
         return all(
             item in received_items and received_items[item] >= amount

--- a/worlds/sc2/mission_order/entry_rules.py
+++ b/worlds/sc2/mission_order/entry_rules.py
@@ -201,15 +201,13 @@ class CountMissionsRuleData(RuleData):
         accessible_rules: Set[int], seen_rules: Set[int]
     ) -> bool:
         # Count rules are accessible if enough of their missions are beaten and accessible
-        # return self.amount <= sum(
-        #     all(
-        #         rule.is_accessible(beaten_missions, received_items, mission_id_to_entry_rules, accessible_rules, seen_rules)
-        #         for rule in mission_id_to_entry_rules[mission_id]
-        #     )
-        #     for mission_id in beaten_missions.intersection(self.mission_ids)
-        # )
-        # Temp hotfix as the missions that have this rule themselves aren't counted in the client against this rule
-        return self.amount <= len(beaten_missions.intersection(self.mission_ids))
+        return self.amount <= sum(
+            all(
+                rule.is_accessible(beaten_missions, received_items, mission_id_to_entry_rules, accessible_rules, seen_rules)
+                for rule in mission_id_to_entry_rules[mission_id]
+            )
+            for mission_id in beaten_missions.intersection(self.mission_ids)
+        )
 
 class SubRuleEntryRule(EntryRule):
     rule_id: int


### PR DESCRIPTION
## What is this fixing or adding?
- Fixes the reported issue of WoL's Artifact not correctly counting accessible missions
  - Also fixes similar situations only possible in custom orders
- Adds an accessibility buffer to the client to make recalculations of the mission order faster
  - This works based on the assumption that a mission, once accessible, can never become inaccessible
  - The buffer is lost when the client disconnects
  - This should have the biggest effect for large mission count entry rules, like in WoL
- Fixes a text issue where an entry rule that requires 1 mission from a layout/campaign would say (for example) "Beat Wings of Liberty" instead of "Beat any mission from Wings of Liberty"

## How was this tested?
I used the vanilla order game from the bug report and a small custom order to replicate and isolate the problem, then sent victory checks via the server console and observed the changed behavior.