### PR TITLE
Add index function support to entry rule scope & mission slot next options

### DIFF
--- a/worlds/sc2/docs/custom_mission_orders_en.md
+++ b/worlds/sc2/docs/custom_mission_orders_en.md
@@ -382,7 +382,7 @@ These keys will never be used by the generator unless you specify them yourself.
 
 The Beat and Count rules both require a list of scopes. This list accepts addresses towards other parts of the mission order.
 
-The basic form of an address is `<Campaign>/<Layout>/<Mission>`, where `<Campaign>` and `<Layout>` are the definition names (not `display_names`!) of a campaign and a layout within that campaign, and `<Mission>` is the index of a mission slot in that layout. The indices of mission slots are determined by the layout's type.
+The basic form of an address is `<Campaign>/<Layout>/<Mission>`, where `<Campaign>` and `<Layout>` are the definition names (not `display_names`!) of a campaign and a layout within that campaign, and `<Mission>` is the index of a mission slot in that layout or an index function for the layout's type. See the section on your layout's type to find valid indices and functions.
 
 If you don't want to point all the way down to a mission slot, you can omit the later parts. `<Campaign>` and `<Campaign>/<Layout>` are valid addresses, and will point to the entire specified campaign or layout.
 
@@ -706,8 +706,9 @@ The following example shows ways to access and modify missions:
         # This sets the mission at index 1 to be an exit
         - index: 1
           exit: true
-        # Indices can be special terms
-        # Valid terms are 'exits', 'entrances', and 'all'
+        # Indices can be special index functions
+        # Valid functions are 'exits', 'entrances', and 'all'
+        # These are available for all types of layouts
         # This takes all exits, including the one set above,
         # and turns them into non-exits
         - index: exits
@@ -756,7 +757,7 @@ Layout types have their own means of creating blank spaces in the client, and so
 ```yaml
 next: []
 ```
-Valid values are indices of other missions within the same layout. Note that this does not accept addresses.
+Valid values are indices of other missions within the same layout and index functions for the layout's type. Note that this does not accept addresses.
 
 This is the mechanism layout types use to establish mission flow. Overriding this will break the intended order of missions within a type. If you wish to add on to the type's flow rather than replace it, you must manually include the indices intended by the type.
 

--- a/worlds/sc2/mission_order/options.py
+++ b/worlds/sc2/mission_order/options.py
@@ -148,7 +148,7 @@ class CustomMissionOrder(OptionDict):
                     Optional("exit"): bool,
                     Optional("goal"): bool,
                     Optional("empty"): bool,
-                    Optional("next"): [int],
+                    Optional("next"): [Or(int, str)],
                     Optional("entry_rules"): [EntryRule],
                     Optional("mission_pool"): {int},
                     Optional("difficulty"): Difficulty,
@@ -274,7 +274,7 @@ def _resolve_special_option(option: str, option_value: Any) -> Any:
         else:
             return [str(option_value)]
         
-    if option == "index":
+    if option in ["index", "next"]:
         # All index values could be ranges
         if type(option_value) == list:
             # Flatten any nested lists
@@ -387,20 +387,20 @@ def _get_target_missions(term: str) -> Set[int]:
 
 # Class-agnostic version of AP Options.Range.custom_range
 def _custom_range(text: str) -> int:
-        textsplit = text.split("-")
-        try:
-            random_range = [int(textsplit[len(textsplit) - 2]), int(textsplit[len(textsplit) - 1])]
-        except ValueError:
-            raise ValueError(f"Invalid random range {text} for option {CustomMissionOrder.__name__}")
-        random_range.sort()
-        if text.startswith("random-range-low"):
-            return _triangular(random_range[0], random_range[1], random_range[0])
-        elif text.startswith("random-range-middle"):
-            return _triangular(random_range[0], random_range[1])
-        elif text.startswith("random-range-high"):
-            return _triangular(random_range[0], random_range[1], random_range[1])
-        else:
-            return random.randint(random_range[0], random_range[1])
+    textsplit = text.split("-")
+    try:
+        random_range = [int(textsplit[len(textsplit) - 2]), int(textsplit[len(textsplit) - 1])]
+    except ValueError:
+        raise ValueError(f"Invalid random range {text} for option {CustomMissionOrder.__name__}")
+    random_range.sort()
+    if text.startswith("random-range-low"):
+        return _triangular(random_range[0], random_range[1], random_range[0])
+    elif text.startswith("random-range-middle"):
+        return _triangular(random_range[0], random_range[1])
+    elif text.startswith("random-range-high"):
+        return _triangular(random_range[0], random_range[1], random_range[1])
+    else:
+        return random.randint(random_range[0], random_range[1])
 
 def _triangular(lower: int, end: int, tri: typing.Optional[int] = None) -> int:
     return int(round(random.triangular(lower, end, tri), 0))


### PR DESCRIPTION
## What is this fixing or adding?
This enhances the `scope` component of entry rules and the `next` option for mission slots to support index functions, as defined by a layout's type. Relevant documentation is updated to reflect this change.

## How was this tested?
I generated with the below mission order and checked the requirements in the client.
```yaml
  custom_mission_order:
    test:
      type: grid
      size: 5
      width: 1
      missions:
      - index: 0
        next: rect(0, 1, 1, 4)
      - index: exits
        entry_rules:
        - scope: "../rect(0, 0, 1, 3)"
```