### PR TITLE
sc2: Updating contributors doc with code contributors

### DIFF
--- a/worlds/sc2/docs/contributors.md
+++ b/worlds/sc2/docs/contributors.md
@@ -1,15 +1,47 @@
 # Contributors
-Contibutors are listed with preferred or Discord names first, with github usernames prepended with an `@`
+Contibutors are listed with preferred or Discord names first, with github usernames prepended with an `@`.
+Within an update, contributors for earlier sections are not repeated for their contributions in later sections;
+code contributors also reported bugs and participated in beta testing.
 
-## Update 2024.0
+## Update 2025
 ### Code Changes
 * Ziktofel (@Ziktofel)
 * Salzkorn (@Salzkorn)
 * EnvyDragon (@EnvyDragon)
-* Phanerus (@MatthewMarinets)
+* Phaneros (@MatthewMarinets)
+* Magnemania (@Magnemania)
+* Bones (@itsjustbones)
+* Gemster (@Gemster312)
+* SirChuckOfTheChuckles (@SirChuckOfTheChuckles)
+* Snarky (@Snarky)
+* MindHawk (@MindHawk)
+* Cristall (@Cristall)
+* WaikinDN (@WaikinDN)
+
+### Additional Assets
+* Alice Voltaire
+
+## Maintenance of 2024 release
+* Ziktofel (@Ziktofel)
+* Phaneros (@MatthewMarinets)
+* Salzkorn (@Salzkorn)
+* neocerber (@neocerber)
+* Alchav (@Alchav)
+* Berserker (@Berserker66)
+* Exempt-Medic (@Exempt-Medic)
+
+And many members of the greater Archipelago community for core changes that affected the StarCraft 2 apworld.
+
+## Update 2024
+### Code Changes
+* Ziktofel (@Ziktofel)
+* Salzkorn (@Salzkorn)
+* EnvyDragon (@EnvyDragon)
+* Phaneros (@MatthewMarinets)
 * Madi Sylveon (@MadiMadsen)
 * Magnemania (@Magnemania)
 * Subsourian (@Subsourian)
+* neocerber (@neocerber)
 * Hopop (@hopop201)
 * Alice Voltaire (@AliceVoltaire)
 * Genderdruid (@ArchonofFail)


### PR DESCRIPTION
## What is this fixing or adding?
Updating contributors document with code contributors, Alice for some coloured icons, and PR authors to main affecting the sc2 apworld.

## How was this tested?
Went through the PR history of Ziktofel/Archipelago, Ziktofel/Archipelago-SC2-Data, and ArchipelagoMW/Archipelago with search filter "sc2". Noted all github usernames I saw going back to March 2024.

## If this makes graphical changes, please attach screenshots.
None