### PR TITLE
Void Trade

### DIFF
--- a/worlds/_sc2common/bot/game_data.py
+++ b/worlds/_sc2common/bot/game_data.py
@@ -19,7 +19,7 @@ class GameData:
         """
         :param data:
         """
-        self.abilities: Dict[int, AbilityData] = {}
+        self.abilities: Dict[int, AbilityData] = {a.ability_id: AbilityData(self, a) for a in data.abilities if a.available}
         self.units: Dict[int, UnitTypeData] = {u.unit_id: UnitTypeData(self, u) for u in data.units if u.available}
         self.upgrades: Dict[int, UpgradeData] = {u.upgrade_id: UpgradeData(self, u) for u in data.upgrades}
         # Cached UnitTypeIds so that conversion does not take long. This needs to be moved elsewhere if a new GameData object is created multiple times per game
@@ -40,7 +40,7 @@ class AbilityData:
         self._proto = proto
 
         # What happens if we comment this out? Should this not be commented out? What is its purpose?
-        assert self.id != 0
+        # assert self.id != 0 # let the world burn
 
     def __repr__(self) -> str:
         return f"AbilityData(name={self._proto.button_name})"

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -195,7 +195,7 @@ class SC2World(World):
             for world in self.multiworld.worlds.values()
             if world.game == self.game and world.options.enable_void_trade == EnableVoidTrade.option_true
         ]
-        if len(traders) >= 2:
+        if len(traders) < 2:
             slot_data["enable_void_trade"] = EnableVoidTrade.option_false
 
         return slot_data

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -21,7 +21,7 @@ from .options import (
     KerriganPresence, KerriganPrimalStatus, kerrigan_unit_available, StarterUnit, SpearOfAdunPresence,
     get_enabled_campaigns, SpearOfAdunAutonomouslyCastAbilityPresence, Starcraft2Options,
     GrantStoryTech, GenericUpgradeResearch, GenericUpgradeItems, RequiredTactics,
-    upgrade_included_names
+    upgrade_included_names, EnableVoidTrade
 )
 from .rules import get_basic_units
 from . import settings
@@ -188,6 +188,16 @@ class SC2World(World):
 
         if SC2Campaign.HOTS not in enabled_campaigns:
             slot_data["kerrigan_presence"] = KerriganPresence.option_not_present
+
+        # Disable trade if there is no trade partner
+        traders = [
+            world
+            for world in self.multiworld.worlds.values()
+            if world.game == self.game and world.options.enable_void_trade == EnableVoidTrade.option_true
+        ]
+        if len(traders) >= 2:
+            slot_data["enable_void_trade"] = EnableVoidTrade.option_false
+
         return slot_data
 
     def pre_fill(self) -> None:

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -95,7 +95,7 @@ TRADE_DATASTORAGE_TEAM = "SC2_VoidTrade_" # + Team
 TRADE_DATASTORAGE_SLOT = "slot_" # + Slot
 TRADE_DATASTORAGE_LOCK = "_lock"
 TRADE_LOCK_TIME = 5000 # Time in ms that the DataStorage may be considered safe to edit
-TRADE_LOCK_WAIT_LIMIT = 540000 # Time in ms that the client may spend trying to get a lock (540000 = 9 minutes)
+TRADE_LOCK_WAIT_LIMIT = 540000 / 1.4 # Time in ms that the client may spend trying to get a lock (540000 = 9 minutes, 1.4 is 'faster' game speed's time scale)
 
 # Games
 STARCRAFT2 = "Starcraft 2"

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -975,12 +975,12 @@ class SC2Context(CommonContext):
             # Make sure we're not past the waiting limit
             # SC2 needs to be notified within 10 minutes (training time of the dummy units)
             if self.trade_lock_start is not None:
-                if lock - self.trade_lock_start >= TRADE_LOCK_WAIT_LIMIT:
+                if self.last_bot.time - self.trade_lock_start >= TRADE_LOCK_WAIT_LIMIT:
                     self.trade_lock_wait = 0
                     self.trade_lock_start = None
                     return None
             elif keep_trying:
