### PR TITLE
sc2: Adding settings to control the mapping of race to colour in the launcher GUI

### DIFF
--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -133,6 +133,7 @@ class SC2Manager(GameManager):
     refresh_from_launching = True
     first_check = True
     first_mission = ""
+    button_colours: Dict[SC2Race, Tuple[float, float, float]] = {}
     ctx: SC2Context
 
     def __init__(self, ctx: SC2Context) -> None:
@@ -147,6 +148,11 @@ class SC2Manager(GameManager):
         Window.size = window_width, window_height
         for startup_warning in warnings:
             logging.getLogger("Starcraft2").warning(f"Startup WARNING: {startup_warning}")
+        for race in (SC2Race.TERRAN, SC2Race.PROTOSS, SC2Race.ZERG):
+            errors, colour = gui_config.get_button_colour(race.name)
+            self.button_colours[race] = colour
+            for error in errors:
+                logging.getLogger("Starcraft2").warning(f"{race.name.title()} button colour setting: {error}")
 
     def clear_tooltip(self) -> None:
         if self.ctx.current_tooltip:
@@ -272,13 +278,8 @@ class SC2Manager(GameManager):
                         if mission_race == SC2Race.ANY:
                             mission_race = mission_obj.campaign.race
                         race = campaign_race_exceptions.get(mission_obj, mission_race)
-                        racial_colors = {
-                            SC2Race.TERRAN: (0.24, 0.84, 0.68),
-                            SC2Race.ZERG: (1, 0.65, 0.37),
-                            SC2Race.PROTOSS: (0.55, 0.7, 1)
-                        }
-                        if race in racial_colors:
-                            mission_button.background_color = racial_colors[race]
+                        if race in self.button_colours:
+                            mission_button.background_color = self.button_colours[race]
                         mission_button.tooltip_text = tooltip
                         mission_button.bind(on_press=self.mission_callback)
                         self.mission_id_to_button[mission_id] = mission_button

--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -133,7 +133,7 @@ class SC2Manager(GameManager):
     refresh_from_launching = True
     first_check = True
     first_mission = ""
-    button_colours: Dict[SC2Race, Tuple[float, float, float]] = {}
+    button_colors: Dict[SC2Race, Tuple[float, float, float]] = {}
     ctx: SC2Context
 
     def __init__(self, ctx: SC2Context) -> None:
@@ -149,10 +149,10 @@ class SC2Manager(GameManager):
         for startup_warning in warnings:
             logging.getLogger("Starcraft2").warning(f"Startup WARNING: {startup_warning}")
         for race in (SC2Race.TERRAN, SC2Race.PROTOSS, SC2Race.ZERG):
-            errors, colour = gui_config.get_button_colour(race.name)
-            self.button_colours[race] = colour
+            errors, color = gui_config.get_button_color(race.name)
+            self.button_colors[race] = color
             for error in errors:
-                logging.getLogger("Starcraft2").warning(f"{race.name.title()} button colour setting: {error}")
+                logging.getLogger("Starcraft2").warning(f"{race.name.title()} button color setting: {error}")
 
     def clear_tooltip(self) -> None:
         if self.ctx.current_tooltip:
@@ -278,8 +278,8 @@ class SC2Manager(GameManager):
                         if mission_race == SC2Race.ANY:
                             mission_race = mission_obj.campaign.race
                         race = campaign_race_exceptions.get(mission_obj, mission_race)
-                        if race in self.button_colours:
-                            mission_button.background_color = self.button_colours[race]
+                        if race in self.button_colors:
+                            mission_button.background_color = self.button_colors[race]
                         mission_button.tooltip_text = tooltip
                         mission_button.bind(on_press=self.mission_callback)
                         self.mission_id_to_button[mission_id] = mission_button

--- a/worlds/sc2/gui_config.py
+++ b/worlds/sc2/gui_config.py
@@ -28,41 +28,41 @@ def get_window_defaults() -> Tuple[List[str], int, int]:
     return warnings, window_width, window_height
 
 
