### PR TITLE
sc2: Removing unnecessary logging tabs

### DIFF
--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -4,7 +4,7 @@ import logging
 
 from BaseClasses import ItemClassification
 from NetUtils import JSONMessagePart
-from kvui import GameManager, HoverBehavior, ServerToolTip, KivyJSONtoTextParser
+from kvui import GameManager, HoverBehavior, ServerToolTip, KivyJSONtoTextParser, LogtoUI
 from kivy.app import App
 from kivy.clock import Clock
 from kivy.uix.gridlayout import GridLayout
@@ -118,10 +118,6 @@ class SC2JSONtoKivyParser(KivyJSONtoTextParser):
 
 
 class SC2Manager(GameManager):
-    logging_pairs = [
-        ("Client", "Archipelago"),
-        ("Starcraft2", "Starcraft2"),
-    ]
     base_title = "Archipelago Starcraft 2 Client"
 
     campaign_panel: Optional[MultiCampaignLayout] = None
@@ -146,6 +142,8 @@ class SC2Manager(GameManager):
         warnings, window_width, window_height = gui_config.get_window_defaults()
         from kivy.core.window import Window
         Window.size = window_width, window_height
+        # Add the logging handler manually here instead of using `logging_pairs` to avoid adding 2 unnecessary tabs
+        logging.getLogger("Starcraft2").addHandler(LogtoUI(self.log_panels["All"].on_log))
         for startup_warning in warnings:
             logging.getLogger("Starcraft2").warning(f"Startup WARNING: {startup_warning}")
         for race in (SC2Race.TERRAN, SC2Race.PROTOSS, SC2Race.ZERG):


### PR DESCRIPTION
## What is this fixing or adding?
Removing the unnecessary "Archipelago" and "Starcraft2" tabs in the client so there's only 3 tabs.

## How was this tested?
Started the client, verified there's only 3 tabs. Checked regular Archipelago output still worked with commands like `/help` and `/received`. Checked Starcraft2 logger messages still showed up by messing with the host.yaml options to have an invalid button colour and verified the log message was visible on startup. Verified that same error log message was visible in the log in logs/

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/9b25abd2-7e03-4c5e-bdf6-d459e64b8931)
