### PR TITLE
SC2: Add Roach Mercenaries

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -829,6 +829,7 @@ item_descriptions = {
     item_names.TORRASQUE_MERC: "Torrasque Mercenary.",
     item_names.HUNTERLING: "Hunterling Mercenary.",
     item_names.YGGDRASIL: "Mercenary Overlord that has the ability to transport buildings and ground units.",
+    item_names.MERC_ROACH: "Mercenary Roaches that have the ability to attack air units.",
     item_names.OVERLORD_VENTRAL_SACS: "Overlords gain the ability to transport ground units.",
     item_names.OVERLORD_GENERATE_CREEP: "Overlords gain the ability to generate creep while standing still.",
     item_names.OVERLORD_ANTENNAE: "Increases Overlord sight range.",

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -573,6 +573,7 @@ HUNTER_KILLERS       = "Hunter Killers"
 TORRASQUE_MERC       = "Torrasque"
 HUNTERLING           = "Hunterling"
 YGGDRASIL            = "Yggdrasil"
+MERC_ROACH           = "Thornshells"
 
     
 # Kerrigan Upgrades

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1610,6 +1610,7 @@ item_table = {
     item_names.TORRASQUE_MERC: ItemData(605 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 5, SC2Race.ZERG),
     item_names.HUNTERLING: ItemData(606 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 6, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.YGGDRASIL: ItemData(607 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 7, SC2Race.ZERG, classification=ItemClassification.progression),
+    item_names.MERC_ROACH: ItemData(608 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 8, SC2Race.ZERG),
 
 
     # Misc Upgrades


### PR DESCRIPTION
## What is this fixing or adding?

Adds a Roach Mercenary item. Working name: Thornshells.
Stronger versions of regular Roaches, that can attack air.

## How was this tested?

Generated a local campaign, added item with console commands

[Data PR](https://github.com/Ziktofel/Archipelago-SC2-data/pull/333)