-def validate_colour(colour: Any, default: Tuple[float, float, float]) -> Tuple[Tuple[str, ...], Tuple[float, float, float]]:
-    if isinstance(colour, int):
-        if colour < 0:
-            return ('Integer colour was negative; expected a value from 0 to 0xffffff',), default
+def validate_color(color: Any, default: Tuple[float, float, float]) -> Tuple[Tuple[str, ...], Tuple[float, float, float]]:
+    if isinstance(color, int):
+        if color < 0:
+            return ('Integer color was negative; expected a value from 0 to 0xffffff',), default
         return (), (
-            ((colour >> 8) & 0xff) / 255,
-            ((colour >> 4) & 0xff) / 255,
-            ((colour >> 0) & 0xff) / 255,
+            ((color >> 8) & 0xff) / 255,
+            ((color >> 4) & 0xff) / 255,
+            ((color >> 0) & 0xff) / 255,
         )
-    elif colour == 'default':
+    elif color == 'default':
         return (), default
-    elif colour == 'white':
+    elif color == 'white':
         return (), (0.9, 0.9, 0.9)
-    elif colour == 'black':
+    elif color == 'black':
         return (), (0.0, 0.0, 0.0)
-    elif colour == 'grey':
+    elif color == 'grey':
         return (), (0.345, 0.345, 0.345)
-    elif colour == 'red':
+    elif color == 'red':
         return (), (0.85, 0.2, 0.1)
-    elif colour == 'orange':
+    elif color == 'orange':
         return (), (1.0, 0.65, 0.37)
-    elif colour == 'green':
+    elif color == 'green':
         return (), (0.24, 0.84, 0.55)
-    elif colour == 'blue':
+    elif color == 'blue':
         return (), (0.3, 0.4, 1.0)
-    elif colour == 'pink':
+    elif color == 'pink':
         return (), (0.886, 0.176, 0.843)
-    elif not isinstance(colour, list):
-        return (f'Invalid type {type(colour)}; expected 3-element list or integer',), default
-    elif len(colour) != 3:
-        return (f'Wrong number of elements in colour; expected 3, got {len(colour)}',), default
+    elif not isinstance(color, list):
+        return (f'Invalid type {type(color)}; expected 3-element list or integer',), default
+    elif len(color) != 3:
+        return (f'Wrong number of elements in color; expected 3, got {len(color)}',), default
     result: list[float] = [0.0, 0.0, 0.0]
     errors: List[str] = []
     expected = 'expected a number from 0 to 1'
-    for index, element in enumerate(colour):
+    for index, element in enumerate(color):
         if isinstance(element, int):
             element = float(element)
         if not isinstance(element, float):
