### PR TITLE
sc2: Adding Smash and Grab mastery locations for killing the zerg base

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -668,7 +668,7 @@ item_descriptions = {
     item_names.DEVOURER_PRESCIENT_SPORES: "Allows Devourers to attack ground targets.",
     item_names.GUARDIAN_PROLONGED_DISPERSION: "Guardians gain +3 range.",
     item_names.GUARDIAN_PRIMAL_ADAPTATION: "Allows Guardians to attack air units with a decreased attack damage.",
-    item_names.GUARDIAN_SORONAN_ACID: "Guardians deal increased damage to ground targets.",
+    item_names.GUARDIAN_SORONAN_ACID: "Guardians deal +10 increased base damage to ground targets.",
     item_names.GUARDIAN_PROPELLANT_SACS: "Guardians gain increased movement speed.",
     item_names.GUARDIAN_EXPLOSIVE_SPORES: "Allows Guardians to launch an explosive spore at ground targets, dealing damage and knocking them back in an area.",
     item_names.GUARDIAN_PRIMORDIAL_FURY: "Guardians gain increasing attack speed as they attack.",

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1217,7 +1217,7 @@ item_table = {
     item_names.ROACH_HYDRIODIC_BILE:
         ItemData(203 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 3, SC2Race.ZERG, parent_item=item_names.ROACH, classification=ItemClassification.progression),
     item_names.ROACH_ADAPTIVE_PLATING:
-        ItemData(204 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 4, SC2Race.ZERG, parent_item=item_names.ROACH),
+        ItemData(204 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 4, SC2Race.ZERG, parent_item=item_names.ROACH, classification=ItemClassification.progression),
     item_names.ROACH_TUNNELING_CLAWS:
         ItemData(205 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 5, SC2Race.ZERG, parent_item=item_names.ROACH, classification=ItemClassification.filler),
     item_names.HYDRALISK_FRENZY:
@@ -1299,7 +1299,7 @@ item_table = {
     item_names.ULTRALISK_ANABOLIC_SYNTHESIS:
         ItemData(240 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 10, SC2Race.ZERG, parent_item=item_names.ULTRALISK, classification=ItemClassification.filler),
     item_names.ULTRALISK_CHITINOUS_PLATING:
-        ItemData(241 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 11, SC2Race.ZERG, parent_item=item_names.ULTRALISK),
+        ItemData(241 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 11, SC2Race.ZERG, parent_item=item_names.ULTRALISK, classification=ItemClassification.progression),
     item_names.ULTRALISK_ORGANIC_CARAPACE:
         ItemData(242 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 12, SC2Race.ZERG, parent_item=item_names.ULTRALISK),
     item_names.ULTRALISK_RESOURCE_EFFICIENCY:
@@ -1325,7 +1325,7 @@ item_table = {
                  parent_item=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT),
     item_names.GUARDIAN_SORONAN_ACID:
         ItemData(250 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 20, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT),
+                 parent_item=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT, classification=ItemClassification.progression),
     item_names.IMPALER_ADAPTIVE_TALONS:
         ItemData(251 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 21, SC2Race.ZERG,
                  parent_item=item_names.HYDRALISK_IMPALER_ASPECT,
@@ -1424,7 +1424,7 @@ item_table = {
     item_names.PRIMAL_IGNITER_CONCENTRATED_FIRE:
         ItemData(290 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 0, SC2Race.ZERG, parent_item=item_names.ROACH_PRIMAL_IGNITER_ASPECT),
     item_names.PRIMAL_IGNITER_PRIMAL_TENACITY:
-        ItemData(291 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 1, SC2Race.ZERG, parent_item=item_names.ROACH_PRIMAL_IGNITER_ASPECT),
+        ItemData(291 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 1, SC2Race.ZERG, parent_item=item_names.ROACH_PRIMAL_IGNITER_ASPECT, classification=ItemClassification.progression),
     item_names.INFESTED_SCV_BUILD_CHARGES:
         ItemData(292 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 2, SC2Race.ZERG),
     item_names.INFESTED_MARINE_PLAGUED_MUNITIONS:
@@ -1515,7 +1515,7 @@ item_table = {
     item_names.INFESTED_LIBERATOR_VIRAL_CONTAMINATION:
         ItemData(367 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 24, SC2Race.ZERG, parent_item=item_names.INFESTED_LIBERATOR),
     item_names.GUARDIAN_PROPELLANT_SACS:
-        ItemData(368 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 25, SC2Race.ZERG, parent_item=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT),
+        ItemData(368 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 25, SC2Race.ZERG, parent_item=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT, classification=ItemClassification.progression),
     item_names.GUARDIAN_EXPLOSIVE_SPORES:
         ItemData(369 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 26, SC2Race.ZERG, parent_item=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT),
     item_names.GUARDIAN_PRIMORDIAL_FURY:

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1182,10 +1182,10 @@ item_table = {
                  classification=ItemClassification.useful),
     item_names.INFESTED_SIEGE_TANK:
         ItemData(20 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 19, SC2Race.ZERG,
-                 classification=ItemClassification.useful),
+                 classification=ItemClassification.progression),
     item_names.INFESTED_DIAMONDBACK:
         ItemData(21 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 20, SC2Race.ZERG,
-                 classification=ItemClassification.useful),
+                 classification=ItemClassification.progression),
     item_names.INFESTED_BANSHEE:
         ItemData(22 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 21, SC2Race.ZERG,
                  classification=ItemClassification.progression),
@@ -1475,7 +1475,7 @@ item_table = {
     item_names.ULTRALISK_NOXIOUS_STRAIN:
         ItemData(312 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 12, SC2Race.ZERG, parent_item=item_names.ULTRALISK, classification=ItemClassification.filler),
     item_names.ULTRALISK_TORRASQUE_STRAIN:
-        ItemData(313 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 13, SC2Race.ZERG, parent_item=item_names.ULTRALISK),
+        ItemData(313 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 13, SC2Race.ZERG, parent_item=item_names.ULTRALISK, classification=ItemClassification.progression),
 
     item_names.TYRANNOZOR_TYRANTS_PROTECTION:
         ItemData(350 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 8, SC2Race.ZERG, parent_item=item_names.ULTRALISK_TYRANNOZOR_ASPECT),
@@ -1497,7 +1497,7 @@ item_table = {
         ItemData(358 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 16, SC2Race.ZERG, parent_item=item_names.NYDUS_WORM, classification=ItemClassification.useful),
     item_names.INFESTED_SIEGE_TANK_PROGRESSIVE_AUTOMATED_MITOSIS:
         ItemData(359 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Progressive, 0, SC2Race.ZERG,
-                 parent_item=item_names.INFESTED_SIEGE_TANK, quantity=2),
+                 parent_item=item_names.INFESTED_SIEGE_TANK, quantity=2, classification=ItemClassification.progression),
     item_names.INFESTED_SIEGE_TANK_ACIDIC_ENZYMES:
         ItemData(360 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 17, SC2Race.ZERG, parent_item=item_names.INFESTED_SIEGE_TANK),
     item_names.INFESTED_SIEGE_TANK_DEEP_TUNNEL:
@@ -1602,9 +1602,9 @@ item_table = {
     item_names.MACROSCOPIC_RECUPERATION: ItemData(707 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 13, SC2Race.ZERG),
 
     # Morphs
-    item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT: ItemData(800 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 6, SC2Race.ZERG),
+    item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT: ItemData(800 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 6, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT: ItemData(801 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 7, SC2Race.ZERG, classification=ItemClassification.progression),
-    item_names.ROACH_RAVAGER_ASPECT: ItemData(802 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 8, SC2Race.ZERG),
+    item_names.ROACH_RAVAGER_ASPECT: ItemData(802 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 8, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.OVERLORD_OVERSEER_ASPECT: ItemData(803 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 4, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.ROACH_PRIMAL_IGNITER_ASPECT: ItemData(804 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 9, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.ULTRALISK_TYRANNOZOR_ASPECT: ItemData(805 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 10, SC2Race.ZERG, classification=ItemClassification.progression),

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1374,7 +1374,7 @@ item_table = {
         ItemData(265 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 5, SC2Race.ZERG,
                  parent_item=item_names.MUTALISK_CORRUPTOR_BROOD_LORD_ASPECT),
     item_names.INFESTOR_INFESTED_TERRAN:
-        ItemData(266 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 6, SC2Race.ZERG, parent_item=item_names.INFESTOR),
+        ItemData(266 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 6, SC2Race.ZERG, parent_item=item_names.INFESTOR, classification=ItemClassification.progression),
     item_names.INFESTOR_MICROBIAL_SHROUD:
         ItemData(267 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 7, SC2Race.ZERG, parent_item=item_names.INFESTOR),
     item_names.SWARM_QUEEN_SPAWN_LARVAE:

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -360,6 +360,12 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                     and logic.terran_basic_anti_air(state)
                     or logic.terran_competent_anti_air(state)))
         ),
+        make_location_data(SC2Mission.SMASH_AND_GRAB.mission_name, "Defeat Kerrigan", SC2WOL_LOC_ID_OFFSET + 807, LocationType.MASTERY,
+            lambda state: (
+                logic.terran_common_unit(state)
+                and logic.terran_base_trasher(state)
+                and logic.terran_competent_anti_air(state))
+        ),
         make_location_data(SC2Mission.THE_DIG.mission_name, "Victory", SC2WOL_LOC_ID_OFFSET + 900, LocationType.VICTORY,
             lambda state: (
                 logic.terran_basic_anti_air(state)
@@ -2732,6 +2738,11 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                     or logic.zerg_competent_anti_air(state)
                 ))
         ),
+        make_location_data(SC2Mission.SMASH_AND_GRAB_Z.mission_name, "Defeat Kerrigan", SC2_RACESWAP_LOC_ID_OFFSET + 1507, LocationType.MASTERY,
+            lambda state: (
+                logic.zerg_common_unit_competent_aa(state)
+                and logic.zerg_base_buster(state))
+        ),
         make_location_data(SC2Mission.SMASH_AND_GRAB_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1600, LocationType.VICTORY,
             lambda state: (
                 logic.protoss_common_unit(state)
@@ -2768,6 +2779,9 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and ((adv_tactics and logic.protoss_basic_anti_air(state))
                     or logic.protoss_competent_anti_air(state)
                 ))
+        ),
+        make_location_data(SC2Mission.SMASH_AND_GRAB_P.mission_name, "Defeat Kerrigan", SC2_RACESWAP_LOC_ID_OFFSET + 1607, LocationType.MASTERY,
+            logic.protoss_competent_comp
         ),
         make_location_data(SC2Mission.DEVILS_PLAYGROUND_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 2500, LocationType.VICTORY,
             lambda state: (
@@ -2854,7 +2868,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             lambda state: (
                 logic.welcome_to_the_jungle_z_requirement(state)
                 and logic.zerg_competent_anti_air(state)
-                and logic.zerg_big_monsters(state))
+                and logic.zerg_base_buster(state))
         ),
         make_location_data(SC2Mission.WELCOME_TO_THE_JUNGLE_Z.mission_name, "No Terrazine Nodes Sealed", SC2_RACESWAP_LOC_ID_OFFSET + 2706, LocationType.CHALLENGE,
             lambda state: (


### PR DESCRIPTION
## What is this fixing or adding?
Client-side changes for adding a Smash and Grab mastery location.

Pairs with [data PR #308](https://github.com/Ziktofel/Archipelago-SC2-data/pull/308)

## How was this tested?
Gen'd and booted the missions to try collecting them.

Logic could use feedback. Terran logic matches pattern set by WTTJ,  Zerg logic seems good, it could probably include more options but would require promoting more upgrades to progression. Protoss I just chucked in competent comp because everything uses competent comp right now and needs to be broken up anyways under #181.

The zerg logic was fairly involved; I tried to keep with the pattern that this function is fundamentally just selecting one "core" unit that would have sufficient capability upgrades on its own to be the meat of the army (+finite supporting queens in the melee case) to account for anti-air probably costing more.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/af532c26-8a5d-436a-9c09-faac56097715)
![image](https://github.com/user-attachments/assets/96f8fbfa-7546-4948-9fd7-c5f68488dfe3)
![image](https://github.com/user-attachments/assets/94d66af4-f24d-43be-95c7-b75a78cdbfe4)
