### PR TITLE
Fix non-determinism in recursive entry rule check

### DIFF
--- a/worlds/sc2/mission_order/presets_scripted.py
+++ b/worlds/sc2/mission_order/presets_scripted.py
@@ -21,7 +21,7 @@ def make_golden_path(options: Dict[str, Any]) -> Dict[str, Any]:
                           'Antiga', 'Braxis', 'Chau Sara', 'Moria', 'Tyrador', 'Xil', 'Zhakul',
                           'Azeroth', 'Crouton', 'Draenor', 'Sanctuary']
     
-    size = max(_required_option("size", options), 2)
+    size = max(_required_option("size", options), 4)
     keys_option = _validate_option("keys", options, "none", ["none", "layouts", "missions"])
     min_chains = 2
     max_chains = 6


### PR DESCRIPTION
## What is this fixing or adding?
This addresses Golden Paths of large sizes causing client hangs when a lot of missions are beaten.

The cause of this was a non-deterministic iteration in mission count entry rules leading to possibly endless looping. I originally thought this was an optimization problem, so some optimizations are in here as well:
- During generation, mission count entry rules sort their missions by depth instead of relying on definition order
  - This should be an optimization in most cases. I think it's possible to build a worst-case mission order using keys, but it's much easier to build sub-optimal mission orders with the current (lack of) sorting.
- Replace `sum()` with manual iterations to add early exits
  - Together with the above this should result in much fewer unnecessary rules being looked at

Finally, this bumps the minimum size of Golden Path from 2 to 4, because I found that size 3 doesn't generate successfully (size 4 does).

## How was this tested?
I generated and `/collect`ed Golden Paths between size 4 and 109 and a vanilla order.
