### PR TITLE
SC2: Add Baneling Launch upgrade for Aberration

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -707,6 +707,10 @@ item_descriptions = {
     item_names.ABERRATION_PROTECTIVE_COVER: "Aberrations grant damage reduction to allied units directly beneath them.",
     item_names.ABERRATION_BANELING_INCUBATION: "Aberrations spawn 2 Banelings upon death.",
     item_names.ABERRATION_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(item_names.ABERRATION),
+    item_names.ABERRATION_PROGRESSIVE_BANELING_LAUNCH: inspect.cleandoc("""
+        Level 1: Allows Aberrations to periodically throw generated Banelings at air targets.
+        Level 2: Can store up to 3 Banelings. Can consume Banelings to recharge faster. Thrown Banelings benefit from Baneling upgrades. 
+    """),
     item_names.CORRUPTOR_MONSTROUS_RESILIENCE: "Corruptors gain +100 life.",
     item_names.CORRUPTOR_CONSTRUCT_REGENERATION: "Corruptors gain increased life regeneration.",
     item_names.CORRUPTOR_SCOURGE_INCUBATION: "Corruptors spawn 2 Scourge upon death (3 with Swarm Scourge).",

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -486,6 +486,7 @@ ABERRATION_CONSTRUCT_REGENERATION                 = "Construct Regeneration (Abe
 ABERRATION_BANELING_INCUBATION                    = "Baneling Incubation (Aberration)"
 ABERRATION_PROTECTIVE_COVER                       = "Protective Cover (Aberration)"
 ABERRATION_RESOURCE_EFFICIENCY                    = "Resource Efficiency (Aberration)"
+ABERRATION_PROGRESSIVE_BANELING_LAUNCH            = "Progressive Baneling Launch (Aberration)"
 CORRUPTOR_MONSTROUS_RESILIENCE                    = "Monstrous Resilience (Corruptor)"
 CORRUPTOR_CONSTRUCT_REGENERATION                  = "Construct Regeneration (Corruptor)"
 CORRUPTOR_SCOURGE_INCUBATION                      = "Scourge Incubation (Corruptor)"

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1549,7 +1549,9 @@ item_table = {
     item_names.INFESTED_LIBERATOR_DEFENDER_MODE:
         ItemData(380 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 8, SC2Race.ZERG, parent_item=item_names.INFESTED_LIBERATOR,
                  classification=ItemClassification.progression),
-
+    item_names.ABERRATION_PROGRESSIVE_BANELING_LAUNCH:
+        ItemData(381 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Progressive, 4, SC2Race.ZERG, parent_item=item_names.ABERRATION, quantity=2),
+    
     item_names.KERRIGAN_KINETIC_BLAST: ItemData(400 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 0, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.KERRIGAN_HEROIC_FORTITUDE: ItemData(401 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 1, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.KERRIGAN_LEAPING_STRIKE: ItemData(402 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 2, SC2Race.ZERG, classification=ItemClassification.progression),


### PR DESCRIPTION
### What is this fixing or adding?

This adds a progressive upgrade for the Aberration that allows it to throw Banelings at air units.
Level 1 allows the Aberration to generate 1 Baneling to throw at air units every 10 seconds for 30 AoE damage.
Level 2 allows the Aberration to store up to 3 Banelings to throw. Additionally, it can now consume Banelings to instantly get another charge. With the level 2 upgrade, launched Banelings are also affected by Baneling upgrades (damage to main target, increased radius, spawn splitterlings, heal).

[Data PR](https://github.com/Ziktofel/Archipelago-SC2-data/pull/322)

### How was this tested?

Generated a local campaign with 1 zerg mission, added Aberrations and the Baneling Launch upgrade with server commands.
