### PR TITLE
sc2: Pygalisk description logic updates

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -595,7 +595,7 @@ item_descriptions = {
     item_names.SWARM_HOST: "Siege unit that attacks by rooting in place and continually spawning Locusts.",
     item_names.INFESTOR: "Support caster that can move while burrowed. Can use the Fungal Growth, Parasitic Domination, and Consumption abilities.",
     item_names.ULTRALISK: "Massive melee attacker. Has an area-damage cleave attack.",
-    item_names.PYGALISK: "Miniature melee attacker. Summoned from the predator nest in large quantities and low cooldown.",
+    item_names.PYGALISK: "Miniature melee attacker.",
     item_names.SPORE_CRAWLER: "Anti-air defensive structure that can detect cloaked units.",
     item_names.SPINE_CRAWLER: "Anti-ground defensive structure.",
     item_names.CORRUPTOR: "Anti-air flying attacker specializing in taking down enemy capital ships.",

--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -437,12 +437,13 @@ zerg_ground_units = [
     item_names.SWARM_HOST, item_names.INFESTOR, item_names.ULTRALISK, item_names.ZERGLING_BANELING_ASPECT,
     item_names.HYDRALISK_LURKER_ASPECT, item_names.HYDRALISK_IMPALER_ASPECT, item_names.ULTRALISK_TYRANNOZOR_ASPECT,
     item_names.ROACH_RAVAGER_ASPECT, item_names.DEFILER, item_names.ROACH_PRIMAL_IGNITER_ASPECT,
+    item_names.PYGALISK,
     item_names.INFESTED_MARINE, item_names.INFESTED_BUNKER, item_names.INFESTED_DIAMONDBACK,
     item_names.INFESTED_SIEGE_TANK,
 ]
 zerg_melee_wa = [
     item_names.ZERGLING, item_names.ABERRATION, item_names.ULTRALISK, item_names.ZERGLING_BANELING_ASPECT,
-    item_names.ULTRALISK_TYRANNOZOR_ASPECT, item_names.INFESTED_BUNKER,
+    item_names.ULTRALISK_TYRANNOZOR_ASPECT, item_names.INFESTED_BUNKER, item_names.PYGALISK,
 ]
 zerg_ranged_wa = [
     item_names.SWARM_QUEEN, item_names.ROACH, item_names.HYDRALISK, item_names.SWARM_HOST,

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -2053,6 +2053,7 @@ advanced_basic_units = {
         item_names.CYCLONE
     }),
     SC2Race.ZERG: basic_units[SC2Race.ZERG].union({
+        item_names.PYGALISK,
         item_names.INFESTOR,
         item_names.ABERRATION,
     }),

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -1090,7 +1090,7 @@ class SC2Logic:
 
     def zerg_mineral_dump(self, state: CollectionState) -> bool:
         return (
-                state.has_any({item_names.ZERGLING, item_names.INFESTED_BUNKER}, self.player)
+                state.has_any({item_names.ZERGLING, item_names.PYGALISK, item_names.INFESTED_BUNKER}, self.player)
                 or state.has_all({item_names.SWARM_QUEEN, item_names.SWARM_QUEEN_RESOURCE_EFFICIENCY}, self.player)
                 or (
                         self.advanced_tactics


### PR DESCRIPTION
## What is this fixing or adding?
Updating the pygalisk description to match [data PR #331](https://github.com/Ziktofel/Archipelago-SC2-data/pull/331), where they no longer come from the predator nest. Also added them to advanced logic starter units, the zerg ground and melee units item groups (which affects upgrades logic), and the zerg mineral dump logic rule.

## How was this tested?
Ran unit tests.

## If this makes graphical changes, please attach screenshots.
None