### PR TITLE
sc2: non-relative imports

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -11,7 +11,6 @@ from .item.item_tables import (
     ItemData, kerrigan_actives, kerrigan_passives,
     not_balanced_starting_units, WEAPON_ARMOR_UPGRADE_MAX_LEVEL, ZergItemType,
 )
-from . import item
 from . import location_groups
 from .item import FilterItem, ItemFilterFlags, StarcraftItem, item_groups, item_names, item_tables
 from .locations import get_locations, DEFAULT_LOCATION_LIST, get_location_types, get_location_flags, get_plando_locations

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -23,8 +23,8 @@ from pathlib import Path
 # CommonClient import first to trigger ModuleUpdater
 from CommonClient import CommonContext, server_loop, ClientCommandProcessor, gui_enabled, get_base_parser
 from Utils import init_logging, is_windows, async_start
-from worlds.sc2.item import item_names
-from worlds.sc2.item.item_groups import item_name_groups, unlisted_item_name_groups
+from .item import item_names
+from .item.item_groups import item_name_groups, unlisted_item_name_groups
 from . import options
 from .options import (
     MissionOrder, KerriganPrimalStatus, kerrigan_unit_available, KerriganPresence, EnableMorphling,

--- a/worlds/sc2/item/__init__.py
+++ b/worlds/sc2/item/__init__.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from BaseClasses import Item, ItemClassification
-from worlds.sc2.item.item_tables import ItemData
+from .item_tables import ItemData
 
 
 class ItemFilterFlags(enum.IntFlag):

--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -3,7 +3,7 @@ Contains descriptions for Starcraft 2 items.
 """
 import inspect
 
-from worlds.sc2.item import item_tables, item_names
+from . import item_tables, item_names
 
 WEAPON_ARMOR_UPGRADE_NOTE = inspect.cleandoc("""
     Must be researched during the mission if the mission type isn't set to auto-unlock generic upgrades.

--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -1,6 +1,6 @@
 import typing
-from worlds.sc2.item import item_tables, item_names
-from worlds.sc2.mission_tables import campaign_mission_table, SC2Campaign, SC2Mission, SC2Race
+from . import item_tables, item_names
+from ..mission_tables import campaign_mission_table, SC2Campaign, SC2Mission, SC2Race
 
 """
 Item name groups, given to Archipelago and used in YAMLs and /received filtering.

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -4,8 +4,10 @@ from typing import *
 from Options import *
 from Utils import get_fuzzy_results
 from BaseClasses import PlandoOptions
-from .mission_tables import SC2Campaign, SC2Mission, lookup_name_to_mission, MissionPools, get_missions_with_any_flags_in_list, \
+from .mission_tables import (
+    SC2Campaign, SC2Mission, lookup_name_to_mission, MissionPools, get_missions_with_any_flags_in_list,
     campaign_mission_table, SC2Race, MissionFlag
+)
 from .mission_groups import mission_groups, MissionGroupNames
 from .mission_order.options import CustomMissionOrder
 from .item import item_names

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -7,7 +7,7 @@ from .options import (
     GrantStoryTech, GrantStoryLevels, TakeOverAIAllies, SpearOfAdunAutonomouslyCastAbilityPresence,
     get_enabled_campaigns, MissionOrder, EnableMorphling, get_enabled_races
 )
-from worlds.sc2.item.item_tables import (
+from .item.item_tables import (
     tvx_defense_ratings, tvz_defense_ratings, kerrigan_actives, tvx_air_defense_ratings,
     kerrigan_levels, get_full_item_list, zvx_air_defense_ratings, zvx_defense_ratings, pvx_defense_ratings,
     pvz_defense_ratings, no_logic_basic_units, advanced_basic_units, basic_units, upgrade_bundle_inverted_lookup, WEAPON_ARMOR_UPGRADE_MAX_LEVEL


### PR DESCRIPTION
## What is this fixing or adding?
For core reasons, worlds can't do absolute imports within the world. Looks like when the `items` stuff was put in a sub-package, the refactoring tool made things absolute imports, so automated tasks / builds are broken now. This fixes them by making them relative again.

## How was this tested?
Ran unit tests. Hoping I get less spam emails about automated jobs failing.

## If this makes graphical changes, please attach screenshots.
None