### PR TITLE
Mission Race Balancing option

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -55,7 +55,7 @@ class Starcraft2WebWorld(WebWorld):
 
     custom_mission_orders_en = Tutorial(
         "Custom Mission Order Usage Guide",
-        "Documentation for the `custom_mission_order` YAML option",
+        "Documentation for the custom_mission_order YAML option",
         "English",
         "en_Custom Mission Orders.md",
         "custom_mission_orders/en",

--- a/worlds/sc2/mission_order/mission_pools.py
+++ b/worlds/sc2/mission_order/mission_pools.py
@@ -158,6 +158,8 @@ class SC2MOGenMissionPools:
             ]
             balanced_weights = mission_scores
 
+        if sum(balanced_weights) == 0.0:
+            balanced_weights = [1.0 for _ in balanced_weights]
         return world.random.choices(balanced_pool, balanced_weights, k=1)[0]
 
     def pull_specific_mission(self, mission: SC2Mission) -> None:

--- a/worlds/sc2/mission_order/options.py
+++ b/worlds/sc2/mission_order/options.py
@@ -83,6 +83,7 @@ EntryRule = Or(SubRuleEntryRule, MissionCountEntryRule, BeatMissionsEntryRule, I
 class CustomMissionOrder(OptionDict):
     """
     Used to generate a custom mission order. Please see documentation to understand usage.
+    Will do nothing unless `mission_order` is set to `custom`.
     """
     display_name = "Custom Mission Order"
     visibility = Visibility.template

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -303,6 +303,22 @@ class EnableRaceSwapVariants(Choice):
     default = option_disabled
 
 
+class EnableMissionRaceBalancing(Choice):
+    """
+    If enabled, picks missions in such a way that the appearance rate of races is roughly equal.
+    The final rates may deviate if there are not enough missions enabled to accomodate each race.
+
+    Disabled: Pick missions at random.
+    Semi Balanced: Use a weighting system to pick missions in a random, but roughly equal ratio.
+    Fully Balanced: Pick missions to preserve equal race counts whenever possible.
+    """
+    display_name = "Enable Mission Race Balancing"
+    option_disabled = 0
+    option_semi_balanced = 1
+    option_fully_balanced = 2
+    default = option_semi_balanced
+
+
 class ShuffleCampaigns(DefaultOnToggle):
     """
     Shuffles the missions between campaigns if enabled.
@@ -1002,6 +1018,7 @@ class Starcraft2Options(PerGameCommonOptions):
     enable_epilogue_missions: EnableEpilogueMissions
     enable_nco_missions: EnableNCOMissions
     enable_race_swap: EnableRaceSwapVariants
+    mission_race_balancing: EnableMissionRaceBalancing
     shuffle_campaigns: ShuffleCampaigns
     shuffle_no_build: ShuffleNoBuild
     starter_unit: StarterUnit

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -827,7 +827,7 @@ class TestItemFiltering(Sc2SetupTestBase):
         world_options = {
             # Reasonably large grid with enough missions to balance races
             'mission_order': options.MissionOrder.option_grid,
-            'campaign_size': campaign_size,
+            'maximum_campaign_size': campaign_size,
             'enable_wol_missions': True,
             'enable_prophecy_missions': True,
             'enable_hots_missions': True,

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -816,3 +816,36 @@ class TestItemFiltering(Sc2SetupTestBase):
         # These items will be in the pool despite exclusions
         self.assertIn(item_names.KERRIGAN_LEAPING_STRIKE, itempool)
         self.assertIn(item_names.KERRIGAN_MEND, itempool)
+
+    
+    def test_fully_balanced_mission_races(self):
+        """
+        Tests whether fully balanced mission race balancing actually is fully balanced.
+        """
+        campaign_size = 57
+        self.assertEqual(campaign_size % 3, 0, "Chosen test size cannot be perfectly balanced")
+        world_options = {
+            # Reasonably large grid with enough missions to balance races
+            'mission_order': options.MissionOrder.option_grid,
+            'campaign_size': campaign_size,
+            'enable_wol_missions': True,
+            'enable_prophecy_missions': True,
+            'enable_hots_missions': True,
+            'enable_lotv_prologue_missions': True,
+            'enable_lotv_missions': True,
+            'enable_epilogue_missions': True,
+            'enable_nco_missions': True,
+            'selected_races': options.SelectRaces.option_all,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
+            'mission_race_balancing': options.EnableMissionRaceBalancing.option_fully_balanced,
+        }
+
+        self.generate_world(world_options)
+        world_regions = [region.name for region in self.multiworld.regions]
+        world_regions.remove('Menu')
+        missions = [mission_tables.lookup_name_to_mission[region] for region in world_regions]
+        race_flags = [mission_tables.MissionFlag.Terran, mission_tables.MissionFlag.Zerg, mission_tables.MissionFlag.Protoss]
+        race_counts = { flag: sum(flag in mission.flags for mission in missions) for flag in race_flags }
+
+        self.assertEqual(race_counts[mission_tables.MissionFlag.Terran], race_counts[mission_tables.MissionFlag.Zerg])
+        self.assertEqual(race_counts[mission_tables.MissionFlag.Zerg], race_counts[mission_tables.MissionFlag.Protoss])


### PR DESCRIPTION
## What is this fixing or adding?
Adds an option to balance mission placements by race. Comes with values `disabled`, `semi_balanced` and `fully_balanced`, defaulting to `semi_balanced`.

I've made the decision for now to **not** count AI allies (with the take over ally option enabled), if only because setting `fully_balanced` and then seeing, for example, an extra Protoss mission in the client because of Harbinger of Oblivion will cause confusion for some users. This can be changed if desired.

This PR also contains some minor changes. I've removed a bit of formatting in the custom order docs' description because it looked a little weird on the webhost, and added a note to the custom order option to say that it does nothing by default, so the option is less spooky to people running into it in a generated template YAML.

## How was this tested?
I generated a few size 57 grids and a few size 9 grids and counted the missions in the client.