### PR TITLE
sc2: Slightly loosened zerg maw requirement to cross the gap

### DIFF
--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1184,7 +1184,7 @@ item_table = {
                  classification=ItemClassification.progression),
     item_names.ECHIDNA_WORM:
         ItemData(19 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 18, SC2Race.ZERG,
-                 classification=ItemClassification.useful),
+                 classification=ItemClassification.progression),
     item_names.INFESTED_SIEGE_TANK:
         ItemData(20 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 19, SC2Race.ZERG,
                  classification=ItemClassification.progression),
@@ -1595,7 +1595,7 @@ item_table = {
     item_names.HUNTER_KILLERS: ItemData(604 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 4, SC2Race.ZERG),
     item_names.TORRASQUE_MERC: ItemData(605 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 5, SC2Race.ZERG),
     item_names.HUNTERLING: ItemData(606 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 6, SC2Race.ZERG, classification=ItemClassification.progression),
-    item_names.YGGDRASIL: ItemData(607 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 7, SC2Race.ZERG),
+    item_names.YGGDRASIL: ItemData(607 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 7, SC2Race.ZERG, classification=ItemClassification.progression),
 
 
     # Misc Upgrades

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -528,58 +528,59 @@ class SC2Logic:
     def zerg_maw_requirement(self, state: CollectionState) -> bool:
         """
         Ability to cross defended gaps, deal with skytoss, and avoid costly losses.
-        :param state:
-        :return:
         """
         return (
                 state.has(item_names.SWARM_QUEEN, self.player)
-                and (state.has(item_names.NYDUS_WORM, self.player)
-                     or (self.advanced_tactics and state.has(item_names.OVERLORD_VENTRAL_SACS, self.player)))
+                # Cross the gap
+                and (state.has_any((item_names.NYDUS_WORM, item_names.OVERLORD_VENTRAL_SACS), self.player)
+                     or (self.advanced_tactics and state.has(item_names.ECHIDNA_WORM, self.player)))
+                # Air to ground
                 and (self.morph_brood_lord(state) or self.morph_guardian(state))
+                # Ground to air
                 and (
-                        state.has(item_names.INFESTOR, self.player)
-                        or self.morph_tyrannozor(state)
-                        or state.has_all({item_names.SWARM_HOST, item_names.SWARM_HOST_RESOURCE_EFFICIENCY, item_names.SWARM_HOST_PRESSURIZED_GLANDS}, self.player)
-                        or state.has_all({item_names.HYDRALISK, item_names.HYDRALISK_RESOURCE_EFFICIENCY}, self.player)
-                        or state.has_all({item_names.INFESTED_DIAMONDBACK, item_names.INFESTED_DIAMONDBACK_PROGRESSIVE_FUNGAL_SNARE}, self.player)
-                    )
+                    state.has(item_names.INFESTOR, self.player)
+                    or self.morph_tyrannozor(state)
+                    or state.has_all({item_names.SWARM_HOST, item_names.SWARM_HOST_RESOURCE_EFFICIENCY, item_names.SWARM_HOST_PRESSURIZED_GLANDS}, self.player)
+                    or state.has_all({item_names.HYDRALISK, item_names.HYDRALISK_RESOURCE_EFFICIENCY}, self.player)
+                    or state.has_all({item_names.INFESTED_DIAMONDBACK, item_names.INFESTED_DIAMONDBACK_PROGRESSIVE_FUNGAL_SNARE}, self.player)
+                )
+                # Survives rip-field
                 and (state.has_any({item_names.ABERRATION, item_names.ROACH, item_names.ULTRALISK}, self.player)
                      or self.morph_tyrannozor(state))
+                # Air-to-air
                 and (state.has_any({item_names.MUTALISK, item_names.CORRUPTOR, item_names.INFESTED_LIBERATOR, item_names.BROOD_QUEEN}, self.player))
+                # Upgrades / general
                 and self.zerg_competent_comp(state)
         )
 
     def protoss_maw_requirement(self, state: CollectionState) -> bool:
         """
         Ability to cross defended gaps and deal with skytoss.
-        :param state:
-        :return:
         """
         return (
-                (state.has(item_names.WARP_PRISM, self.player)
-                 or (self.advanced_tactics and state.has(item_names.ARBITER, self.player))
-                 )
-                and self.protoss_common_unit_anti_armor_air(state)
-                and self.protoss_fleet(state)
+            (
+                state.has(item_names.WARP_PRISM, self.player)
+                or (self.advanced_tactics and state.has(item_names.ARBITER, self.player))
+            )
+            and self.protoss_common_unit_anti_armor_air(state)
+            and self.protoss_fleet(state)
         )
 
     def terran_sustainable_mech_heal(self, state: CollectionState) -> bool:
         """
         Can heal mech units without spending resources
-        :param state:
-        :return:
         """
         return (
-                state.has(item_names.SCIENCE_VESSEL, self.player)
-                or (
-                    state.has_any({item_names.MEDIC, item_names.FIELD_RESPONSE_THETA}, self.player)
-                    and state.has(item_names.MEDIC_ADAPTIVE_MEDPACKS, self.player)
+            state.has(item_names.SCIENCE_VESSEL, self.player)
+            or (
+                state.has_any({item_names.MEDIC, item_names.FIELD_RESPONSE_THETA}, self.player)
+                and state.has(item_names.MEDIC_ADAPTIVE_MEDPACKS, self.player)
             )
-                or state.count(item_names.PROGRESSIVE_REGENERATIVE_BIO_STEEL, self.player) >= 3
-                or (self.advanced_tactics
+            or state.count(item_names.PROGRESSIVE_REGENERATIVE_BIO_STEEL, self.player) >= 3
+            or (self.advanced_tactics
                 and (
-                            state.has_all({item_names.RAVEN, item_names.RAVEN_BIO_MECHANICAL_REPAIR_DRONE}, self.player)
-                            or state.count(item_names.PROGRESSIVE_REGENERATIVE_BIO_STEEL, self.player) >= 2
+                    state.has_all({item_names.RAVEN, item_names.RAVEN_BIO_MECHANICAL_REPAIR_DRONE}, self.player)
+                    or state.count(item_names.PROGRESSIVE_REGENERATIVE_BIO_STEEL, self.player) >= 2
                 )
             )
         )

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -533,7 +533,7 @@ class SC2Logic:
                 state.has(item_names.SWARM_QUEEN, self.player)
                 # Cross the gap
                 and (state.has_any((item_names.NYDUS_WORM, item_names.OVERLORD_VENTRAL_SACS), self.player)
-                     or (self.advanced_tactics and state.has_any((item_names.ECHIDNA_WORM, item_names.YGGDRASIL), self.player)))
+                     or (self.advanced_tactics and state.has(item_names.YGGDRASIL, self.player)))
                 # Air to ground
                 and (self.morph_brood_lord(state) or self.morph_guardian(state))
                 # Ground to air

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -533,7 +533,7 @@ class SC2Logic:
                 state.has(item_names.SWARM_QUEEN, self.player)
                 # Cross the gap
                 and (state.has_any((item_names.NYDUS_WORM, item_names.OVERLORD_VENTRAL_SACS), self.player)
-                     or (self.advanced_tactics and state.has(item_names.ECHIDNA_WORM, self.player)))
+                     or (self.advanced_tactics and state.has_any((item_names.ECHIDNA_WORM, item_names.YGGDRASIL), self.player)))
                 # Air to ground
                 and (self.morph_brood_lord(state) or self.morph_guardian(state))
                 # Ground to air


### PR DESCRIPTION
also tidied style of some logic rules

## What is this fixing or adding?
Minor adjustment to Zerg Maw logic following feedback from Snarky. Also tidied style a little.

Only non-comment change should be that Overlord Drop is no longer advanced-tactics only, and echidna worm and yggdrasil are advanced-tactics options to cross the gap. Also provided comments to explain what capability each section adds (hopefully this is useful to a future logic pass where we allow for only a subset of capabilities rather than all of them)

## How was this tested?
Ran unit tests

## If this makes graphical changes, please attach screenshots.
None.