@@ -79,20 +79,20 @@ def validate_colour(colour: Any, default: Tuple[float, float, float]) -> Tuple[T
     return tuple(errors), tuple(result)
 
 
-def get_button_colour(race: str) -> Tuple[Tuple[str, ...], Tuple[float, float, float]]:
+def get_button_color(race: str) -> Tuple[Tuple[str, ...], Tuple[float, float, float]]:
     from . import SC2World
-    baseline_colour = 0.345  # the button graphic is grey, with this value in each colour channel
+    baseline_color = 0.345  # the button graphic is grey, with this value in each color channel
     if race == 'TERRAN':
-        user_colour = SC2World.settings.terran_button_colour
-        default_colour = (0.0838, 0.2898, 0.2346)
+        user_color = SC2World.settings.terran_button_color
+        default_color = (0.0838, 0.2898, 0.2346)
     elif race == 'PROTOSS':
-        user_colour = SC2World.settings.protoss_button_colour
-        default_colour = (0.345, 0.22425, 0.12765)
+        user_color = SC2World.settings.protoss_button_color
+        default_color = (0.345, 0.22425, 0.12765)
     elif race == 'ZERG':
-        user_colour = SC2World.settings.zerg_button_colour
-        default_colour = (0.18975, 0.2415, 0.345)
+        user_color = SC2World.settings.zerg_button_color
+        default_color = (0.18975, 0.2415, 0.345)
     else:
-        user_colour = [baseline_colour, baseline_colour, baseline_colour]
-        default_colour = (baseline_colour, baseline_colour, baseline_colour)
-    errors, colour = validate_colour(user_colour, default_colour)
-    return errors, tuple(x / baseline_colour for x in colour)
+        user_color = [baseline_color, baseline_color, baseline_color]
+        default_color = (baseline_color, baseline_color, baseline_color)
+    errors, color = validate_color(user_color, default_color)
+    return errors, tuple(x / baseline_color for x in color)

--- a/worlds/sc2/gui_config.py
+++ b/worlds/sc2/gui_config.py
@@ -2,9 +2,10 @@
 Import this before importing client_gui.py to set window defaults from world settings.
 """
 from .settings import Starcraft2Settings
-from typing import List
+from typing import List, Tuple, Any
 
-def get_window_defaults() -> List[str]:
+
+def get_window_defaults() -> Tuple[List[str], int, int]:
     """
     Gets the window size options from the sc2 settings.
     Returns a list of warnings to be printed once the GUI is started, followed by the window width and height
@@ -25,3 +26,69 @@ def get_window_defaults() -> List[str]:
         window_width = Starcraft2Settings.window_width
 
     return warnings, window_width, window_height
+
+
+def validate_colour(colour: Any, default: Tuple[float, float, float]) -> Tuple[Tuple[str, ...], Tuple[float, float, float]]:
+    if isinstance(colour, int):
+        return (), (
+            ((colour >> 8) & 0xff) / 255,
+            ((colour >> 4) & 0xff) / 255,
+            ((colour >> 0) & 0xff) / 255,
+        )
+    elif  colour == 'white':
+        return (), (0.9, 0.9, 0.9)
+    elif  colour == 'black':
+        return (), (0.0, 0.0, 0.0)
+    elif  colour == 'grey':
+        return (), (0.345, 0.345, 0.345)
+    elif  colour == 'red':
+        return (), (0.85, 0.2, 0.1)
+    elif  colour == 'orange':
+        return (), (1.0, 0.65, 0.37)
+    elif colour == 'green':
+        return (), (0.24, 0.84, 0.55)
+    elif colour == 'blue':
+        return (), (0.3, 0.4, 1.0)
+    elif not isinstance(colour, list):
+        return (f'Invalid type {type(colour)}; expected 3-element list or integer',), default
+    elif len(colour) != 3:
+        return (f'Wrong number of elements in colour; expected 3, got {len(colour)}',), default
+    result: list[float] = [0.0, 0.0, 0.0]
+    errors: List[str] = []
+    expected = 'expected a number from 0 to 1'
+    for index, element in enumerate(colour):
+        if isinstance(element, int):
+            element = float(element)
+        if not isinstance(element, float):
+            errors.append(f'Invalid type {type(element)} at index {index}; {expected}')
+            continue
+        if element < 0:
+            errors.append(f'Negative element {element} at index {index}; {expected}')
+            continue
+        if element > 1:
+            errors.append(f'Element {element} at index {index} is greater than 1; {expected}')
+            result[index] = 1.0
+            continue
+        result[index] = element
+    return tuple(errors), tuple(result)
+
+
+def get_button_colour(race: str) -> Tuple[Tuple[str, ...], Tuple[float, float, float]]:
+    from . import SC2World
+    baseline_colour = 0.345  # the button graphic is grey, with this value in each colour channel
+    # user_colour = [0.24, 0.84, 0.68]
+    if race == 'TERRAN':
+        user_colour = SC2World.settings.terran_button_colour
+    elif race == 'PROTOSS':
+        user_colour = SC2World.settings.protoss_button_colour
+    elif race == 'ZERG':
+        user_colour = SC2World.settings.zerg_button_colour
+    else:
+        user_colour = [baseline_colour, baseline_colour, baseline_colour]
+    default_colours = {
+        'TERRAN': (0.0838, 0.2898, 0.2346),
+        'ZERG': (0.345, 0.22425, 0.12765),
+        'PROTOSS': (0.18975, 0.2415, 0.345),
+    }
+    errors, colour = validate_colour(user_colour, default_colours.get(race, (baseline_colour, baseline_colour, baseline_colour)))
+    return errors, tuple(x / baseline_colour for x in colour)

--- a/worlds/sc2/gui_config.py
+++ b/worlds/sc2/gui_config.py
@@ -84,16 +84,15 @@ def get_button_colour(race: str) -> Tuple[Tuple[str, ...], Tuple[float, float, f
     baseline_colour = 0.345  # the button graphic is grey, with this value in each colour channel
     if race == 'TERRAN':
         user_colour = SC2World.settings.terran_button_colour
+        default_colour = (0.0838, 0.2898, 0.2346)
     elif race == 'PROTOSS':
         user_colour = SC2World.settings.protoss_button_colour
+        default_colour = (0.345, 0.22425, 0.12765)
     elif race == 'ZERG':
         user_colour = SC2World.settings.zerg_button_colour
+        default_colour = (0.18975, 0.2415, 0.345)
     else:
         user_colour = [baseline_colour, baseline_colour, baseline_colour]
-    default_colours = {
-        'TERRAN': (0.0838, 0.2898, 0.2346),
-        'ZERG': (0.345, 0.22425, 0.12765),
-        'PROTOSS': (0.18975, 0.2415, 0.345),
-    }
-    errors, colour = validate_colour(user_colour, default_colours.get(race, (baseline_colour, baseline_colour, baseline_colour)))
+        default_colour = (baseline_colour, baseline_colour, baseline_colour)
+    errors, colour = validate_colour(user_colour, default_colour)
     return errors, tuple(x / baseline_colour for x in colour)

--- a/worlds/sc2/gui_config.py
+++ b/worlds/sc2/gui_config.py
@@ -82,7 +82,6 @@ def validate_colour(colour: Any, default: Tuple[float, float, float]) -> Tuple[T
 def get_button_colour(race: str) -> Tuple[Tuple[str, ...], Tuple[float, float, float]]:
     from . import SC2World
     baseline_colour = 0.345  # the button graphic is grey, with this value in each colour channel
-    # user_colour = [0.24, 0.84, 0.68]
     if race == 'TERRAN':
         user_colour = SC2World.settings.terran_button_colour
     elif race == 'PROTOSS':

--- a/worlds/sc2/gui_config.py
+++ b/worlds/sc2/gui_config.py
@@ -37,15 +37,17 @@ def validate_colour(colour: Any, default: Tuple[float, float, float]) -> Tuple[T
             ((colour >> 4) & 0xff) / 255,
             ((colour >> 0) & 0xff) / 255,
         )
-    elif  colour == 'white':
+    elif colour == 'default':
+        return (), default
+    elif colour == 'white':
         return (), (0.9, 0.9, 0.9)
-    elif  colour == 'black':
+    elif colour == 'black':
         return (), (0.0, 0.0, 0.0)
-    elif  colour == 'grey':
+    elif colour == 'grey':
         return (), (0.345, 0.345, 0.345)
-    elif  colour == 'red':
+    elif colour == 'red':
         return (), (0.85, 0.2, 0.1)
-    elif  colour == 'orange':
+    elif colour == 'orange':
         return (), (1.0, 0.65, 0.37)
     elif colour == 'green':
         return (), (0.24, 0.84, 0.55)

--- a/worlds/sc2/gui_config.py
+++ b/worlds/sc2/gui_config.py
@@ -30,6 +30,8 @@ def get_window_defaults() -> Tuple[List[str], int, int]:
 
 def validate_colour(colour: Any, default: Tuple[float, float, float]) -> Tuple[Tuple[str, ...], Tuple[float, float, float]]:
     if isinstance(colour, int):
+        if colour < 0:
+            return ('Integer colour was negative; expected a value from 0 to 0xffffff',), default
         return (), (
             ((colour >> 8) & 0xff) / 255,
             ((colour >> 4) & 0xff) / 255,
@@ -49,6 +51,8 @@ def validate_colour(colour: Any, default: Tuple[float, float, float]) -> Tuple[T
         return (), (0.24, 0.84, 0.55)
     elif colour == 'blue':
         return (), (0.3, 0.4, 1.0)
+    elif colour == 'pink':
+        return (), (0.886, 0.176, 0.843)
     elif not isinstance(colour, list):
         return (f'Invalid type {type(colour)}; expected 3-element list or integer',), default
     elif len(colour) != 3:

--- a/worlds/sc2/settings.py
+++ b/worlds/sc2/settings.py
@@ -9,16 +9,16 @@ class Starcraft2Settings(settings.Group):
         """The starting height the client window in pixels"""
     class GameWindowedMode(settings.Bool):
         """Controls whether the game should start in windowed mode"""
-    class TerranButtonColour(list):
+    class TerranButtonColor(list):
         """Defines the colour of terran mission buttons in the launcher in rgb format (3 elements ranging from 0 to 1)"""
-    class ZergButtonColour(list):
+    class ZergButtonColor(list):
         """Defines the colour of zerg mission buttons in the launcher in rgb format (3 elements ranging from 0 to 1)"""
-    class ProtossButtonColour(list):
+    class ProtossButtonColor(list):
         """Defines the colour of protoss mission buttons in the launcher in rgb format (3 elements ranging from 0 to 1)"""
 
     window_width = WindowWidth(1080)
     window_height = WindowHeight(720)
     game_windowed_mode: Union[GameWindowedMode, bool] = False
-    terran_button_colour = TerranButtonColour([0.0838, 0.2898, 0.2346])
-    zerg_button_colour = ZergButtonColour([0.345, 0.22425, 0.12765])
-    protoss_button_colour = ProtossButtonColour([0.18975, 0.2415, 0.345])
+    terran_button_color = TerranButtonColor([0.0838, 0.2898, 0.2346])
+    zerg_button_color = ZergButtonColor([0.345, 0.22425, 0.12765])
+    protoss_button_color = ProtossButtonColor([0.18975, 0.2415, 0.345])

--- a/worlds/sc2/settings.py
+++ b/worlds/sc2/settings.py
@@ -9,7 +9,16 @@ class Starcraft2Settings(settings.Group):
         """The starting height the client window in pixels"""
     class GameWindowedMode(settings.Bool):
         """Controls whether the game should start in windowed mode"""
+    class TerranButtonColour(list):
+        """Defines the colour of terran mission buttons in the launcher in rgb format (3 elements ranging from 0 to 1)"""
+    class ZergButtonColour(list):
+        """Defines the colour of zerg mission buttons in the launcher in rgb format (3 elements ranging from 0 to 1)"""
+    class ProtossButtonColour(list):
+        """Defines the colour of protoss mission buttons in the launcher in rgb format (3 elements ranging from 0 to 1)"""
 
     window_width = WindowWidth(1080)
     window_height = WindowHeight(720)
     game_windowed_mode: Union[GameWindowedMode, bool] = False
+    terran_button_colour = TerranButtonColour([0.0838, 0.2898, 0.2346])
+    zerg_button_colour = ZergButtonColour([0.345, 0.22425, 0.12765])
+    protoss_button_colour = ProtossButtonColour([0.18975, 0.2415, 0.345])


### PR DESCRIPTION
## What is this fixing or adding?
New sc2 settings in host.yaml that allow controlling the colour of buttons in the GUI. I find the colours quite dark and murky and like some over-the-top colours myself. I admit the preset colours may be a little too bright, but I'm not sure how to get a good set of colours that allow for bright highlights while keeping the overall colours sane to look at. It may be that the best route is to allow additional configuration, like different colours for no-builds or fine control over borders.

## How was this tested?
Changed the colours around a lot and restarted the client. 

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/1dab853a-b94a-45dd-a12c-ba539284bc9f)
![image](https://github.com/user-attachments/assets/2167c2f1-159c-46f3-a9f1-4db5da38a166)

![image](https://github.com/user-attachments/assets/cf408dca-9c15-40af-9020-b872be939e0e)
![image](https://github.com/user-attachments/assets/da8dfbf5-2ed6-4727-9ec1-a8c97f669651)

![image](https://github.com/user-attachments/assets/b55d9812-7672-4652-a0a2-86af266612ce)

![image](https://github.com/user-attachments/assets/7a2f0946-a551-486a-b976-c7280865b0bd)

![image](https://github.com/user-attachments/assets/84834567-7fe0-40ff-9e77-5aab997cfe5b)
