### PR TITLE
sc2: Fixing a potentially broken CMO depth assert; improving error message on disconnected CMO

### DIFF
--- a/worlds/sc2/mission_order/structs.py
+++ b/worlds/sc2/mission_order/structs.py
@@ -217,8 +217,7 @@ class SC2MissionOrder(MissionOrderNode):
             # Check for accessible missions
             cur_missions: Set[SC2MOGenMission] = {
                 mission for mission in next_missions
-                if not mission.option_empty
-                and mission.is_unlocked(beaten_missions)
+                if mission.is_unlocked(beaten_missions)
             }
             if len(cur_missions) == 0:
                 raise Exception(f"Mission order ran out of accessible missions during iteration {iterations}")
@@ -231,9 +230,7 @@ class SC2MissionOrder(MissionOrderNode):
                 # If the beaten missions at depth X unlock a mission, said mission can be beaten at depth X+1 
                 mission.min_depth = mission.entry_rule.get_depth(beaten_missions) + 1
                 new_next = [
-                    next_mission for next_mission in mission.next
-                    if not next_mission.option_empty
-                    and not (
+                    next_mission for next_mission in mission.next if not (
                         next_mission in cur_missions
                         or next_mission in beaten_missions
                         or next_mission in new_beaten_missions
@@ -710,23 +707,15 @@ class SC2MOGenLayout(MissionOrderNode):
                 mission.next = [self.missions[idx] for idx in mission.option_next]
         
         # Set up missions' prev data
-        seen_missions: Set[SC2MOGenMission] = set()
-        cur_missions: List[SC2MOGenMission] = [mission for mission in self.entrances]
-        while len(cur_missions) > 0:
-            mission = cur_missions.pop()
-            seen_missions.add(mission)
+        for mission in self.missions:
             for next_mission in mission.next:
                 next_mission.prev.append(mission)
-                if next_mission not in seen_missions and \
-                   next_mission not in cur_missions:
-                    cur_missions.append(next_mission)
         
         # Remove empty missions from access data
         for mission in self.missions:
             if mission.option_empty:
                 for next_mission in mission.next:
-                    if mission in next_mission.prev:
-                        next_mission.prev.remove(mission)
+                    next_mission.prev.remove(mission)
                 mission.next.clear()
                 for prev_mission in mission.prev:
                     prev_mission.next.remove(mission)


### PR DESCRIPTION
## What is this fixing or adding?
I was encountering a few weird errors while playing around with CMO.

### Issue 1: Poor error message
If a CMO is not connected / there is no path to the goal in a layout, then the user just gets a nondescript AssertionError. I added a message so it would actually tell the user what went wrong

### Issue 2: Ghost missions
The assert could sometimes fail with `len(beaten_missions)` being _greater than_ the number of missions in all campaigns. The yaml I submitted was odd to begin with (generated the CMO with a script, and the script had bugs), but it seems that the `next` section of the CMO causes the beaten missions check to sometimes count empty mission slots?

In the yaml linked below, len(beaten_missions) was 116 and the number of missions in the campaign was 106 if I'm remembering the numbers correctly:
[broken_logo.zip](https://github.com/user-attachments/files/17930190/broken_logo.zip)

(with seed `36823199845345298932`)

I don't know why exactly that yaml caused the ghost missions to count. I briefly attempted to recreate the effect with simpler connections (real->empty, empty->real, real->empty->real), but that didn't recreate it. I gave up trying to recreate it intentionally when I got the original yaml generating.

## How was this tested?
Generated from the same broken yaml as before; it actually generated. Generated from other broken yamls that were disconnected; verified the error message was a little nicer.

## If this makes graphical changes, please attach screenshots.
Not really.