### PR TITLE
Fix regular mission orders to generate at size 1

### DIFF
--- a/worlds/sc2/regions.py
+++ b/worlds/sc2/regions.py
@@ -423,7 +423,7 @@ def make_hopscotch(world: 'SC2World', size: int) -> Dict[str, Dict[str, Any]]:
 
 def create_dynamic_mission_order(world: 'SC2World', mission_order_type: int, mission_pools: SC2MOGenMissionPools) -> Dict[str, Dict[str, Any]]:
     num_missions = min(mission_pools.get_allowed_mission_count(), get_option_value(world, "maximum_campaign_size"))
-    num_missions = max(2, num_missions)
+    num_missions = max(1, num_missions)
     if mission_order_type == MissionOrder.option_golden_path:
         return make_golden_path(world, num_missions)
     


### PR DESCRIPTION
## What is this fixing or adding?
This allows non-custom mission orders to generate with only one mission.

## How was this tested?
Generated a game with `mission_order: grid` and `maximum_campaign_size: 1`.