-                self.trade_lock_start = lock
+                self.trade_lock_start = self.last_bot.time
 
             message_uuid = str(uuid.uuid4())
             await self.send_msgs([{

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -370,7 +370,7 @@ class EnableVoidTrade(Toggle):
     Enables the Void Trade Wormhole to be built from the Advanced Construction tab of SCVs, Drones and Probes.  
     This structure allows sending units to the Archipelago server, as well as buying random units from the server.  
     
-    This feature requires at least two Starcraft II worlds.  You cannot receive units that you sent.
+    Note: Always disabled if there is no other Starcraft II world with Void Trade enabled in the multiworld.  You cannot receive units that you send.
     """
     display_name = "Enable Void Trade"
 

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -365,6 +365,16 @@ class RequiredTactics(Choice):
     option_no_logic = 2
 
 
+class EnableVoidTrade(Toggle):
+    """
+    Enables the Void Trade Wormhole to be built from the Advanced Construction tab of SCVs, Drones and Probes.  
+    This structure allows sending units to the Archipelago server, as well as buying random units from the server.  
+    
+    This feature requires at least two Starcraft II worlds.  You cannot receive units that you sent.
+    """
+    display_name = "Enable Void Trade"
+
+
 class GenericUpgradeMissions(Range):
     """
     Determines the percentage of missions in the mission order that must be completed before
@@ -1023,6 +1033,7 @@ class Starcraft2Options(PerGameCommonOptions):
     shuffle_no_build: ShuffleNoBuild
     starter_unit: StarterUnit
     required_tactics: RequiredTactics
+    enable_void_trade: EnableVoidTrade
     ensure_generic_items: EnsureGenericItems
     min_number_of_upgrades: MinNumberOfUpgrades
     max_number_of_upgrades: MaxNumberOfUpgrades

--- a/worlds/sc2/transfer_data.py
+++ b/worlds/sc2/transfer_data.py
@@ -1,0 +1,29 @@
+from typing import Dict
+
+"""
+This file is for handling SC2 data read via the bot
+"""
+
+normalized_unit_types: Dict[str, str] = {
+    # Thor morphs
+    "AP_ThorAP": "AP_Thor",
+    "AP_MercThorAP": "AP_MercThor",
+    "AP_ThorMengskSieged": "AP_ThorMengsk",
+    "AP_ThorMengskAP": "AP_ThorMengsk",
+    # Siege Tank morphs
+    "AP_SiegeTankSiegedTransportable": "AP_SiegeTank",
+    "AP_SiegeTankMengskSiegedTransportable": "AP_SiegeTankMengsk",
+    "AP_SiegeBreakerSiegedTransportable": "AP_SiegeBreaker",
+    "AP_InfestedSiegeBreakerSiegedTransportable": "AP_InfestedSiegeBreaker",
+    "AP_StukovInfestedSiegeTank": "AP_StukovInfestedSiegeTankUprooted",
+    # Cargo size upgrades
+    "AP_FirebatOptimizedLogistics": "AP_Firebat",
+    "AP_DevilDogOptimizedLogistics": "AP_DevilDog",
+    "AP_GhostResourceEfficiency": "AP_Ghost",
+    "AP_GhostMengskResourceEfficiency": "AP_GhostMengsk",
+    "AP_SpectreResourceEfficiency": "AP_Spectre",
+    "AP_UltraliskResourceEfficiency": "AP_Ultralisk",
+    "AP_MercUltraliskResourceEfficiency": "AP_MercUltralisk",
+    "AP_ReaperResourceEfficiency": "AP_Reaper",
+    "AP_MercReaperResourceEfficiency": "AP_MercReaper",
+}


### PR DESCRIPTION
## What is this fixing or adding?
This adds an option for trade functionality based on my proposal here: https://github.com/Ziktofel/Archipelago/issues/336#issuecomment-2466765309
The concrete implementation has changed slightly, but overall the functionality is the same: Enable the option, build the structure, send units for free or get units for a token cost.
The core of the networking system was taken from Pokemon Emerald's Wonder Trade system.

This also includes a small patch to the bot, to allow reading ability data from the game.

The accompanying data PR is here: https://github.com/Ziktofel/Archipelago-SC2-data/pull/315

## How was this tested?
Generating a multiworld with 4 players, of whom 3 had trade enabled, and then sending various units back and forth. I also made sure to at least load a map from each campaign mod (WoL, HotS, LotV Prologue, LotV and NCO) to test the updated dependencies.

Notably simultaneous trade requests weren't tested, owing to me only being one person, but I have some confidence that it works since it's based on a working system.