### PR TITLE
Item parents and filtering refactor

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -12,7 +12,7 @@ from .item.item_tables import (
     not_balanced_starting_units, WEAPON_ARMOR_UPGRADE_MAX_LEVEL, ZergItemType,
 )
 from . import location_groups
-from .item import FilterItem, ItemFilterFlags, StarcraftItem, item_groups, item_names, item_tables
+from .item import FilterItem, ItemFilterFlags, StarcraftItem, item_groups, item_names, item_tables, item_parents
 from .locations import get_locations, DEFAULT_LOCATION_LIST, get_location_types, get_location_flags, get_plando_locations
 from .mission_order.layout_types import LayoutType, Gauntlet
 from .options import (
@@ -130,15 +130,18 @@ class SC2World(World):
         flag_war_council_items(self, item_list)
         flag_and_add_resource_locations(self, item_list)
         flag_mission_order_required_items(self, item_list)
-        pool: List[Item] = prune_item_pool(self, item_list)
+        pruned_items: List[StarcraftItem] = prune_item_pool(self, item_list)
+
+        start_inventory = [item for item in pruned_items if ItemFilterFlags.StartInventory in item.filter_flags]
+        pool = [item for item in pruned_items if ItemFilterFlags.StartInventory not in item.filter_flags]
         pad_item_pool_with_filler(self, len(self.location_cache) - len(self.locked_locations) - len(pool), pool)
 
-        push_precollected_items_to_multiworld(self, item_list)
+        push_precollected_items_to_multiworld(self, start_inventory)
 
         self.multiworld.itempool += pool
 
         # Tell the logic which unit classes are used for required W/A upgrades
-        used_item_names: Set[str] = {item.name for item in item_list}
+        used_item_names: Set[str] = {item.name for item in pruned_items}
         used_item_names = used_item_names.union(item.name for item in self.multiworld.itempool if item.player == self.player)
         if used_item_names.isdisjoint(item_groups.barracks_wa_group):
             self.has_barracks_unit = False
@@ -201,8 +204,8 @@ class SC2World(World):
 
     def pre_fill(self) -> None:
         if (
-                self.options.generic_upgrade_missions > 0
-                and self.options.required_tactics != options.RequiredTactics.option_no_logic
+            self.options.generic_upgrade_missions > 0
+            and self.options.required_tactics != RequiredTactics.option_no_logic
         ):
             # Attempt to resolve situation when the option is too high for the mission order rolled
             # TODO: Attempt to resolve Kerrigan levels too
@@ -355,7 +358,7 @@ def create_and_flag_explicit_item_locks_and_excludes(world: SC2World) -> List[Fi
             if item_name in world.options.non_local_items:
                 result[-1].flags |= ItemFilterFlags.NonLocal
             if index >= max(max_count - excluded_count, key_count):
-                result[-1].flags |= ItemFilterFlags.Excluded
+                result[-1].flags |= ItemFilterFlags.UserExcluded
     return result
 
 
@@ -382,23 +385,23 @@ def flag_excludes_by_faction_presence(world: SC2World, item_list: List[FilterIte
         # Catch-all for all of a faction's items
         if not terran_missions and item.data.race == SC2Race.TERRAN:
             if item.name not in item_groups.nova_equipment:
-                item.flags |= ItemFilterFlags.Removed
+                item.flags |= ItemFilterFlags.FilterExcluded
                 continue
         if not zerg_missions and item.data.race == SC2Race.ZERG:
             if item.data.type != item_tables.ZergItemType.Ability \
                     and item.data.type != ZergItemType.Level:
-                item.flags |= ItemFilterFlags.Removed
+                item.flags |= ItemFilterFlags.FilterExcluded
                 continue
         if not protoss_missions and item.data.race == SC2Race.PROTOSS:
             if item.name not in item_groups.soa_items:
-                item.flags |= ItemFilterFlags.Removed
+                item.flags |= ItemFilterFlags.FilterExcluded
             continue
         
         # Faction units
         if (not terran_build_missions
             and item.data.type in (item_tables.TerranItemType.Unit, item_tables.TerranItemType.Building, item_tables.TerranItemType.Mercenary)
         ):
-            item.flags |= ItemFilterFlags.Removed
+            item.flags |= ItemFilterFlags.FilterExcluded
         if (not zerg_build_missions
             and item.data.type in (item_tables.ZergItemType.Unit, item_tables.ZergItemType.Mercenary, item_tables.ZergItemType.Evolution_Pit)
         ):
@@ -406,7 +409,7 @@ def flag_excludes_by_faction_presence(world: SC2World, item_list: List[FilterIte
                 or world.options.grant_story_tech.value == GrantStoryTech.option_true
                 or item.name not in (item_names.ZERGLING, item_names.ROACH, item_names.HYDRALISK, item_names.INFESTOR)
             ):
-                item.flags |= ItemFilterFlags.Removed
+                item.flags |= ItemFilterFlags.FilterExcluded
         if (not protoss_build_missions
             and item.data.type in (
                         item_tables.ProtossItemType.Unit,
@@ -424,24 +427,24 @@ def flag_excludes_by_faction_presence(world: SC2World, item_list: List[FilterIte
                             item_names.SENTRY, item_names.HIGH_TEMPLAR,
                 )
             ):
-                item.flags |= ItemFilterFlags.Removed
+                item.flags |= ItemFilterFlags.FilterExcluded
         
         # Faction +attack/armour upgrades
         if (item.data.type == item_tables.TerranItemType.Upgrade
             and not terran_build_missions
             and not auto_upgrades_in_nobuilds
         ):
-            item.flags |= ItemFilterFlags.Removed
+            item.flags |= ItemFilterFlags.FilterExcluded
         if (item.data.type == item_tables.ZergItemType.Upgrade
             and not zerg_build_missions
             and not auto_upgrades_in_nobuilds
         ):
-            item.flags |= ItemFilterFlags.Removed
+            item.flags |= ItemFilterFlags.FilterExcluded
         if (item.data.type == item_tables.ProtossItemType.Upgrade
             and not protoss_build_missions
             and not auto_upgrades_in_nobuilds
         ):
-            item.flags |= ItemFilterFlags.Removed
+            item.flags |= ItemFilterFlags.FilterExcluded
 
 
 def flag_mission_based_item_excludes(world: SC2World, item_list: List[FilterItem]) -> None:
@@ -457,7 +460,7 @@ def flag_mission_based_item_excludes(world: SC2World, item_list: List[FilterItem
     kerrigan_is_present = (
             len(kerrigan_missions) > 0
             and world.options.kerrigan_presence == KerriganPresence.option_vanilla
-            and SC2Campaign.HOTS in options.get_enabled_campaigns(world) # TODO: Kerrigan available all Zerg/Everywhere
+            and SC2Campaign.HOTS in get_enabled_campaigns(world) # TODO: Kerrigan available all Zerg/Everywhere
     )
 
     # TvZ build missions -- check flags Terran and VsZerg are true and NoBuild is false
@@ -499,36 +502,36 @@ def flag_mission_based_item_excludes(world: SC2World, item_list: List[FilterItem
     for item in item_list:
         # Filter Nova equipment if you never get Nova
         if not nova_missions and (item.name in item_groups.nova_equipment):
-            item.flags |= ItemFilterFlags.Removed
+            item.flags |= ItemFilterFlags.FilterExcluded
         
         # Todo(mm): How should no-build only / grant_story_tech affect excluding Kerrigan items?
         # Exclude Primal form based on Kerrigan presence or primal form option
         if (item.data.type == item_tables.ZergItemType.Primal_Form
             and ((not kerrigan_is_present) or world.options.kerrigan_primal_status != KerriganPrimalStatus.option_item)
         ):
-            item.flags |= ItemFilterFlags.Removed
+            item.flags |= ItemFilterFlags.FilterExcluded
         
         # Remove Kerrigan abilities if there's no kerrigan
         if item.data.type == item_tables.ZergItemType.Ability:
             if not kerrigan_is_present:
                 # TODO: Kerrigan presence Zerg/Everywhere
-                item.flags |= ItemFilterFlags.Removed
+                item.flags |= ItemFilterFlags.FilterExcluded
             elif world.options.grant_story_tech and not kerrigan_build_missions:
-                item.flags |= ItemFilterFlags.Removed
+                item.flags |= ItemFilterFlags.FilterExcluded
         
         # Remove Spear of Adun if it's off
         if item.name in item_tables.spear_of_adun_calldowns and not soa_presence:
-            item.flags |= ItemFilterFlags.Removed
+            item.flags |= ItemFilterFlags.FilterExcluded
 
         # Remove Spear of Adun passives
         if item.name in item_tables.spear_of_adun_castable_passives and not soa_passive_presence:
-            item.flags |= ItemFilterFlags.Removed
+            item.flags |= ItemFilterFlags.FilterExcluded
         
         # Remove Psi Disrupter and Hive Mind Emulator if you never play a build TvZ
         if (item.name in (item_names.HIVE_MIND_EMULATOR, item_names.PSI_DISRUPTER)
             and not tvz_build_missions
         ):
-            item.flags |= ItemFilterFlags.Removed
+            item.flags |= ItemFilterFlags.FilterExcluded
     return
 
 
@@ -581,7 +584,7 @@ def flag_start_unit(world: SC2World, item_list: List[FilterItem], starter_unit: 
 
     if first_race != SC2Race.ANY:
         possible_starter_items = {
-            item.name: item for item in item_list if (ItemFilterFlags.Plando|ItemFilterFlags.Excluded|ItemFilterFlags.Removed) & item.flags == 0
+            item.name: item for item in item_list if (ItemFilterFlags.Plando|ItemFilterFlags.UserExcluded|ItemFilterFlags.FilterExcluded) & item.flags == 0
         }
 
         # The race of the early unit has been chosen
@@ -614,7 +617,7 @@ def flag_start_unit(world: SC2World, item_list: List[FilterItem], starter_unit: 
                 item for item in basic_unit_options
                 if item.name not in nco_support_items
                 or nco_support_items[item.name] in possible_starter_items
-                and ((ItemFilterFlags.Plando|ItemFilterFlags.Excluded|ItemFilterFlags.Removed) & possible_starter_items[nco_support_items[item.name]].flags) == 0
+                and ((ItemFilterFlags.Plando|ItemFilterFlags.UserExcluded|ItemFilterFlags.FilterExcluded) & possible_starter_items[nco_support_items[item.name]].flags) == 0
             ]
         if not basic_unit_options:
             raise Exception("Early Unit: At least one basic unit must be included")
@@ -661,7 +664,7 @@ def flag_start_abilities(world: SC2World, item_list: List[FilterItem]) -> None:
         potential_starter_abilities = [
             item for item in item_list 
             if item.name in abilities_in_tier
-            and (ItemFilterFlags.Excluded|ItemFilterFlags.StartInventory|ItemFilterFlags.Plando) & item.flags == 0
+            and (ItemFilterFlags.UserExcluded|ItemFilterFlags.StartInventory|ItemFilterFlags.Plando) & item.flags == 0
         ]
         # Try to avoid giving non-local items unless there is no alternative
         abilities = [item for item in potential_starter_abilities if ItemFilterFlags.NonLocal not in item.flags]
@@ -682,7 +685,7 @@ def flag_unused_upgrade_types(world: SC2World, item_list: List[FilterItem]) -> N
     for item in item_list:
         if item.data.type in item_tables.upgrade_item_types:
             if not include_upgrades or (item.name not in upgrade_included_names[upgrade_items]):
-                item.flags |= ItemFilterFlags.Removed
+                item.flags |= ItemFilterFlags.FilterExcluded
 
 
 def flag_user_excluded_item_sets(world: SC2World, item_list: List[FilterItem]) -> None:
@@ -695,13 +698,13 @@ def flag_user_excluded_item_sets(world: SC2World, item_list: List[FilterItem]) -
     }
     vanilla_items = item_groups.vanilla_items + item_groups.nova_equipment
     for item in item_list:
-        if ItemFilterFlags.Excluded in item.flags:
+        if ItemFilterFlags.UserExcluded in item.flags:
             continue
         if item.name not in vanilla_items:
-            item.flags |= ItemFilterFlags.Excluded
+            item.flags |= ItemFilterFlags.UserExcluded
         if item.name in item_groups.terran_original_progressive_upgrades:
             if vanilla_nonprogressive_count[item.name]:
-                item.flags |= ItemFilterFlags.Excluded
+                item.flags |= ItemFilterFlags.UserExcluded
             vanilla_nonprogressive_count[item.name] += 1
 
 def flag_war_council_items(world: SC2World, item_list: List[FilterItem]) -> None:
@@ -745,54 +748,43 @@ def flag_mission_order_required_items(world: SC2World, item_list: List[FilterIte
     locks_done = {item: 0 for item in locks_required}
     for item in item_list:
         if item.name in locks_required and locks_done[item.name] < locks_required[item.name]:
-            item.flags |= ItemFilterFlags.Necessary
+            item.flags |= ItemFilterFlags.Locked
             item.flags |= ItemFilterFlags.ForceProgression
             locks_done[item.name] += 1
 
 
-def prune_item_pool(world: SC2World, item_list: List[FilterItem]) -> List[Item]:
+def prune_item_pool(world: SC2World, item_list: List[FilterItem]) -> List[StarcraftItem]:
     """Prunes the item pool size to be less than the number of available locations"""
 
-    item_list = [item for item in item_list if ItemFilterFlags.Unremovable & item.flags or ItemFilterFlags.Removed not in item.flags]
+    item_list = [item for item in item_list if ItemFilterFlags.Unexcludable & item.flags or ItemFilterFlags.FilterExcluded not in item.flags]
     num_items = len(item_list)
     last_num_items = -1
     while num_items != last_num_items:
         # Remove orphan items until there are no more being removed
+        item_name_list = [item.name for item in item_list]
         item_list = [item for item in item_list
-            if (ItemFilterFlags.Unremovable|ItemFilterFlags.AllowedOrphan) & item.flags
-            or item_list_contains_parent(item.data, item_list)]
+            if (ItemFilterFlags.Unexcludable|ItemFilterFlags.AllowedOrphan) & item.flags
+            or item_list_contains_parent(world, item.data, item_name_list)]
         last_num_items = num_items
         num_items = len(item_list)
 
     pool: List[StarcraftItem] = []
-    locked_items: List[StarcraftItem] = []
-    existing_items: List[StarcraftItem] = []
-    necessary_items: List[StarcraftItem] = []
     for item in item_list:
         ap_item = create_item_with_correct_settings(world.player, item.name, item.flags)
         if ItemFilterFlags.ForceProgression in item.flags:
             ap_item.classification = ItemClassification.progression
-        if ItemFilterFlags.StartInventory in item.flags:
-            existing_items.append(ap_item)
-        elif ItemFilterFlags.Necessary in item.flags:
-            necessary_items.append(ap_item)
-        elif ItemFilterFlags.Locked in item.flags:
-            locked_items.append(ap_item)
-        else:
-            pool.append(ap_item)
+        pool.append(ap_item)
 
     fill_pool_with_kerrigan_levels(world, pool)
-    filtered_pool = filter_items(world, world.location_cache, pool, existing_items, locked_items, necessary_items)
+    filtered_pool = filter_items(world, world.location_cache, pool)
     return filtered_pool
 
 
-def item_list_contains_parent(item_data: ItemData, item_list: List[FilterItem]) -> bool:
+def item_list_contains_parent(world: SC2World, item_data: ItemData, item_name_list: List[str]) -> bool:
     if item_data.parent_item is None:
         # The item has no associated parent, the item is valid
         return True
-    parent_item = item_data.parent_item
-    # Check if the pool contains the parent item
-    return parent_item in [item.name for item in item_list]
+    return item_parents.parent_present[item_data.parent_item](item_name_list, world.options)
 
 
 def pad_item_pool_with_filler(self: SC2World, num_items: int, pool: List[Item]):
@@ -822,7 +814,7 @@ def create_item_with_correct_settings(player: int, name: str, filter_flags: Item
     return item
 
 
-def fill_pool_with_kerrigan_levels(world: SC2World, item_pool: List[Item]):
+def fill_pool_with_kerrigan_levels(world: SC2World, item_pool: List[StarcraftItem]):
     total_levels = world.options.kerrigan_level_item_sum.value
     missions = get_all_missions(world.custom_mission_order)
     kerrigan_missions = [mission for mission in missions if MissionFlag.Kerrigan in mission.flags]
@@ -864,14 +856,14 @@ def fill_pool_with_kerrigan_levels(world: SC2World, item_pool: List[Item]):
             round_func = ceil
         add_kerrigan_level_items(size, round_func(float(total_levels) / size))
 
-def push_precollected_items_to_multiworld(world: SC2World, item_list: List[FilterItem]) -> None:
+def push_precollected_items_to_multiworld(world: SC2World, item_list: List[StarcraftItem]) -> None:
     # world.multiworld.push_precollected() has side-effects, so we can't just clear
     # world.multiworld.precollected_items[world.player]
     precollected_amounts: Dict[str, int] = {}
     for ap_item in world.multiworld.precollected_items[world.player]:
         precollected_amounts[ap_item.name] = precollected_amounts.get(ap_item.name, 0) + 1
     for item in item_list:
-        if ItemFilterFlags.StartInventory not in item.flags:
+        if ItemFilterFlags.StartInventory not in item.filter_flags:
             continue
         if precollected_amounts.get(item.name, 0) <= 0:
             world.multiworld.push_precollected(create_item_with_correct_settings(world.player, item.name))

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -810,6 +810,8 @@ def create_item_with_correct_settings(player: int, name: str, filter_flags: Item
     data = item_tables.item_table[name]
 
     item = StarcraftItem(name, data.classification, data.code, player, filter_flags)
+    if ItemFilterFlags.ForceProgression:
+        item.classification = ItemClassification.progression
 
     return item
 

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -781,10 +781,10 @@ def prune_item_pool(world: SC2World, item_list: List[FilterItem]) -> List[Starcr
 
 
 def item_list_contains_parent(world: SC2World, item_data: ItemData, item_name_list: List[str]) -> bool:
-    if item_data.parent_item is None:
+    if item_data.parent is None:
         # The item has no associated parent, the item is valid
         return True
-    return item_parents.parent_present[item_data.parent_item](item_name_list, world.options)
+    return item_parents.parent_present[item_data.parent](item_name_list, world.options)
 
 
 def pad_item_pool_with_filler(self: SC2World, num_items: int, pool: List[Item]):

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -274,8 +274,8 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         for item_data in items.values():
             if item_data.parent:
                 parent_rule = item_parents.parent_present[item_data.parent]
-                if parent_rule.main_item is not None and parent_rule.main_item in items:
-                    parent_to_child.setdefault(items[parent_rule.main_item].code, []).append(item_data.code)
+                if parent_rule.constraint_group is not None and parent_rule.constraint_group in items:
+                    parent_to_child.setdefault(items[parent_rule.constraint_group].code, []).append(item_data.code)
                     continue
                 race = items[parent_rule.parent_items()[0]].race
                 categorized_items.setdefault(race, [])

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -273,8 +273,8 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             items_received.setdefault(item.item, []).append(item)
         items_received_set = set(items_received)
         for item_data in items.values():
-            if item_data.parent_item:
-                parent_to_child.setdefault(items[item_data.parent_item].code, []).append(item_data.code)
+            if item_data.parent:
+                parent_to_child.setdefault(items[item_data.parent].code, []).append(item_data.code)
             else:
                 categorized_items.setdefault(item_data.race, []).append(item_data.code)
         for faction in SC2Race:

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -25,7 +25,7 @@ from pathlib import Path
 # CommonClient import first to trigger ModuleUpdater
 from CommonClient import CommonContext, server_loop, ClientCommandProcessor, gui_enabled, get_base_parser
 from Utils import init_logging, is_windows, async_start
-from .item import item_names
+from .item import item_names, item_parents
 from .item.item_groups import item_name_groups, unlisted_item_name_groups
 from . import options
 from .options import (
@@ -265,71 +265,92 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             return False
 
         items = get_full_item_list()
-        categorized_items: typing.Dict[SC2Race, typing.List[int]] = {}
-        parent_to_child: typing.Dict[int, typing.List[int]] = {}
+        categorized_items: typing.Dict[SC2Race, typing.List[typing.Union[int, str]]] = {}
+        parent_to_child: typing.Dict[typing.Union[int, str], typing.List[int]] = {}
         items_received: typing.Dict[int, typing.List[NetworkItem]] = {}
-        filter_match_count = 0
         for item in self.ctx.items_received:
             items_received.setdefault(item.item, []).append(item)
         items_received_set = set(items_received)
         for item_data in items.values():
             if item_data.parent:
-                parent_to_child.setdefault(items[item_data.parent].code, []).append(item_data.code)
+                parent_rule = item_parents.parent_present[item_data.parent]
+                if parent_rule.main_item is not None and parent_rule.main_item in items:
+                    parent_to_child.setdefault(items[parent_rule.main_item].code, []).append(item_data.code)
+                    continue
+                race = items[parent_rule.parent_items()[0]].race
+                categorized_items.setdefault(race, [])
+                if parent_rule.display_string not in categorized_items[race]:
+                    categorized_items[race].append(parent_rule.display_string)
+                parent_to_child.setdefault(parent_rule.display_string, []).append(item_data.code)
             else:
                 categorized_items.setdefault(item_data.race, []).append(item_data.code)
-        for faction in SC2Race:
-            has_printed_faction_title = False
-            def print_faction_title():
-                if not has_printed_faction_title:
-                    self.formatted_print(f" [u]{faction.name}[/u] ")
-            
-            for item_id in categorized_items[faction]:
-                item_name = self.ctx.item_names.lookup_in_game(item_id)
-                received_child_items = items_received_set.intersection(parent_to_child.get(item_id, []))
-                matching_children = [child for child in received_child_items
-                                     if item_matches_filter(self.ctx.item_names.lookup_in_game(child))]
-                received_items_of_this_type = items_received.get(item_id, [])
-                item_is_match = item_matches_filter(item_name)
-                if item_is_match or len(matching_children) > 0:
-                    # Print found item if it or its children match the filter
-                    if item_is_match:
-                        filter_match_count += len(received_items_of_this_type)
-                    for item in received_items_of_this_type:
-                        print_faction_title()
-                        has_printed_faction_title = True
-                        (ColouredMessage('* ').item(item.item, self.ctx.slot, flags=item.flags)
-                            (" from ").location(item.location, item.player)
-                            (" by ").player(item.player)
-                        ).send(self.ctx)
-                
-                if received_child_items:
-                    # We have this item's children
-                    if len(matching_children) == 0:
-                        # ...but none of them match the filter
-                        continue
 
-                    if not received_items_of_this_type:
-                        # We didn't receive the item itself
-                        print_faction_title()
-                        has_printed_faction_title = True
-                        ColouredMessage("- ").coloured(item_name, "black")(" - not obtained").send(self.ctx)
-                    
-                    for child_item in matching_children:
-                        received_items_of_this_type = items_received.get(child_item, [])
-                        for item in received_items_of_this_type:
-                            filter_match_count += len(received_items_of_this_type)
-                            (ColouredMessage('  * ').item(item.item, self.ctx.slot, flags=item.flags)
-                                (" from ").location(item.location, item.player)
-                                (" by ").player(item.player)
-                            ).send(self.ctx)
-                    
-                    non_matching_children = len(received_child_items) - len(matching_children)
-                    if non_matching_children > 0:
-                        self.formatted_print(f"  + {non_matching_children} child items that don't match the filter")
+        def display_info(element: typing.Union[SC2Race, str, int]) -> tuple:
+            """Return (should display, name, type, children, sum(obtained), sum(matching filter))"""
+            have_item = isinstance(element, int) and element in items_received_set
+            if isinstance(element, SC2Race):
+                children: typing.Sequence[typing.Union[str, int]] = categorized_items[faction]
+                name = element.name
+            elif isinstance(element, int):
+                children = parent_to_child.get(element, [])
+                name = self.ctx.item_names.lookup_in_game(element)
+            else:
+                assert isinstance(element, str)
+                children = parent_to_child[element]
+                name = element
+            matches_filter = item_matches_filter(name)
+            child_states = [display_info(child) for child in children]
+            return (
+                (have_item and matches_filter) or any(child_state[0] for child_state in child_states),
+                name,
+                element,
+                child_states,
+                sum(child_state[4] for child_state in child_states) + have_item,
+                sum(child_state[5] for child_state in child_states) + (have_item and matches_filter),
+            )
+
+        def display_tree(
+            should_display: bool, name: str, element: typing.Union[SC2Race, str, int], child_states: tuple, indent: int = 0
+        ) -> None:
+            if not should_display:
+                return
+            indent_str = " " * indent
+            if isinstance(element, SC2Race):
+                self.formatted_print(f" [u]{name}[/u] ")
+                for child in child_states:
+                    display_tree(*child[:4])
+            elif isinstance(element, str):
+                ColouredMessage(indent_str)("- ").coloured(name, "white").send(self.ctx)
+                for child in child_states:
+                    display_tree(*child[:4], indent=indent+2)
+            elif isinstance(element, int):
+                items = items_received.get(element, [])
+                if not items:
+                    ColouredMessage(indent_str)("- ").coloured(name, "black")(" - not obtained").send(self.ctx)
+                for item in items:
+                    (ColouredMessage(indent_str)('- ')
+                        .item(item.item, self.ctx.slot, flags=item.flags)
+                        (" from ").location(item.location, item.player)
+                        (" by ").player(item.player)
+                    ).send(self.ctx)
+                for child in child_states:
+                    display_tree(*child[:4], indent=indent+2)
+            non_matching_descendents = sum(child[5] - child[4] for child in children)
+            if non_matching_descendents > 0:
+                self.formatted_print(f"{indent_str}  + {non_matching_descendents} child items that don't match the filter")
+
+
+        item_types_obtained = 0
+        items_obtained_matching_filter = 0
+        for faction in SC2Race:
+            should_display, name, element, children, faction_items_obtained, faction_items_matching_filter = display_info(faction)
+            item_types_obtained += faction_items_obtained
+            items_obtained_matching_filter += faction_items_matching_filter
+            display_tree(should_display, name, element, children)
         if filter_search == "":
-            self.formatted_print(f"[b]Obtained: {len(self.ctx.items_received)} items[/b]")
+            self.formatted_print(f"[b]Obtained: {len(self.ctx.items_received)} items ({item_types_obtained} types)[/b]")
         else:
-            self.formatted_print(f"[b]Filter \"{filter_search}\" found {filter_match_count} out of {len(self.ctx.items_received)} obtained items[/b]")
+            self.formatted_print(f"[b]Filter \"{filter_search}\" found {items_obtained_matching_filter} out of {item_types_obtained} obtained item types[/b]")
         return True
 
     def _received_recent(self, amount: str) -> None:

--- a/worlds/sc2/item/__init__.py
+++ b/worlds/sc2/item/__init__.py
@@ -12,6 +12,8 @@ class ItemFilterFlags(enum.IntFlag):
     StartInventory = enum.auto()
     Locked = enum.auto()
     """Used to flag items that are never allowed to be culled."""
+    LogicLocked = enum.auto()
+    """Locked by item cull logic checks; logic-locked w/a upgrades may be removed if all parents are removed"""
     Requested = enum.auto()
     """Soft-locked items by item count checks during item culling; may be re-added"""
     Removed = enum.auto()
@@ -29,10 +31,11 @@ class ItemFilterFlags(enum.IntFlag):
     ForceProgression = enum.auto()
     """Used to flag items that aren't classified as progression by default"""
 
-    Unexcludable = StartInventory|Plando|Locked
-    Uncullable = StartInventory|Plando|Locked|Requested
+    Unexcludable = StartInventory|Plando|Locked|LogicLocked
+    UnexcludableUpgrade = StartInventory|Plando|Locked
+    Uncullable = StartInventory|Plando|Locked|LogicLocked|Requested
     Excluded = UserExcluded|FilterExcluded
-    RequestedOrBetter = StartInventory|Locked|Requested
+    RequestedOrBetter = StartInventory|Locked|LogicLocked|Requested
     CulledOrBetter = Removed|Excluded|Culled
 
 

--- a/worlds/sc2/item/__init__.py
+++ b/worlds/sc2/item/__init__.py
@@ -7,22 +7,33 @@ from .item_tables import ItemData
 
 
 class ItemFilterFlags(enum.IntFlag):
+    """Removed > Start Inventory > Locked > Excluded > Requested > Culled"""
     Available = 0
-    Locked = enum.auto()
     StartInventory = enum.auto()
-    NonLocal = enum.auto()
+    Locked = enum.auto()
+    """Used to flag items that are never allowed to be culled."""
+    Requested = enum.auto()
+    """Soft-locked items by item count checks during item culling; may be re-added"""
     Removed = enum.auto()
+    """Marked for immediate removal"""
+    UserExcluded = enum.auto()
+    """Excluded by the user; display an error message if failing to exclude"""
+    FilterExcluded = enum.auto()
+    """Excluded by item filtering"""
+    Culled = enum.auto()
+    """Soft-removed by the item culling"""
+    NonLocal = enum.auto()
     Plando = enum.auto()
-    Excluded = enum.auto()
     AllowedOrphan = enum.auto()
     """Used to flag items that shouldn't be filtered out with their parents"""
     ForceProgression = enum.auto()
     """Used to flag items that aren't classified as progression by default"""
-    Necessary = enum.auto()
-    """Used to flag items that are never allowed to be culled.
-    This differs from `Locked` in that locked items may still be culled if there's space issues or in some circumstances when a parent item is culled."""
 
-    Unremovable = Locked|StartInventory|Plando|Necessary
+    Unexcludable = StartInventory|Plando|Locked
+    Uncullable = StartInventory|Plando|Locked|Requested
+    Excluded = UserExcluded|FilterExcluded
+    RequestedOrBetter = StartInventory|Locked|Requested
+    CulledOrBetter = Removed|Excluded|Culled
 
 
 @dataclass

--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -760,8 +760,7 @@ item_descriptions = {
     item_names.INFESTED_LIBERATOR_VIRAL_CONTAMINATION: "Increases the damage Infested Liberators deal to their primary target by 100%.",
     item_names.INFESTED_LIBERATOR_DEFENDER_MODE: "Allows Infested Liberators to deploy into Defender Mode to attack ground units.",
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_SIEGE_TANK: _get_resource_efficiency_desc(item_names.INFESTED_SIEGE_TANK),
-    item_names.FRIGHTFUL_FLESHWELDER_INFESTED_DIAMONDBACK: _get_resource_efficiency_desc(
-        item_names.INFESTED_DIAMONDBACK),
+    item_names.FRIGHTFUL_FLESHWELDER_INFESTED_DIAMONDBACK: _get_resource_efficiency_desc(item_names.INFESTED_DIAMONDBACK),
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_BANSHEE: _get_resource_efficiency_desc(item_names.INFESTED_BANSHEE),
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_LIBERATOR: _get_resource_efficiency_desc(item_names.INFESTED_LIBERATOR),
     item_names.ZERG_EXCAVATING_CLAWS: "Increases movement speed of uprooted Zerg structures, especially off creep. Also increases root speed.",

--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -64,9 +64,9 @@ for item, data in item_tables.get_full_item_list().items():
             # Short-name groups are unlisted
             unlisted_item_name_groups.add(short_name)
     # Items with a parent get assigned to their parent's group
-    if data.parent_item:
+    if data.parent:
         # The parent groups need a special name, otherwise they are ambiguous with the parent
-        parent_group = f"{data.parent_item} Items"
+        parent_group = f"{data.parent} Items"
         item_name_groups.setdefault(parent_group, []).append(item)
         # Parent groups are unlisted
         unlisted_item_name_groups.add(parent_group)

--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -108,7 +108,8 @@ class ItemGroupNames:
     TERRAN_ORIGINAL_PROGRESSIVE_UPGRADES = "Terran Original Progressive Upgrades"
     """Progressive items where level 1 appeared in WoL"""
     MENGSK_UNITS = "Mengsk Units"
-    TERRAN_VETERANCY_UNITS= "Terran Veterancy Units"
+    TERRAN_VETERANCY_UNITS = "Terran Veterancy Units"
+    ORBITAL_COMMAND_ABILITIES = "Orbital Command Abilities"
 
     ZERG_ITEMS = "Zerg Items"
     ZERG_UNITS = "Zerg Units"
@@ -270,6 +271,17 @@ item_name_groups[ItemGroupNames.TERRAN_VETERANCY_UNITS] = [
     item_names.AEGIS_GUARD, item_names.EMPERORS_SHADOW, item_names.SHOCK_DIVISION, item_names.BLACKHAMMER,
     item_names.PRIDE_OF_AUGUSTRGRAD, item_names.SKY_FURY, item_names.SON_OF_KORHAL, item_names.FIELD_RESPONSE_THETA,
     item_names.BULWARK_COMPANY, item_names.NIGHT_HAWK, item_names.EMPERORS_GUARDIAN, item_names.NIGHT_WOLF,
+]
+item_name_groups[ItemGroupNames.ORBITAL_COMMAND_ABILITIES] = orbital_command_abilities = [
+    item_names.COMMAND_CENTER_SCANNER_SWEEP,
+    item_names.COMMAND_CENTER_MULE,
+    item_names.COMMAND_CENTER_EXTRA_SUPPLIES,
+]
+spider_mine_sources = [
+    item_names.VULTURE,
+    item_names.REAPER_SPIDER_MINES,
+    item_names.SIEGE_TANK_SPIDER_MINES,
+    item_names.RAVEN_SPIDER_MINES,
 ]
 
 # Terran Upgrades
@@ -564,14 +576,38 @@ item_name_groups[ItemGroupNames.HOTS_ITEMS] = vanilla_hots_items = (
 # Zerg - Infested Terran (Stukov Co-op)
 item_name_groups[ItemGroupNames.INF_TERRAN_UNITS] = infterr_units = [
     item_names.INFESTED_MARINE,
-    item_names.INFESTED_BUNKER]
+    item_names.INFESTED_BUNKER,
+    item_names.INFESTED_DIAMONDBACK,
+    item_names.INFESTED_SIEGE_TANK,
+    item_names.INFESTED_LIBERATOR,
+    item_names.INFESTED_BANSHEE,
+]
 item_name_groups[ItemGroupNames.INF_TERRAN_UPGRADES] = infterr_upgrades = [
     item_names.INFESTED_SCV_BUILD_CHARGES,
     item_names.INFESTED_MARINE_PLAGUED_MUNITIONS,
     item_names.INFESTED_MARINE_RETINAL_AUGMENTATION,
     item_names.INFESTED_BUNKER_CALCIFIED_ARMOR,
     item_names.INFESTED_BUNKER_REGENERATIVE_PLATING,
-    item_names.INFESTED_BUNKER_ENGORGED_BUNKERS
+    item_names.INFESTED_BUNKER_ENGORGED_BUNKERS,
+    item_names.INFESTED_DIAMONDBACK_CAUSTIC_MUCUS,
+    item_names.INFESTED_DIAMONDBACK_CONCENTRATED_SPEW,
+    item_names.INFESTED_DIAMONDBACK_PROGRESSIVE_FUNGAL_SNARE,
+    item_names.INFESTED_DIAMONDBACK_VIOLENT_ENZYMES,
+    item_names.INFESTED_SIEGE_TANK_ACIDIC_ENZYMES,
+    item_names.INFESTED_SIEGE_TANK_BALANCED_ROOTS,
+    item_names.INFESTED_SIEGE_TANK_DEEP_TUNNEL,
+    item_names.INFESTED_SIEGE_TANK_PROGRESSIVE_AUTOMATED_MITOSIS,
+    item_names.INFESTED_SIEGE_TANK_SEISMIC_SONAR,
+    item_names.INFESTED_LIBERATOR_CLOUD_DISPERSAL,
+    item_names.INFESTED_LIBERATOR_DEFENDER_MODE,
+    item_names.INFESTED_LIBERATOR_VIRAL_CONTAMINATION,
+    item_names.INFESTED_BANSHEE_ADVANCED_TARGETING_OPTICS,
+    item_names.INFESTED_BANSHEE_BRACED_EXOSKELETON,
+    item_names.INFESTED_BANSHEE_RAPID_HIBERNATION,
+    item_names.FRIGHTFUL_FLESHWELDER_INFESTED_DIAMONDBACK,
+    item_names.FRIGHTFUL_FLESHWELDER_INFESTED_SIEGE_TANK,
+    item_names.FRIGHTFUL_FLESHWELDER_INFESTED_LIBERATOR,
+    item_names.FRIGHTFUL_FLESHWELDER_INFESTED_BANSHEE,
 ]
 item_name_groups[ItemGroupNames.INF_TERRAN_ITEMS] = (
     infterr_units

--- a/worlds/sc2/item/item_parents.py
+++ b/worlds/sc2/item/item_parents.py
@@ -215,10 +215,10 @@ parent_id_to_children: Dict[str, Sequence[str]] = {}
 """Parent identifier to child items. Only contains parent rules with children."""
 child_item_to_parent_items: Dict[str, Sequence[str]] = {}
 for _item_name, _item_data in item_tables.item_table.items():
-    if _item_data.parent_item is None:
+    if _item_data.parent is None:
         continue
-    parent_id_to_children.setdefault(_item_data.parent_item, []).append(_item_name)
-    child_item_to_parent_items[_item_name] = parent_present[_item_data.parent_item].parent_items()
+    parent_id_to_children.setdefault(_item_data.parent, []).append(_item_name)
+    child_item_to_parent_items[_item_name] = parent_present[_item_data.parent].parent_items()
 
 
 parent_item_to_ids: Dict[str, Sequence[str]] = {}

--- a/worlds/sc2/item/item_parents.py
+++ b/worlds/sc2/item/item_parents.py
@@ -20,7 +20,7 @@ class PresenceRule(abc.ABC):
     display_string: str
     """Main item to count as the parent for min/max upgrades per unit purposes"""
     @abc.abstractmethod
-    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool: ...
+    def __call__(self, inventory: Iterable[str], options: 'Starcraft2Options') -> bool: ...
     @abc.abstractmethod
     def parent_items(self) -> Sequence[str]: ...
 
@@ -31,7 +31,7 @@ class ItemPresent(PresenceRule):
         self.constraint_group = item_name
         self.display_string = item_name
 
-    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool:
+    def __call__(self, inventory: Iterable[str], options: 'Starcraft2Options') -> bool:
         return self.item_name in inventory
 
     def parent_items(self) -> List[str]:
@@ -44,7 +44,7 @@ class AnyOf(PresenceRule):
         self.constraint_group = main_item
         self.display_string = display_string or main_item or ' | '.join(group)
 
-    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool:
+    def __call__(self, inventory: Iterable[str], options: 'Starcraft2Options') -> bool:
         return len(self.group.intersection(inventory)) > 0
 
     def parent_items(self) -> List[str]:
@@ -57,7 +57,7 @@ class AllOf(PresenceRule):
         self.constraint_group = main_item
         self.display_string = main_item or ' & '.join(group)
 
-    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool:
+    def __call__(self, inventory: Iterable[str], options: 'Starcraft2Options') -> bool:
         return len(self.group.intersection(inventory)) == len(self.group)
 
     def parent_items(self) -> List[str]:
@@ -71,7 +71,7 @@ class AnyOfGroupAndOneOtherItem(PresenceRule):
         self.constraint_group = item_name
         self.display_string = item_name
 
-    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool:
+    def __call__(self, inventory: Iterable[str], options: 'Starcraft2Options') -> bool:
         return (len(self.group.intersection(inventory)) > 0) and self.item_name in inventory
 
     def parent_items(self) -> List[str]:
@@ -84,7 +84,7 @@ class MorphlingOrItem(PresenceRule):
         self.constraint_group = None  # Keep morphs from counting towards the parent unit's upgrade count
         self.display_string = f'{item_name} Morphs'
 
-    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool:
+    def __call__(self, inventory: Iterable[str], options: 'Starcraft2Options') -> bool:
         return (options.enable_morphling.value != 0) or self.item_name in inventory
 
     def parent_items(self) -> List[str]:
@@ -97,7 +97,7 @@ class MorphlingOrAnyOf(PresenceRule):
         self.constraint_group = main_item
         self.display_string = display_string
 
-    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool:
+    def __call__(self, inventory: Iterable[str], options: 'Starcraft2Options') -> bool:
         return (options.enable_morphling.value != 0) or (len(self.group.intersection(inventory)) > 0)
 
     def parent_items(self) -> List[str]:

--- a/worlds/sc2/item/item_parents.py
+++ b/worlds/sc2/item/item_parents.py
@@ -1,0 +1,237 @@
+"""
+Utilities for telling item parentage hierarchy.
+ItemData in item_tables.py will point from child item -> parent rule.
+Rules have a `parent_items()` method which links rule -> parent items.
+Rules may be more complex than all or any items being present. Call them to determine if they are satisfied.
+"""
+
+from typing import Dict, List, Iterable, Sequence, Optional, TYPE_CHECKING
+import abc
+from . import item_names, parent_names, item_tables, item_groups
+
+if TYPE_CHECKING:
+    from ..options import Starcraft2Options
+
+
+class PresenceRule(abc.ABC):
+    """Contract for a parent presence rule. This should be a protocol in Python 3.10+"""
+    main_item: Optional[str]
+    """Main item to count as the parent for min/max upgrades per unit purposes"""
+    @abc.abstractmethod
+    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool: ...
+    @abc.abstractmethod
+    def parent_items(self) -> Sequence[str]: ...
+
+
+class ItemPresent(PresenceRule):
+    def __init__(self, item_name: str) -> None:
+        self.item_name = item_name
+        self.main_item = item_name
+
+    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool:
+        return self.item_name in inventory
+
+    def parent_items(self) -> List[str]:
+        return [self.item_name]
+
+
+class AnyOf(PresenceRule):
+    def __init__(self, group: Iterable[str], main_item: Optional[str] = None) -> None:
+        self.group = set(group)
+        self.main_item = main_item
+
+    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool:
+        return len(self.group.intersection(inventory)) > 0
+
+    def parent_items(self) -> List[str]:
+        return sorted(self.group)
+
+
+class AllOf(PresenceRule):
+    def __init__(self, group: Iterable[str], main_item: Optional[str] = None) -> None:
+        self.group = set(group)
+        self.main_item = main_item
+
+    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool:
+        return len(self.group.intersection(inventory)) == len(self.group)
+
+    def parent_items(self) -> List[str]:
+        return sorted(self.group)
+
+
+class AnyOfGroupAndOneOtherItem(PresenceRule):
+    def __init__(self, group: Iterable[str], item_name: str) -> None:
+        self.group = set(group)
+        self.item_name = item_name
+        self.main_item = item_name
+
+    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool:
+        return (len(self.group.intersection(inventory)) > 0) and self.item_name in inventory
+
+    def parent_items(self) -> List[str]:
+        return sorted(self.group) + [self.item_name]
+
+
+class MorphlingOrItem(PresenceRule):
+    def __init__(self, item_name: str, has_parent: bool = True) -> None:
+        self.item_name = item_name
+        self.main_item = None  # Keep morphs from counting towards the parent unit's upgrade count
+
+    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool:
+        return (options.enable_morphling.value != 0) or self.item_name in inventory
+
+    def parent_items(self) -> List[str]:
+        return [self.item_name]
+
+
+class MorphlingOrAnyOf(PresenceRule):
+    def __init__(self, group: Iterable[str], main_item: Optional[str] = None) -> None:
+        self.group = set(group)
+        self.main_item = main_item
+
+    def __call__(self, inventory: List[str], options: 'Starcraft2Options') -> bool:
+        return (options.enable_morphling.value != 0) or (len(self.group.intersection(inventory)) > 0)
+
+    def parent_items(self) -> List[str]:
+        return sorted(self.group)
+
+
+parent_present: Dict[str, PresenceRule] = {
+    item_name: ItemPresent(item_name)
+    for item_name in item_tables.item_table
+}
+
+# Terran
+parent_present[parent_names.DOMINION_TROOPER_WEAPONS] = AnyOf([
+    item_names.DOMINION_TROOPER_B2_HIGH_CAL_LMG,
+    item_names.DOMINION_TROOPER_CPO7_SALAMANDER_FLAMETHROWER,
+    item_names.DOMINION_TROOPER_HAILSTORM_LAUNCHER,
+], main_item=item_names.DOMINION_TROOPER)
+parent_present[parent_names.INFANTRY_UNITS] = AnyOf(item_groups.barracks_units)
+parent_present[parent_names.INFANTRY_WEAPON_UNITS] = AnyOf(item_groups.barracks_wa_group)
+parent_present[parent_names.ORBITAL_COMMAND_AND_PLANETARY] = AnyOfGroupAndOneOtherItem(
+    item_groups.orbital_command_abilities,
+    item_names.PLANETARY_FORTRESS,
+)
+parent_present[parent_names.SIEGE_TANK_AND_TRANSPORT] = AnyOfGroupAndOneOtherItem(
+    (item_names.MEDIVAC, item_names.HERCULES),
+    item_names.SIEGE_TANK,
+)
+parent_present[parent_names.SIEGE_TANK_AND_MEDIVAC] = AllOf((item_names.SIEGE_TANK, item_names.MEDIVAC), item_names.SIEGE_TANK)
+parent_present[parent_names.SPIDER_MINE_SOURCE] = AnyOf(item_groups.spider_mine_sources)
+parent_present[parent_names.STARSHIP_UNITS] = AnyOf(item_groups.starport_units)
+parent_present[parent_names.STARSHIP_WEAPON_UNITS] = AnyOf(item_groups.starport_wa_group)
+parent_present[parent_names.VEHICLE_UNITS] = AnyOf(item_groups.factory_units)
+parent_present[parent_names.VEHICLE_WEAPON_UNITS] = AnyOf(item_groups.factory_wa_group)
+
+# Zerg
+parent_present[parent_names.ANY_NYDUS_WORM] = AnyOf((item_names.NYDUS_WORM, item_names.ECHIDNA_WORM), item_names.NYDUS_WORM)
+parent_present[parent_names.BANELING_SOURCE] = AnyOf(
+    (item_names.ZERGLING_BANELING_ASPECT, item_names.KERRIGAN_SPAWN_BANELINGS),
+    item_names.ZERGLING_BANELING_ASPECT,
+)
+parent_present[parent_names.INFESTED_UNITS] = AnyOf(item_groups.infterr_units)
+parent_present[parent_names.MORPH_SOURCE_AIR] = MorphlingOrAnyOf((item_names.MUTALISK, item_names.CORRUPTOR))
+parent_present[parent_names.MORPH_SOURCE_ROACH] = MorphlingOrItem(item_names.ROACH)
+parent_present[parent_names.MORPH_SOURCE_ZERGLING] = MorphlingOrAnyOf((item_names.ZERGLING, item_names.ZERGLING_RECONSTITUTION))
+parent_present[parent_names.MORPH_SOURCE_HYDRALISK] = MorphlingOrItem(item_names.HYDRALISK)
+parent_present[parent_names.MORPH_SOURCE_ULTRALISK] = MorphlingOrItem(item_names.ULTRALISK)
+parent_present[parent_names.ZERG_UPROOTABLE_BUILDINGS] = AnyOf(
+    (item_names.SPINE_CRAWLER, item_names.SPORE_CRAWLER, item_names.INFESTED_MISSILE_TURRET, item_names.INFESTED_BUNKER),
+)
+parent_present[parent_names.ZERG_MELEE_ATTACKER] = AnyOf(item_groups.zerg_melee_wa)
+parent_present[parent_names.ZERG_MISSILE_ATTACKER] = AnyOf(item_groups.zerg_ranged_wa)
+parent_present[parent_names.ZERG_CARAPACE_UNIT] = AnyOf(item_groups.zerg_ground_units)
+parent_present[parent_names.ZERG_FLYING_UNIT] = AnyOf(item_groups.zerg_air_units)
+
+# Protoss
+parent_present[parent_names.ARCHON_SOURCE] = AnyOf(
+    (item_names.HIGH_TEMPLAR, item_names.SIGNIFIER, item_names.ASCENDANT, item_names.DARK_TEMPLAR),
+    main_item="Archon",
+)
+parent_present[parent_names.CARRIER_CLASS] = AnyOf(
+    (item_names.CARRIER, item_names.TRIREME, item_names.SKYLORD),
+    main_item=item_names.CARRIER,
+)
+parent_present[parent_names.CARRIER_OR_TRIREME] = AnyOf(
+    (item_names.CARRIER, item_names.TRIREME),
+    main_item=item_names.CARRIER,
+)
+parent_present[parent_names.DARK_ARCHON_SOURCE] = AnyOf(
+    (item_names.DARK_ARCHON, item_names.DARK_TEMPLAR_DARK_ARCHON_MELD),
+    main_item=item_names.DARK_ARCHON,
+)
+parent_present[parent_names.DARK_TEMPLAR_CLASS] = AnyOf(
+    (item_names.DARK_TEMPLAR, item_names.AVENGER, item_names.BLOOD_HUNTER),
+    main_item=item_names.DARK_TEMPLAR,
+)
+parent_present[parent_names.STORM_CASTER] = AnyOf(
+    (item_names.HIGH_TEMPLAR, item_names.SIGNIFIER),
+    main_item=item_names.HIGH_TEMPLAR,
+)
+parent_present[parent_names.IMMORTAL_OR_ANNIHILATOR] = AnyOf(
+    (item_names.IMMORTAL, item_names.ANNIHILATOR),
+    main_item=item_names.IMMORTAL,
+)
+parent_present[parent_names.PHOENIX_CLASS] = AnyOf(
+    (item_names.PHOENIX, item_names.MIRAGE, item_names.SKIRMISHER),
+    main_item=item_names.PHOENIX,
+)
+parent_present[parent_names.SENTRY_CLASS] = AnyOf(
+    (item_names.SENTRY, item_names.ENERGIZER, item_names.HAVOC),
+    main_item=item_names.SENTRY,
+)
+parent_present[parent_names.SENTRY_CLASS_OR_SHIELD_BATTERY] = AnyOf(
+    (item_names.SENTRY, item_names.ENERGIZER, item_names.HAVOC, item_names.SHIELD_BATTERY),
+    main_item=item_names.SENTRY,
+)
+parent_present[parent_names.STALKER_CLASS] = AnyOf(
+    (item_names.STALKER, item_names.SLAYER, item_names.INSTIGATOR),
+    main_item=item_names.STALKER,
+)
+parent_present[parent_names.SUPPLICANT_AND_ASCENDANT] = AnyOf(
+    (item_names.SUPPLICANT, item_names.ASCENDANT),
+    main_item=item_names.ASCENDANT,
+)
+parent_present[parent_names.VOID_RAY_CLASS] = AnyOf(
+    (item_names.VOID_RAY, item_names.DESTROYER, item_names.WARP_RAY, item_names.DAWNBRINGER),
+    main_item=item_names.VOID_RAY,
+)
+parent_present[parent_names.ZEALOT_OR_SENTINEL_OR_CENTURION] = AnyOf(
+    (item_names.ZEALOT, item_names.SENTINEL, item_names.CENTURION),
+    main_item=item_names.ZEALOT,
+)
+parent_present[parent_names.PROTOSS_STATIC_DEFENSE] = AnyOf(
+    (item_names.NEXUS_OVERCHARGE, item_names.PHOTON_CANNON, item_names.KHAYDARIN_MONOLITH, item_names.SHIELD_BATTERY),
+    main_item=item_names.PHOTON_CANNON,
+)
+parent_present[parent_names.PROTOSS_ATTACKING_BUILDING] = AnyOf(
+    (item_names.NEXUS_OVERCHARGE, item_names.PHOTON_CANNON, item_names.KHAYDARIN_MONOLITH),
+    main_item=item_names.PHOTON_CANNON,
+)
+
+
+parent_id_to_children: Dict[str, Sequence[str]] = {}
+"""Parent identifier to child items. Only contains parent rules with children."""
+child_item_to_parent_items: Dict[str, Sequence[str]] = {}
+for _item_name, _item_data in item_tables.item_table.items():
+    if _item_data.parent_item is None:
+        continue
+    parent_id_to_children.setdefault(_item_data.parent_item, []).append(_item_name)
+    child_item_to_parent_items[_item_name] = parent_present[_item_data.parent_item].parent_items()
+
+
+parent_item_to_ids: Dict[str, Sequence[str]] = {}
+"""Parent item to parent identifiers it affects. Populated for all items and parent IDs."""
+parent_item_to_children: Dict[str, Sequence[str]] = {}
+"""Parent item to child item names. Populated for all items and parent IDs."""
+item_upgrade_groups: Dict[str, Sequence[str]] = {}
+"""Mapping of upgradable item group -> child items. Only populated for groups with child items."""
+# Note(mm): "All items" promise satisfied by the basic ItemPresent auto-generated rules
+for _parent_id, _presence_func in parent_present.items():
+    for parent_item in _presence_func.parent_items():
+        parent_item_to_ids.setdefault(parent_item, []).append(_parent_id)
+        parent_item_to_children.setdefault(parent_item, []).extend(parent_id_to_children.get(_parent_id, []))
+    if _presence_func.main_item is not None and parent_id_to_children.get(_parent_id):
+        item_upgrade_groups.setdefault(_presence_func.main_item, []).extend(parent_id_to_children[_parent_id])
+

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -5,7 +5,7 @@ import typing
 import enum
 
 from ..mission_tables import SC2Mission, SC2Race, SC2Campaign
-from ..item import item_names
+from ..item import item_names, parent_names
 from ..mission_order.presets_static import get_used_layout_names
 
 
@@ -112,9 +112,11 @@ class ItemData(typing.NamedTuple):
     important_for_filtering: bool = False
 
     def is_important_for_filtering(self):
-        return self.important_for_filtering \
-            or self.classification == ItemClassification.progression \
+        return (
+            self.important_for_filtering
+            or self.classification == ItemClassification.progression
             or self.classification == ItemClassification.progression_skip_balancing
+        )
 
 
 def get_full_item_list():
@@ -248,18 +250,18 @@ item_table = {
                  classification=ItemClassification.progression),
 
     # Some other items are moved to Upgrade group because of the way how the bot message is parsed
-    item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON: ItemData(100 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 0, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR: ItemData(102 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 4, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON: ItemData(103 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 8, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_TERRAN_VEHICLE_ARMOR: ItemData(104 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 12, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_TERRAN_SHIP_WEAPON: ItemData(105 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 16, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_TERRAN_SHIP_ARMOR: ItemData(106 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 20, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
+    item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON: ItemData(100 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 0, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.INFANTRY_WEAPON_UNITS),
+    item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR: ItemData(102 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 4, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.INFANTRY_UNITS),
+    item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON: ItemData(103 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 8, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.VEHICLE_WEAPON_UNITS),
+    item_names.PROGRESSIVE_TERRAN_VEHICLE_ARMOR: ItemData(104 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 12, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.VEHICLE_UNITS),
+    item_names.PROGRESSIVE_TERRAN_SHIP_WEAPON: ItemData(105 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 16, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.STARSHIP_WEAPON_UNITS),
+    item_names.PROGRESSIVE_TERRAN_SHIP_ARMOR: ItemData(106 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 20, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.STARSHIP_UNITS),
     # Bundles
     item_names.PROGRESSIVE_TERRAN_WEAPON_UPGRADE: ItemData(107 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
     item_names.PROGRESSIVE_TERRAN_ARMOR_UPGRADE: ItemData(108 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE: ItemData(109 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE: ItemData(110 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_TERRAN_SHIP_UPGRADE: ItemData(111 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
+    item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE: ItemData(109 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.INFANTRY_UNITS),
+    item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE: ItemData(110 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.VEHICLE_UNITS),
+    item_names.PROGRESSIVE_TERRAN_SHIP_UPGRADE: ItemData(111 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.STARSHIP_UNITS),
     item_names.PROGRESSIVE_TERRAN_WEAPON_ARMOR_UPGRADE: ItemData(112 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
 
     # Unit and structure upgrades
@@ -449,7 +451,8 @@ item_table = {
         ItemData(261 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 26, SC2Race.TERRAN,
                  parent_item=item_names.VULTURE),
     item_names.SPIDER_MINE_HIGH_EXPLOSIVE_MUNITION:
-        ItemData(262 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 27, SC2Race.TERRAN),
+        ItemData(262 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 27, SC2Race.TERRAN,
+            parent_item=parent_names.SPIDER_MINE_SOURCE),
     item_names.GOLIATH_JUMP_JETS:
         ItemData(263 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 28, SC2Race.TERRAN,
                  classification=ItemClassification.progression, parent_item=item_names.GOLIATH),
@@ -531,7 +534,7 @@ item_table = {
                  classification=ItemClassification.filler, parent_item=item_names.REAPER),
     item_names.SIEGE_TANK_PROGRESSIVE_TRANSPORT_HOOK:
         ItemData(289 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive_2, 6, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.SIEGE_TANK, quantity=2),
+                 classification=ItemClassification.progression, parent_item=parent_names.SIEGE_TANK_AND_TRANSPORT, quantity=2),
     item_names.SIEGE_TANK_ENHANCED_COMBUSTION_ENGINES:
         ItemData(290 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 20, SC2Race.TERRAN,
                  classification=ItemClassification.filler, parent_item=item_names.SIEGE_TANK),
@@ -570,7 +573,7 @@ item_table = {
                  parent_item=item_names.HELLION),
     item_names.SPIDER_MINE_CERBERUS_MINE:
         ItemData(302 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 18, SC2Race.TERRAN,
-                 classification=ItemClassification.filler),
+                 classification=ItemClassification.filler, parent_item=parent_names.SPIDER_MINE_SOURCE),
     item_names.VULTURE_PROGRESSIVE_REPLENISHABLE_MAGAZINE:
         ItemData(303 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 16, SC2Race.TERRAN,
                  classification=ItemClassification.filler, parent_item=item_names.VULTURE, quantity=2),
@@ -846,7 +849,7 @@ item_table = {
                  classification=ItemClassification.progression, parent_item=item_names.BATTLECRUISER),
     item_names.PLANETARY_FORTRESS_ORBITAL_MODULE:
         ItemData(395 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 1, SC2Race.TERRAN,
-                 parent_item=item_names.PLANETARY_FORTRESS),
+                 parent_item=parent_names.ORBITAL_COMMAND_AND_PLANETARY),
     item_names.DEVASTATOR_TURRET_CONCUSSIVE_GRENADES:
         ItemData(396 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 0, SC2Race.TERRAN,
                  parent_item=item_names.DEVASTATOR_TURRET),
@@ -933,7 +936,8 @@ item_table = {
     item_names.TECH_REACTOR:
         ItemData(608 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 6, SC2Race.TERRAN),
     item_names.ORBITAL_STRIKE:
-        ItemData(609 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 7, SC2Race.TERRAN),
+        ItemData(609 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 7, SC2Race.TERRAN,
+                parent_item=parent_names.INFANTRY_UNITS),
     item_names.BUNKER_SHRIKE_TURRET:
         ItemData(610 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 6, SC2Race.TERRAN,
                  parent_item=item_names.BUNKER),
@@ -1043,7 +1047,7 @@ item_table = {
                  parent_item=item_names.DOMINION_TROOPER, important_for_filtering=True),
     item_names.DOMINION_TROOPER_ADVANCED_ALLOYS:
         ItemData(760 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 14, SC2Race.TERRAN,
-                 parent_item=item_names.DOMINION_TROOPER),
+                 parent_item=parent_names.DOMINION_TROOPER_WEAPONS),
     item_names.DOMINION_TROOPER_OPTIMIZED_LOGISTICS:
         ItemData(761 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 15, SC2Race.TERRAN,
                  parent_item=item_names.DOMINION_TROOPER, classification=ItemClassification.filler),
@@ -1139,7 +1143,7 @@ item_table = {
                  classification=ItemClassification.progression),
     item_names.ZERGLING_BANELING_ASPECT:
         ItemData(4 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 5, SC2Race.ZERG,
-                 classification=ItemClassification.progression),
+                 classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_ZERGLING),
     item_names.ABERRATION:
         ItemData(5 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 5, SC2Race.ZERG,
                  classification=ItemClassification.progression),
@@ -1204,16 +1208,16 @@ item_table = {
         ItemData(25 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 24, SC2Race.ZERG,
                  classification=ItemClassification.progression),
 
-    item_names.PROGRESSIVE_ZERG_MELEE_ATTACK: ItemData(100 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 0, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_ZERG_MISSILE_ATTACK: ItemData(101 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 4, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_ZERG_GROUND_CARAPACE: ItemData(102 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 8, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_ZERG_FLYER_ATTACK: ItemData(103 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 12, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_ZERG_FLYER_CARAPACE: ItemData(104 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 16, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
+    item_names.PROGRESSIVE_ZERG_MELEE_ATTACK: ItemData(100 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 0, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_MELEE_ATTACKER),
+    item_names.PROGRESSIVE_ZERG_MISSILE_ATTACK: ItemData(101 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 4, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_MISSILE_ATTACKER),
+    item_names.PROGRESSIVE_ZERG_GROUND_CARAPACE: ItemData(102 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 8, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_CARAPACE_UNIT),
+    item_names.PROGRESSIVE_ZERG_FLYER_ATTACK: ItemData(103 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 12, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_FLYING_UNIT),
+    item_names.PROGRESSIVE_ZERG_FLYER_CARAPACE: ItemData(104 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 16, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_FLYING_UNIT),
     # Bundles
     item_names.PROGRESSIVE_ZERG_WEAPON_UPGRADE: ItemData(105 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
     item_names.PROGRESSIVE_ZERG_ARMOR_UPGRADE: ItemData(106 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_ZERG_GROUND_UPGRADE: ItemData(107 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_ZERG_FLYER_UPGRADE: ItemData(108 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
+    item_names.PROGRESSIVE_ZERG_GROUND_UPGRADE: ItemData(107 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_CARAPACE_UNIT),
+    item_names.PROGRESSIVE_ZERG_FLYER_UPGRADE: ItemData(108 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_FLYING_UNIT),
     item_names.PROGRESSIVE_ZERG_WEAPON_ARMOR_UPGRADE: ItemData(109 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
 
     item_names.ZERGLING_HARDENED_CARAPACE:
@@ -1236,14 +1240,14 @@ item_table = {
         ItemData(208 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 8, SC2Race.ZERG, parent_item=item_names.HYDRALISK),
     item_names.BANELING_CORROSIVE_ACID:
         ItemData(209 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 9, SC2Race.ZERG,
-                 parent_item=item_names.ZERGLING_BANELING_ASPECT, classification=ItemClassification.progression),
+                 parent_item=parent_names.BANELING_SOURCE, classification=ItemClassification.progression),
     item_names.BANELING_RUPTURE:
         ItemData(210 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 10, SC2Race.ZERG,
-                 parent_item=item_names.ZERGLING_BANELING_ASPECT,
+                 parent_item=parent_names.BANELING_SOURCE,
                  classification=ItemClassification.filler),
     item_names.BANELING_REGENERATIVE_ACID:
         ItemData(211 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 11, SC2Race.ZERG,
-                 parent_item=item_names.ZERGLING_BANELING_ASPECT,
+                 parent_item=parent_names.BANELING_SOURCE,
                  classification=ItemClassification.filler),
     item_names.MUTALISK_VICIOUS_GLAIVE:
         ItemData(212 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 12, SC2Race.ZERG, parent_item=item_names.MUTALISK, classification=ItemClassification.progression),
@@ -1285,13 +1289,13 @@ item_table = {
         ItemData(230 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 0, SC2Race.ZERG, parent_item=item_names.HYDRALISK, classification=ItemClassification.progression),
     item_names.BANELING_CENTRIFUGAL_HOOKS:
         ItemData(231 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 1, SC2Race.ZERG,
-                 parent_item=item_names.ZERGLING_BANELING_ASPECT),
+                 parent_item=parent_names.BANELING_SOURCE),
     item_names.BANELING_TUNNELING_JAWS:
         ItemData(232 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 2, SC2Race.ZERG,
-                 parent_item=item_names.ZERGLING_BANELING_ASPECT),
+                 parent_item=parent_names.BANELING_SOURCE),
     item_names.BANELING_RAPID_METAMORPH:
         ItemData(233 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 3, SC2Race.ZERG,
-                 parent_item=item_names.ZERGLING_BANELING_ASPECT),
+                 parent_item=parent_names.MORPH_SOURCE_ZERGLING),
     item_names.MUTALISK_SEVERING_GLAIVE:
         ItemData(234 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 4, SC2Race.ZERG, parent_item=item_names.MUTALISK, classification=ItemClassification.progression),
     item_names.MUTALISK_AERODYNAMIC_GLAIVE_SHAPE:
@@ -1436,7 +1440,7 @@ item_table = {
     item_names.PRIMAL_IGNITER_PRIMAL_TENACITY:
         ItemData(291 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 1, SC2Race.ZERG, parent_item=item_names.ROACH_PRIMAL_IGNITER_ASPECT, classification=ItemClassification.progression),
     item_names.INFESTED_SCV_BUILD_CHARGES:
-        ItemData(292 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 2, SC2Race.ZERG),
+        ItemData(292 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 2, SC2Race.ZERG, parent_item=parent_names.INFESTED_UNITS),
     item_names.INFESTED_MARINE_PLAGUED_MUNITIONS:
         ItemData(293 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 3, SC2Race.ZERG, parent_item=item_names.INFESTED_MARINE),
     item_names.INFESTED_MARINE_RETINAL_AUGMENTATION:
@@ -1462,22 +1466,20 @@ item_table = {
         ItemData(303 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 3, SC2Race.ZERG, parent_item=item_names.ROACH, classification=ItemClassification.progression),
     item_names.HYDRALISK_IMPALER_ASPECT:
         ItemData(304 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 0, SC2Race.ZERG,
-                 classification=ItemClassification.progression),
+                 classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_HYDRALISK),
     item_names.HYDRALISK_LURKER_ASPECT:
         ItemData(305 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 1, SC2Race.ZERG,
-                 classification=ItemClassification.progression),
+                 classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_HYDRALISK),
     item_names.BANELING_SPLITTER_STRAIN:
-        ItemData(306 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 6, SC2Race.ZERG,
-                 parent_item=item_names.ZERGLING_BANELING_ASPECT),
+        ItemData(306 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 6, SC2Race.ZERG, parent_item=parent_names.BANELING_SOURCE),
     item_names.BANELING_HUNTER_STRAIN:
-        ItemData(307 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 7, SC2Race.ZERG,
-                 parent_item=item_names.ZERGLING_BANELING_ASPECT),
+        ItemData(307 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 7, SC2Race.ZERG, parent_item=parent_names.BANELING_SOURCE),
     item_names.MUTALISK_CORRUPTOR_BROOD_LORD_ASPECT:
         ItemData(308 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 2, SC2Race.ZERG,
-                 classification=ItemClassification.progression),
+                 classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_AIR),
     item_names.MUTALISK_CORRUPTOR_VIPER_ASPECT:
         ItemData(309 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 3, SC2Race.ZERG,
-                 classification=ItemClassification.progression),
+                 classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_AIR),
     item_names.SWARM_HOST_CARRION_STRAIN:
         ItemData(310 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 10, SC2Race.ZERG, parent_item=item_names.SWARM_HOST),
     item_names.SWARM_HOST_CREEPER_STRAIN:
@@ -1496,11 +1498,11 @@ item_table = {
     item_names.TYRANNOZOR_HEALING_ADAPTATION:
         ItemData(353 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 11, SC2Race.ZERG, parent_item=item_names.ULTRALISK_TYRANNOZOR_ASPECT),
     item_names.NYDUS_WORM_ECHIDNA_WORM_SUBTERRANEAN_SCALES:
-        ItemData(354 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 12, SC2Race.ZERG, classification=ItemClassification.filler),
+        ItemData(354 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 12, SC2Race.ZERG, parent_item=parent_names.ANY_NYDUS_WORM, classification=ItemClassification.filler),
     item_names.NYDUS_WORM_ECHIDNA_WORM_JORMUNGANDR_STRAIN:
-        ItemData(355 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 13, SC2Race.ZERG, classification=ItemClassification.useful),
+        ItemData(355 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 13, SC2Race.ZERG, parent_item=parent_names.ANY_NYDUS_WORM, classification=ItemClassification.useful),
     item_names.NYDUS_WORM_ECHIDNA_WORM_RESOURCE_EFFICIENCY:
-        ItemData(356 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 14, SC2Race.ZERG, classification=ItemClassification.useful),
+        ItemData(356 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 14, SC2Race.ZERG, parent_item=parent_names.ANY_NYDUS_WORM, classification=ItemClassification.useful),
     item_names.ECHIDNA_WORM_OUROBOROS_STRAIN:
         ItemData(357 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 15, SC2Race.ZERG, parent_item=item_names.ECHIDNA_WORM, classification=ItemClassification.useful),
     item_names.NYDUS_WORM_RAVENOUS_APPETITE:
@@ -1618,7 +1620,7 @@ item_table = {
     item_names.OVERLORD_GENERATE_CREEP: ItemData(701 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 7, SC2Race.ZERG),
     item_names.OVERLORD_ANTENNAE: ItemData(702 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 8, SC2Race.ZERG, classification=ItemClassification.filler),
     item_names.OVERLORD_PNEUMATIZED_CARAPACE: ItemData(703 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 9, SC2Race.ZERG),
-    item_names.ZERG_EXCAVATING_CLAWS: ItemData(704 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 11, SC2Race.ZERG),
+    item_names.ZERG_EXCAVATING_CLAWS: ItemData(704 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 11, SC2Race.ZERG, parent_item=parent_names.ZERG_UPROOTABLE_BUILDINGS),
     item_names.ZERG_CREEP_STOMACH: ItemData(705 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 10, SC2Race.ZERG),
     item_names.HIVE_CLUSTER_MATURATION: ItemData(706 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 12, SC2Race.ZERG),
     item_names.MACROSCOPIC_RECUPERATION: ItemData(707 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 13, SC2Race.ZERG),
@@ -1626,12 +1628,12 @@ item_table = {
     item_names.BROODLING_PACKING: ItemData(709 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 15, SC2Race.ZERG),
 
     # Morphs
-    item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT: ItemData(800 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 6, SC2Race.ZERG, classification=ItemClassification.progression),
-    item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT: ItemData(801 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 7, SC2Race.ZERG, classification=ItemClassification.progression),
-    item_names.ROACH_RAVAGER_ASPECT: ItemData(802 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 8, SC2Race.ZERG, classification=ItemClassification.progression),
+    item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT: ItemData(800 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 6, SC2Race.ZERG, classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_AIR),
+    item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT: ItemData(801 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 7, SC2Race.ZERG, classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_AIR),
+    item_names.ROACH_RAVAGER_ASPECT: ItemData(802 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 8, SC2Race.ZERG, classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_ROACH),
     item_names.OVERLORD_OVERSEER_ASPECT: ItemData(803 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 4, SC2Race.ZERG, classification=ItemClassification.progression),
-    item_names.ROACH_PRIMAL_IGNITER_ASPECT: ItemData(804 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 9, SC2Race.ZERG, classification=ItemClassification.progression),
-    item_names.ULTRALISK_TYRANNOZOR_ASPECT: ItemData(805 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 10, SC2Race.ZERG, classification=ItemClassification.progression),
+    item_names.ROACH_PRIMAL_IGNITER_ASPECT: ItemData(804 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 9, SC2Race.ZERG, classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_ROACH),
+    item_names.ULTRALISK_TYRANNOZOR_ASPECT: ItemData(805 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 10, SC2Race.ZERG, classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_ULTRALISK),
 
 
     # Protoss Units (those that aren't as items in WoL (Prophecy))
@@ -1768,8 +1770,8 @@ item_table = {
     item_names.ADEPT_SHOCKWAVE: ItemData(303 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 3, SC2Race.PROTOSS, parent_item=item_names.ADEPT),
     item_names.ADEPT_RESONATING_GLAIVES: ItemData(304 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 4, SC2Race.PROTOSS, parent_item=item_names.ADEPT),
     item_names.ADEPT_PHASE_BULWARK: ItemData(305 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 5, SC2Race.PROTOSS, parent_item=item_names.ADEPT),
-    item_names.STALKER_INSTIGATOR_SLAYER_DISINTEGRATING_PARTICLES: ItemData(306 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 6, SC2Race.PROTOSS, classification=ItemClassification.useful),
-    item_names.STALKER_INSTIGATOR_SLAYER_PARTICLE_REFLECTION: ItemData(307 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 7, SC2Race.PROTOSS, classification=ItemClassification.useful),
+    item_names.STALKER_INSTIGATOR_SLAYER_DISINTEGRATING_PARTICLES: ItemData(306 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 6, SC2Race.PROTOSS, classification=ItemClassification.useful, parent_item=parent_names.STALKER_CLASS),
+    item_names.STALKER_INSTIGATOR_SLAYER_PARTICLE_REFLECTION: ItemData(307 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 7, SC2Race.PROTOSS, classification=ItemClassification.useful, parent_item=parent_names.STALKER_CLASS),
     item_names.DRAGOON_HIGH_IMPACT_PHASE_DISRUPTORS: ItemData(308 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 8, SC2Race.PROTOSS, parent_item=item_names.DRAGOON),
     item_names.DRAGOON_TRILLIC_COMPRESSION_SYSTEM: ItemData(309 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 9, SC2Race.PROTOSS, parent_item=item_names.DRAGOON),
     item_names.DRAGOON_SINGULARITY_CHARGE: ItemData(310 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 10, SC2Race.PROTOSS, parent_item=item_names.DRAGOON),
@@ -1781,8 +1783,8 @@ item_table = {
     item_names.TEMPEST_TECTONIC_DESTABILIZERS: ItemData(316 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 16, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.TEMPEST),
     item_names.TEMPEST_QUANTIC_REACTOR: ItemData(317 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 17, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.TEMPEST),
     item_names.TEMPEST_GRAVITY_SLING: ItemData(318 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 18, SC2Race.PROTOSS, parent_item=item_names.TEMPEST),
-    item_names.PHOENIX_CLASS_IONIC_WAVELENGTH_FLUX: ItemData(319 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 19, SC2Race.PROTOSS),
-    item_names.PHOENIX_CLASS_ANION_PULSE_CRYSTALS: ItemData(320 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 20, SC2Race.PROTOSS),
+    item_names.PHOENIX_CLASS_IONIC_WAVELENGTH_FLUX: ItemData(319 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 19, SC2Race.PROTOSS, parent_item=parent_names.PHOENIX_CLASS),
+    item_names.PHOENIX_CLASS_ANION_PULSE_CRYSTALS: ItemData(320 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 20, SC2Race.PROTOSS, parent_item=parent_names.PHOENIX_CLASS),
     item_names.CORSAIR_STEALTH_DRIVE: ItemData(321 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 21, SC2Race.PROTOSS, parent_item=item_names.CORSAIR),
     item_names.CORSAIR_ARGUS_JEWEL: ItemData(322 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 22, SC2Race.PROTOSS, parent_item=item_names.CORSAIR),
     item_names.CORSAIR_SUSTAINING_DISRUPTION: ItemData(323 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 23, SC2Race.PROTOSS, parent_item=item_names.CORSAIR),
@@ -1796,11 +1798,11 @@ item_table = {
     item_names.ARBITER_RESOURCE_EFFICIENCY: ItemData(331 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 1, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.ARBITER),
     item_names.ARBITER_ENHANCED_CLOAK_FIELD: ItemData(332 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 2, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.ARBITER),
     item_names.CARRIER_TRIREME_GRAVITON_CATAPULT:
-        ItemData(333 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 3, SC2Race.PROTOSS),
+        ItemData(333 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 3, SC2Race.PROTOSS, parent_item=parent_names.CARRIER_OR_TRIREME),
     item_names.CARRIER_SKYLORD_TRIREME_HULL_OF_PAST_GLORIES:
-        ItemData(334 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 4, SC2Race.PROTOSS),
+        ItemData(334 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 4, SC2Race.PROTOSS, parent_item=parent_names.CARRIER_CLASS),
     item_names.VOID_RAY_DESTROYER_WARP_RAY_DAWNBRINGER_FLUX_VANES:
-        ItemData(335 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 5, SC2Race.PROTOSS, classification=ItemClassification.filler),
+        ItemData(335 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 5, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=parent_names.VOID_RAY_CLASS),
     item_names.DESTROYER_RESOURCE_EFFICIENCY: ItemData(535 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 6, SC2Race.PROTOSS, parent_item=item_names.DESTROYER),
     item_names.WARP_PRISM_GRAVITIC_DRIVE:
         ItemData(337 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 7, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.WARP_PRISM),
@@ -1816,39 +1818,39 @@ item_table = {
     item_names.REAVER_RESOURCE_EFFICIENCY: ItemData(345 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 15, SC2Race.PROTOSS, parent_item=item_names.REAVER),
     item_names.VANGUARD_AGONY_LAUNCHERS: ItemData(346 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 16, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
     item_names.VANGUARD_MATTER_DISPERSION: ItemData(347 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 17, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
-    item_names.IMMORTAL_ANNIHILATOR_SINGULARITY_CHARGE: ItemData(348 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 18, SC2Race.PROTOSS),
-    item_names.IMMORTAL_ANNIHILATOR_ADVANCED_TARGETING_MECHANICS: ItemData(349 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 19, SC2Race.PROTOSS, classification=ItemClassification.progression),
+    item_names.IMMORTAL_ANNIHILATOR_SINGULARITY_CHARGE: ItemData(348 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 18, SC2Race.PROTOSS, parent_item=parent_names.IMMORTAL_OR_ANNIHILATOR),
+    item_names.IMMORTAL_ANNIHILATOR_ADVANCED_TARGETING_MECHANICS: ItemData(349 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 19, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=parent_names.IMMORTAL_OR_ANNIHILATOR),
     item_names.COLOSSUS_PACIFICATION_PROTOCOL: ItemData(350 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 20, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.COLOSSUS),
     item_names.WRATHWALKER_RAPID_POWER_CYCLING: ItemData(351 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 21, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.WRATHWALKER),
     item_names.WRATHWALKER_EYE_OF_WRATH: ItemData(352 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 22, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.WRATHWALKER),
-    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_SHROUD_OF_ADUN: ItemData(353 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 23, SC2Race.PROTOSS),
-    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_SHADOW_GUARD_TRAINING: ItemData(354 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 24, SC2Race.PROTOSS),
-    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_BLINK: ItemData(355 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 25, SC2Race.PROTOSS, classification=ItemClassification.progression),
-    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_RESOURCE_EFFICIENCY: ItemData(356 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 26, SC2Race.PROTOSS),
+    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_SHROUD_OF_ADUN: ItemData(353 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 23, SC2Race.PROTOSS, parent_item=parent_names.DARK_TEMPLAR_CLASS),
+    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_SHADOW_GUARD_TRAINING: ItemData(354 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 24, SC2Race.PROTOSS, parent_item=parent_names.DARK_TEMPLAR_CLASS),
+    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_BLINK: ItemData(355 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 25, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=parent_names.DARK_TEMPLAR_CLASS),
+    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_RESOURCE_EFFICIENCY: ItemData(356 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 26, SC2Race.PROTOSS, parent_item=parent_names.DARK_TEMPLAR_CLASS),
     item_names.DARK_TEMPLAR_DARK_ARCHON_MELD: ItemData(357 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 27, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.DARK_TEMPLAR),
-    item_names.HIGH_TEMPLAR_SIGNIFIER_UNSHACKLED_PSIONIC_STORM: ItemData(358 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 28, SC2Race.PROTOSS),
-    item_names.HIGH_TEMPLAR_SIGNIFIER_HALLUCINATION: ItemData(359 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 29, SC2Race.PROTOSS, classification=ItemClassification.filler),
-    item_names.HIGH_TEMPLAR_SIGNIFIER_KHAYDARIN_AMULET: ItemData(360 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 0, SC2Race.PROTOSS),
-    item_names.ARCHON_HIGH_ARCHON: ItemData(361 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 1, SC2Race.PROTOSS, classification=ItemClassification.progression),
-    item_names.DARK_ARCHON_FEEDBACK: ItemData(362 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 2, SC2Race.PROTOSS, classification=ItemClassification.progression),
-    item_names.DARK_ARCHON_MAELSTROM: ItemData(363 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 3, SC2Race.PROTOSS),
-    item_names.DARK_ARCHON_ARGUS_TALISMAN: ItemData(364 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 4, SC2Race.PROTOSS),
-    item_names.ASCENDANT_POWER_OVERWHELMING: ItemData(365 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 5, SC2Race.PROTOSS, parent_item=item_names.ASCENDANT),
+    item_names.HIGH_TEMPLAR_SIGNIFIER_UNSHACKLED_PSIONIC_STORM: ItemData(358 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 28, SC2Race.PROTOSS, parent_item=parent_names.STORM_CASTER),
+    item_names.HIGH_TEMPLAR_SIGNIFIER_HALLUCINATION: ItemData(359 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 29, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=parent_names.STORM_CASTER),
+    item_names.HIGH_TEMPLAR_SIGNIFIER_KHAYDARIN_AMULET: ItemData(360 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 0, SC2Race.PROTOSS, parent_item=parent_names.STORM_CASTER),
+    item_names.ARCHON_HIGH_ARCHON: ItemData(361 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 1, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=parent_names.ARCHON_SOURCE),
+    item_names.DARK_ARCHON_FEEDBACK: ItemData(362 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 2, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=parent_names.DARK_ARCHON_SOURCE),
+    item_names.DARK_ARCHON_MAELSTROM: ItemData(363 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 3, SC2Race.PROTOSS, parent_item=parent_names.DARK_ARCHON_SOURCE),
+    item_names.DARK_ARCHON_ARGUS_TALISMAN: ItemData(364 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 4, SC2Race.PROTOSS, parent_item=parent_names.DARK_ARCHON_SOURCE),
+    item_names.ASCENDANT_POWER_OVERWHELMING: ItemData(365 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 5, SC2Race.PROTOSS, parent_item=parent_names.SUPPLICANT_AND_ASCENDANT),
     item_names.ASCENDANT_CHAOTIC_ATTUNEMENT: ItemData(366 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 6, SC2Race.PROTOSS, parent_item=item_names.ASCENDANT),
     item_names.ASCENDANT_BLOOD_AMULET: ItemData(367 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 7, SC2Race.PROTOSS, parent_item=item_names.ASCENDANT),
-    item_names.SENTRY_ENERGIZER_HAVOC_CLOAKING_MODULE: ItemData(368 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 8, SC2Race.PROTOSS),
-    item_names.SENTRY_ENERGIZER_HAVOC_SHIELD_BATTERY_RAPID_RECHARGING: ItemData(369 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 9, SC2Race.PROTOSS),
+    item_names.SENTRY_ENERGIZER_HAVOC_CLOAKING_MODULE: ItemData(368 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 8, SC2Race.PROTOSS, parent_item=parent_names.SENTRY_CLASS),
+    item_names.SENTRY_ENERGIZER_HAVOC_SHIELD_BATTERY_RAPID_RECHARGING: ItemData(369 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 9, SC2Race.PROTOSS, parent_item=parent_names.SENTRY_CLASS_OR_SHIELD_BATTERY),
     item_names.SENTRY_FORCE_FIELD: ItemData(370 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 10, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.SENTRY),
     item_names.SENTRY_HALLUCINATION: ItemData(371 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 11, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.SENTRY),
     item_names.ENERGIZER_RECLAMATION: ItemData(372 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 12, SC2Race.PROTOSS, parent_item=item_names.ENERGIZER),
     item_names.ENERGIZER_FORGED_CHASSIS: ItemData(373 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 13, SC2Race.PROTOSS, parent_item=item_names.ENERGIZER),
     item_names.HAVOC_DETECT_WEAKNESS: ItemData(374 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 14, SC2Race.PROTOSS, parent_item=item_names.HAVOC),
     item_names.HAVOC_BLOODSHARD_RESONANCE: ItemData(375 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 15, SC2Race.PROTOSS, parent_item=item_names.HAVOC),
-    item_names.ZEALOT_SENTINEL_CENTURION_LEG_ENHANCEMENTS: ItemData(376 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 16, SC2Race.PROTOSS),
-    item_names.ZEALOT_SENTINEL_CENTURION_SHIELD_CAPACITY: ItemData(377 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 17, SC2Race.PROTOSS, classification=ItemClassification.progression),
+    item_names.ZEALOT_SENTINEL_CENTURION_LEG_ENHANCEMENTS: ItemData(376 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 16, SC2Race.PROTOSS, parent_item=parent_names.ZEALOT_OR_SENTINEL_OR_CENTURION),
+    item_names.ZEALOT_SENTINEL_CENTURION_SHIELD_CAPACITY: ItemData(377 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 17, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=parent_names.ZEALOT_OR_SENTINEL_OR_CENTURION),
     item_names.ORACLE_BOSONIC_CORE: ItemData(378 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 18, SC2Race.PROTOSS, parent_item=item_names.ORACLE),
     item_names.SCOUT_RESOURCE_EFFICIENCY: ItemData(379 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 19, SC2Race.PROTOSS, parent_item=item_names.SCOUT),
-    item_names.IMMORTAL_ANNIHILATOR_DISRUPTOR_DISPERSION: ItemData(380 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 20, SC2Race.PROTOSS),
+    item_names.IMMORTAL_ANNIHILATOR_DISRUPTOR_DISPERSION: ItemData(380 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 20, SC2Race.PROTOSS, parent_item=parent_names.IMMORTAL_OR_ANNIHILATOR),
     item_names.DISRUPTOR_CLOAKING_MODULE: ItemData(381 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 21, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.DISRUPTOR),
     item_names.DISRUPTOR_PERFECTED_POWER:  ItemData(382 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 22, SC2Race.PROTOSS, parent_item=item_names.DISRUPTOR, classification=ItemClassification.progression),
     item_names.DISRUPTOR_RESTRAINED_DESTRUCTION: ItemData(383 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 23, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.DISRUPTOR),
@@ -1879,7 +1881,7 @@ item_table = {
     item_names.HIGH_TEMPLAR_PLASMA_SURGE: ItemData(515 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 15, SC2Race.PROTOSS, parent_item=item_names.HIGH_TEMPLAR),
     item_names.SIGNIFIER_FEEDBACK: ItemData(516 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 16, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.SIGNIFIER),
     item_names.ASCENDANT_ABILITY_EFFICIENCY: ItemData(517 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 17, SC2Race.PROTOSS, parent_item=item_names.ASCENDANT),
-    item_names.DARK_ARCHON_INDOMITABLE_WILL: ItemData(518 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 18, SC2Race.PROTOSS),
+    item_names.DARK_ARCHON_INDOMITABLE_WILL: ItemData(518 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 18, SC2Race.PROTOSS, parent_item=parent_names.DARK_ARCHON_SOURCE),
     item_names.IMMORTAL_IMPROVED_BARRIER: ItemData(519 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 19, SC2Race.PROTOSS, parent_item=item_names.IMMORTAL),
     item_names.VANGUARD_RAPIDFIRE_CANNON: ItemData(520 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 20, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.VANGUARD),
     item_names.VANGUARD_FUSION_MORTARS: ItemData(521 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 21, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
@@ -1944,9 +1946,9 @@ item_table = {
     item_names.SUPERIOR_WARP_GATES:
         ItemData(808 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 8, SC2Race.PROTOSS),
     item_names.ENHANCED_TARGETING:
-        ItemData(809 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 9, SC2Race.PROTOSS),
+        ItemData(809 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 9, SC2Race.PROTOSS, parent_item=parent_names.PROTOSS_STATIC_DEFENSE),
     item_names.OPTIMIZED_ORDNANCE:
-        ItemData(810 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 10, SC2Race.PROTOSS),
+        ItemData(810 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 10, SC2Race.PROTOSS, parent_item=parent_names.PROTOSS_ATTACKING_BUILDING),
     item_names.KHALAI_INGENUITY:
         ItemData(811 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 11, SC2Race.PROTOSS),
     item_names.AMPLIFIED_ASSIMILATORS:
@@ -2111,91 +2113,6 @@ not_balanced_starting_units = {
 }
 
 
-# Items that can be placed before resources if not already in
-# General upgrades and Mercs
-second_pass_placeable_items: typing.Tuple[str, ...] = (
-    # Global weapon/armor upgrades
-    item_names.PROGRESSIVE_TERRAN_ARMOR_UPGRADE,
-    item_names.PROGRESSIVE_TERRAN_WEAPON_UPGRADE,
-    item_names.PROGRESSIVE_TERRAN_WEAPON_ARMOR_UPGRADE,
-    item_names.PROGRESSIVE_ZERG_ARMOR_UPGRADE,
-    item_names.PROGRESSIVE_ZERG_WEAPON_UPGRADE,
-    item_names.PROGRESSIVE_ZERG_WEAPON_ARMOR_UPGRADE,
-    item_names.PROGRESSIVE_PROTOSS_ARMOR_UPGRADE,
-    item_names.PROGRESSIVE_PROTOSS_WEAPON_UPGRADE,
-    item_names.PROGRESSIVE_PROTOSS_WEAPON_ARMOR_UPGRADE,
-    item_names.PROGRESSIVE_PROTOSS_SHIELDS,
-    # Terran Buildings without upgrades
-    item_names.SENSOR_TOWER,
-    item_names.HIVE_MIND_EMULATOR,
-    item_names.PSI_DISRUPTER,
-    item_names.PERDITION_TURRET,
-    # General Terran upgrades without any dependencies
-    item_names.SCV_ADVANCED_CONSTRUCTION,
-    item_names.SCV_DUAL_FUSION_WELDERS,
-    item_names.SCV_CONSTRUCTION_JUMP_JETS,
-    item_names.PROGRESSIVE_FIRE_SUPPRESSION_SYSTEM,
-    item_names.PROGRESSIVE_ORBITAL_COMMAND,
-    item_names.ULTRA_CAPACITORS,
-    item_names.VANADIUM_PLATING,
-    item_names.ORBITAL_DEPOTS,
-    item_names.MICRO_FILTERING,
-    item_names.AUTOMATED_REFINERY,
-    item_names.COMMAND_CENTER_COMMAND_CENTER_REACTOR,
-    item_names.COMMAND_CENTER_SCANNER_SWEEP,
-    item_names.COMMAND_CENTER_MULE,
-    item_names.COMMAND_CENTER_EXTRA_SUPPLIES,
-    item_names.TECH_REACTOR,
-    item_names.CELLULAR_REACTOR,
-    item_names.PROGRESSIVE_REGENERATIVE_BIO_STEEL,  # Place only L1
-    item_names.STRUCTURE_ARMOR,
-    item_names.HI_SEC_AUTO_TRACKING,
-    item_names.ADVANCED_OPTICS,
-    item_names.ROGUE_FORCES,
-    # Mercenaries (All races)
-    *[item_name for item_name, item_data in item_table.items()
-      if item_data.type in (TerranItemType.Mercenary, ZergItemType.Mercenary)],
-    # Kerrigan and Nova levels, abilities and generally useful stuff
-    *[item_name for item_name, item_data in get_full_item_list().items()
-      if item_data.type in (ZergItemType.Level, ZergItemType.Ability, ZergItemType.Evolution_Pit, TerranItemType.Nova_Gear)],
-    item_names.NOVA_PROGRESSIVE_STEALTH_SUIT_MODULE,
-    # Zerg static defenses
-    item_names.SPORE_CRAWLER,
-    item_names.SPINE_CRAWLER,
-    # Overseer
-    item_names.OVERLORD_OVERSEER_ASPECT,
-    # Spear of Adun Abilities
-    item_names.SOA_CHRONO_SURGE,
-    item_names.SOA_PROGRESSIVE_PROXY_PYLON,
-    item_names.SOA_PYLON_OVERCHARGE,
-    item_names.SOA_ORBITAL_STRIKE,
-    item_names.SOA_TEMPORAL_FIELD,
-    item_names.SOA_SOLAR_LANCE,
-    item_names.SOA_MASS_RECALL,
-    item_names.SOA_SHIELD_OVERCHARGE,
-    item_names.SOA_DEPLOY_FENIX,
-    item_names.SOA_PURIFIER_BEAM,
-    item_names.SOA_TIME_STOP,
-    item_names.SOA_SOLAR_BOMBARDMENT,
-    # Protoss generic upgrades
-    item_names.MATRIX_OVERLOAD,
-    item_names.QUATRO,
-    item_names.NEXUS_OVERCHARGE,
-    item_names.ORBITAL_ASSIMILATORS,
-    item_names.WARP_HARMONIZATION,
-    item_names.GUARDIAN_SHELL,
-    item_names.RECONSTRUCTION_BEAM,
-    item_names.OVERWATCH,
-    item_names.SUPERIOR_WARP_GATES,
-    item_names.KHALAI_INGENUITY,
-    item_names.AMPLIFIED_ASSIMILATORS,
-    # Protoss static defenses
-    item_names.PHOTON_CANNON,
-    item_names.KHAYDARIN_MONOLITH,
-    item_names.SHIELD_BATTERY
-)
-
-
 filler_items: typing.Tuple[str, ...] = (
     item_names.STARTING_MINERALS,
     item_names.STARTING_VESPENE,
@@ -2280,13 +2197,6 @@ kerrigan_levels = [
     item_name for item_name, item_data in item_table.items()
     if item_data.type == ZergItemType.Level and item_data.race == SC2Race.ZERG
 ]
-
-spider_mine_sources = {
-    item_names.VULTURE,
-    item_names.REAPER_SPIDER_MINES,
-    item_names.SIEGE_TANK_SPIDER_MINES,
-    item_names.RAVEN_SPIDER_MINES,
-}
 
 kerrigan_actives: typing.List[typing.Set[str]] = [
     {item_names.KERRIGAN_KINETIC_BLAST, item_names.KERRIGAN_LEAPING_STRIKE},

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -108,7 +108,7 @@ class ItemData(typing.NamedTuple):
     race: SC2Race
     classification: ItemClassification = ItemClassification.useful
     quantity: int = 1
-    parent_item: typing.Optional[str] = None
+    parent: typing.Optional[str] = None
     important_for_filtering: bool = False
 
     def is_important_for_filtering(self):
@@ -250,33 +250,33 @@ item_table = {
                  classification=ItemClassification.progression),
 
     # Some other items are moved to Upgrade group because of the way how the bot message is parsed
-    item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON: ItemData(100 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 0, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.INFANTRY_WEAPON_UNITS),
-    item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR: ItemData(102 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 4, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.INFANTRY_UNITS),
-    item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON: ItemData(103 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 8, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.VEHICLE_WEAPON_UNITS),
-    item_names.PROGRESSIVE_TERRAN_VEHICLE_ARMOR: ItemData(104 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 12, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.VEHICLE_UNITS),
-    item_names.PROGRESSIVE_TERRAN_SHIP_WEAPON: ItemData(105 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 16, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.STARSHIP_WEAPON_UNITS),
-    item_names.PROGRESSIVE_TERRAN_SHIP_ARMOR: ItemData(106 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 20, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.STARSHIP_UNITS),
+    item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON: ItemData(100 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 0, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.INFANTRY_WEAPON_UNITS),
+    item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR: ItemData(102 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 4, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.INFANTRY_UNITS),
+    item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON: ItemData(103 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 8, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.VEHICLE_WEAPON_UNITS),
+    item_names.PROGRESSIVE_TERRAN_VEHICLE_ARMOR: ItemData(104 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 12, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.VEHICLE_UNITS),
+    item_names.PROGRESSIVE_TERRAN_SHIP_WEAPON: ItemData(105 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 16, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.STARSHIP_WEAPON_UNITS),
+    item_names.PROGRESSIVE_TERRAN_SHIP_ARMOR: ItemData(106 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, 20, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.STARSHIP_UNITS),
     # Bundles
     item_names.PROGRESSIVE_TERRAN_WEAPON_UPGRADE: ItemData(107 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
     item_names.PROGRESSIVE_TERRAN_ARMOR_UPGRADE: ItemData(108 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE: ItemData(109 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.INFANTRY_UNITS),
-    item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE: ItemData(110 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.VEHICLE_UNITS),
-    item_names.PROGRESSIVE_TERRAN_SHIP_UPGRADE: ItemData(111 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.STARSHIP_UNITS),
+    item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE: ItemData(109 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.INFANTRY_UNITS),
+    item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE: ItemData(110 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.VEHICLE_UNITS),
+    item_names.PROGRESSIVE_TERRAN_SHIP_UPGRADE: ItemData(111 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.STARSHIP_UNITS),
     item_names.PROGRESSIVE_TERRAN_WEAPON_ARMOR_UPGRADE: ItemData(112 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Upgrade, -1, SC2Race.TERRAN, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
 
     # Unit and structure upgrades
     item_names.BUNKER_PROJECTILE_ACCELERATOR:
         ItemData(200 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 0, SC2Race.TERRAN,
-                 parent_item=item_names.BUNKER),
+                 parent=item_names.BUNKER),
     item_names.BUNKER_NEOSTEEL_BUNKER:
         ItemData(201 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 1, SC2Race.TERRAN,
-                 parent_item=item_names.BUNKER),
+                 parent=item_names.BUNKER),
     item_names.MISSILE_TURRET_TITANIUM_HOUSING:
         ItemData(202 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 2, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MISSILE_TURRET),
+                 classification=ItemClassification.filler, parent=item_names.MISSILE_TURRET),
     item_names.MISSILE_TURRET_HELLSTORM_BATTERIES:
         ItemData(203 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 3, SC2Race.TERRAN,
-                 parent_item=item_names.MISSILE_TURRET),
+                 parent=item_names.MISSILE_TURRET),
     item_names.SCV_ADVANCED_CONSTRUCTION:
         ItemData(204 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 4, SC2Race.TERRAN),
     item_names.SCV_DUAL_FUSION_WELDERS:
@@ -289,273 +289,273 @@ item_table = {
                  quantity=0, classification=ItemClassification.progression),
     item_names.MARINE_PROGRESSIVE_STIMPACK:
         ItemData(208 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 0, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.MARINE, quantity=2),
+                 classification=ItemClassification.progression, parent=item_names.MARINE, quantity=2),
     item_names.MARINE_COMBAT_SHIELD:
         ItemData(209 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 9, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.MARINE),
+                 classification=ItemClassification.progression, parent=item_names.MARINE),
     item_names.MEDIC_ADVANCED_MEDIC_FACILITIES:
         ItemData(210 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 10, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MEDIC),
+                 classification=ItemClassification.filler, parent=item_names.MEDIC),
     item_names.MEDIC_STABILIZER_MEDPACKS:
         ItemData(211 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 11, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.MEDIC),
+                 classification=ItemClassification.progression, parent=item_names.MEDIC),
     item_names.FIREBAT_INCINERATOR_GAUNTLETS:
         ItemData(212 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 12, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.FIREBAT),
+                 classification=ItemClassification.filler, parent=item_names.FIREBAT),
     item_names.FIREBAT_JUGGERNAUT_PLATING:
         ItemData(213 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 13, SC2Race.TERRAN,
-                 parent_item=item_names.FIREBAT),
+                 parent=item_names.FIREBAT),
     item_names.MARAUDER_CONCUSSIVE_SHELLS:
         ItemData(214 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 14, SC2Race.TERRAN,
-                 parent_item=item_names.MARAUDER),
+                 parent=item_names.MARAUDER),
     item_names.MARAUDER_KINETIC_FOAM:
         ItemData(215 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 15, SC2Race.TERRAN,
-                 parent_item=item_names.MARAUDER),
+                 parent=item_names.MARAUDER),
     item_names.REAPER_U238_ROUNDS:
         ItemData(216 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 16, SC2Race.TERRAN,
-                 parent_item=item_names.REAPER),
+                 parent=item_names.REAPER),
     item_names.REAPER_G4_CLUSTERBOMB:
         ItemData(217 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 17, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.REAPER),
+                 classification=ItemClassification.progression, parent=item_names.REAPER),
     item_names.CYCLONE_MAG_FIELD_ACCELERATORS:
         ItemData(218 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 18, SC2Race.TERRAN,
-                 parent_item=item_names.CYCLONE),
+                 parent=item_names.CYCLONE),
     item_names.CYCLONE_MAG_FIELD_LAUNCHERS:
         ItemData(219 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 19, SC2Race.TERRAN,
-                 parent_item=item_names.CYCLONE),
+                 parent=item_names.CYCLONE),
     item_names.MARINE_LASER_TARGETING_SYSTEM:
         ItemData(220 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 8, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MARINE),
+                 classification=ItemClassification.filler, parent=item_names.MARINE),
     item_names.MARINE_MAGRAIL_MUNITIONS:
         ItemData(221 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 20, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.MARINE),
+                 classification=ItemClassification.progression, parent=item_names.MARINE),
     item_names.MARINE_OPTIMIZED_LOGISTICS:
         ItemData(222 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 21, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MARINE),
+                 classification=ItemClassification.filler, parent=item_names.MARINE),
     item_names.MEDIC_RESTORATION:
         ItemData(223 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 22, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MEDIC),
+                 classification=ItemClassification.filler, parent=item_names.MEDIC),
     item_names.MEDIC_OPTICAL_FLARE:
         ItemData(224 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 23, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MEDIC),
+                 classification=ItemClassification.filler, parent=item_names.MEDIC),
     item_names.MEDIC_RESOURCE_EFFICIENCY:
         ItemData(225 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 24, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MEDIC),
+                 classification=ItemClassification.filler, parent=item_names.MEDIC),
     item_names.FIREBAT_PROGRESSIVE_STIMPACK:
         ItemData(226 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 6, SC2Race.TERRAN,
-                 parent_item=item_names.FIREBAT, quantity=2),
+                 parent=item_names.FIREBAT, quantity=2),
     item_names.FIREBAT_RESOURCE_EFFICIENCY:
         ItemData(227 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 25, SC2Race.TERRAN,
-                 parent_item=item_names.FIREBAT),
+                 parent=item_names.FIREBAT),
     item_names.MARAUDER_PROGRESSIVE_STIMPACK:
         ItemData(228 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 8, SC2Race.TERRAN,
-                 parent_item=item_names.MARAUDER, quantity=2),
+                 parent=item_names.MARAUDER, quantity=2),
     item_names.MARAUDER_LASER_TARGETING_SYSTEM:
         ItemData(229 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 26, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MARAUDER),
+                 classification=ItemClassification.filler, parent=item_names.MARAUDER),
     item_names.MARAUDER_MAGRAIL_MUNITIONS:
         ItemData(230 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 27, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MARAUDER),
+                 classification=ItemClassification.filler, parent=item_names.MARAUDER),
     item_names.MARAUDER_INTERNAL_TECH_MODULE:
         ItemData(231 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 28, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MARAUDER),
+                 classification=ItemClassification.filler, parent=item_names.MARAUDER),
     item_names.SCV_HOSTILE_ENVIRONMENT_ADAPTATION:
         ItemData(232 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 29, SC2Race.TERRAN,
                  classification=ItemClassification.filler),
     item_names.MEDIC_ADAPTIVE_MEDPACKS:
         ItemData(233 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 0, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.MEDIC),
+                 classification=ItemClassification.progression, parent=item_names.MEDIC),
     item_names.MEDIC_NANO_PROJECTOR:
         ItemData(234 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 1, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MEDIC),
+                 classification=ItemClassification.filler, parent=item_names.MEDIC),
     item_names.FIREBAT_INFERNAL_PRE_IGNITER:
         ItemData(235 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 2, SC2Race.TERRAN,
-                 parent_item=item_names.FIREBAT),
+                 parent=item_names.FIREBAT),
     item_names.FIREBAT_KINETIC_FOAM:
         ItemData(236 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 3, SC2Race.TERRAN,
-                 parent_item=item_names.FIREBAT),
+                 parent=item_names.FIREBAT),
     item_names.FIREBAT_NANO_PROJECTORS:
         ItemData(237 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 4, SC2Race.TERRAN,
-                 parent_item=item_names.FIREBAT),
+                 parent=item_names.FIREBAT),
     item_names.MARAUDER_JUGGERNAUT_PLATING:
         ItemData(238 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 5, SC2Race.TERRAN,
-                 parent_item=item_names.MARAUDER),
+                 parent=item_names.MARAUDER),
     item_names.REAPER_JET_PACK_OVERDRIVE:
         ItemData(239 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 6, SC2Race.TERRAN,
-                 parent_item=item_names.REAPER),
+                 parent=item_names.REAPER),
     item_names.HELLION_INFERNAL_PLATING:
         ItemData(240 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 7, SC2Race.TERRAN,
-                 parent_item=item_names.HELLION),
+                 parent=item_names.HELLION),
     item_names.VULTURE_AUTO_REPAIR:
         ItemData(241 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 8, SC2Race.TERRAN,
-                 parent_item=item_names.VULTURE),
+                 parent=item_names.VULTURE),
     item_names.GOLIATH_SHAPED_HULL:
         ItemData(242 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 9, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.GOLIATH),
+                 classification=ItemClassification.filler, parent=item_names.GOLIATH),
     item_names.GOLIATH_RESOURCE_EFFICIENCY:
         ItemData(243 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 10, SC2Race.TERRAN,
-                 parent_item=item_names.GOLIATH),
+                 parent=item_names.GOLIATH),
     item_names.GOLIATH_INTERNAL_TECH_MODULE:
         ItemData(244 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 11, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.GOLIATH),
+                 classification=ItemClassification.filler, parent=item_names.GOLIATH),
     item_names.SIEGE_TANK_SHAPED_HULL:
         ItemData(245 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 12, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.SIEGE_TANK),
+                 classification=ItemClassification.filler, parent=item_names.SIEGE_TANK),
     item_names.SIEGE_TANK_RESOURCE_EFFICIENCY:
         ItemData(246 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 13, SC2Race.TERRAN,
-                 parent_item=item_names.SIEGE_TANK),
+                 parent=item_names.SIEGE_TANK),
     item_names.PREDATOR_CLOAK:
         ItemData(247 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 14, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.PREDATOR),
+                 classification=ItemClassification.filler, parent=item_names.PREDATOR),
     item_names.PREDATOR_CHARGE:
         ItemData(248 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 15, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.PREDATOR),
+                 classification=ItemClassification.filler, parent=item_names.PREDATOR),
     item_names.MEDIVAC_SCATTER_VEIL:
         ItemData(249 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 16, SC2Race.TERRAN,
-                 parent_item=item_names.MEDIVAC),
+                 parent=item_names.MEDIVAC),
     item_names.REAPER_PROGRESSIVE_STIMPACK:
         ItemData(250 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 10, SC2Race.TERRAN,
-                 parent_item=item_names.REAPER, quantity=2),
+                 parent=item_names.REAPER, quantity=2),
     item_names.REAPER_LASER_TARGETING_SYSTEM:
         ItemData(251 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 17, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.REAPER),
+                 classification=ItemClassification.filler, parent=item_names.REAPER),
     item_names.REAPER_ADVANCED_CLOAKING_FIELD:
         ItemData(252 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 18, SC2Race.TERRAN,
-                 parent_item=item_names.REAPER),
+                 parent=item_names.REAPER),
     item_names.REAPER_SPIDER_MINES:
         ItemData(253 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 19, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.REAPER,
+                 classification=ItemClassification.filler, parent=item_names.REAPER,
                  important_for_filtering=True),
     item_names.REAPER_COMBAT_DRUGS:
         ItemData(254 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 20, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.REAPER),
+                 classification=ItemClassification.filler, parent=item_names.REAPER),
     item_names.HELLION_HELLBAT_ASPECT:
         ItemData(255 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 21, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.HELLION),
+                 classification=ItemClassification.progression, parent=item_names.HELLION),
     item_names.HELLION_SMART_SERVOS:
         ItemData(256 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 22, SC2Race.TERRAN,
-                 parent_item=item_names.HELLION),
+                 parent=item_names.HELLION),
     item_names.HELLION_OPTIMIZED_LOGISTICS:
         ItemData(257 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 23, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.HELLION),
+                 classification=ItemClassification.filler, parent=item_names.HELLION),
     item_names.HELLION_JUMP_JETS:
         ItemData(258 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 24, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.HELLION),
+                 classification=ItemClassification.filler, parent=item_names.HELLION),
     item_names.HELLION_PROGRESSIVE_STIMPACK:
         ItemData(259 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 12, SC2Race.TERRAN,
-                 parent_item=item_names.HELLION, quantity=2),
+                 parent=item_names.HELLION, quantity=2),
     item_names.VULTURE_ION_THRUSTERS:
         ItemData(260 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 25, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.VULTURE),
+                 classification=ItemClassification.filler, parent=item_names.VULTURE),
     item_names.VULTURE_AUTO_LAUNCHERS:
         ItemData(261 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 26, SC2Race.TERRAN,
-                 parent_item=item_names.VULTURE),
+                 parent=item_names.VULTURE),
     item_names.SPIDER_MINE_HIGH_EXPLOSIVE_MUNITION:
         ItemData(262 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 27, SC2Race.TERRAN,
-            parent_item=parent_names.SPIDER_MINE_SOURCE),
+            parent=parent_names.SPIDER_MINE_SOURCE),
     item_names.GOLIATH_JUMP_JETS:
         ItemData(263 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 28, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.GOLIATH),
+                 classification=ItemClassification.progression, parent=item_names.GOLIATH),
     item_names.GOLIATH_OPTIMIZED_LOGISTICS:
         ItemData(264 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 29, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.GOLIATH),
+                 classification=ItemClassification.filler, parent=item_names.GOLIATH),
     item_names.DIAMONDBACK_HYPERFLUXOR:
         ItemData(265 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 0, SC2Race.TERRAN,
-                 parent_item=item_names.DIAMONDBACK),
+                 parent=item_names.DIAMONDBACK),
     item_names.DIAMONDBACK_BURST_CAPACITORS:
         ItemData(266 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 1, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.DIAMONDBACK),
+                 classification=ItemClassification.filler, parent=item_names.DIAMONDBACK),
     item_names.DIAMONDBACK_RESOURCE_EFFICIENCY:
         ItemData(267 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 2, SC2Race.TERRAN,
-                 parent_item=item_names.DIAMONDBACK),
+                 parent=item_names.DIAMONDBACK),
     item_names.SIEGE_TANK_JUMP_JETS:
         ItemData(268 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 3, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.SIEGE_TANK),
+                 classification=ItemClassification.progression, parent=item_names.SIEGE_TANK),
     item_names.SIEGE_TANK_SPIDER_MINES:
         ItemData(269 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 4, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.SIEGE_TANK,
+                 classification=ItemClassification.filler, parent=item_names.SIEGE_TANK,
                  important_for_filtering=True),
     item_names.SIEGE_TANK_SMART_SERVOS:
         ItemData(270 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 5, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.SIEGE_TANK),
+                 classification=ItemClassification.progression, parent=item_names.SIEGE_TANK),
     item_names.SIEGE_TANK_GRADUATING_RANGE:
         ItemData(271 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 6, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.SIEGE_TANK),
+                 classification=ItemClassification.progression, parent=item_names.SIEGE_TANK),
     item_names.SIEGE_TANK_LASER_TARGETING_SYSTEM:
         ItemData(272 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 7, SC2Race.TERRAN,
-                 parent_item=item_names.SIEGE_TANK),
+                 parent=item_names.SIEGE_TANK),
     item_names.SIEGE_TANK_ADVANCED_SIEGE_TECH:
         ItemData(273 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 8, SC2Race.TERRAN,
-                 parent_item=item_names.SIEGE_TANK),
+                 parent=item_names.SIEGE_TANK),
     item_names.SIEGE_TANK_INTERNAL_TECH_MODULE:
         ItemData(274 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 9, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.SIEGE_TANK),
+                 classification=ItemClassification.filler, parent=item_names.SIEGE_TANK),
     item_names.PREDATOR_RESOURCE_EFFICIENCY:
         ItemData(275 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 10, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.PREDATOR),
+                 classification=ItemClassification.filler, parent=item_names.PREDATOR),
     item_names.MEDIVAC_EXPANDED_HULL:
         ItemData(276 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 11, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MEDIVAC),
+                 classification=ItemClassification.filler, parent=item_names.MEDIVAC),
     item_names.MEDIVAC_AFTERBURNERS:
         ItemData(277 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 12, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MEDIVAC),
+                 classification=ItemClassification.filler, parent=item_names.MEDIVAC),
     item_names.WRAITH_ADVANCED_LASER_TECHNOLOGY:
         ItemData(278 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 13, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.WRAITH),
+                 classification=ItemClassification.progression, parent=item_names.WRAITH),
     item_names.VIKING_SMART_SERVOS:
         ItemData(279 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 14, SC2Race.TERRAN,
-                 parent_item=item_names.VIKING),
+                 parent=item_names.VIKING),
     item_names.VIKING_ANTI_MECHANICAL_MUNITION:
         ItemData(280 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 15, SC2Race.TERRAN,
-                 parent_item=item_names.VIKING),
+                 parent=item_names.VIKING),
     item_names.DIAMONDBACK_ION_THRUSTERS:
         ItemData(281 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 21, SC2Race.TERRAN,
-                 parent_item=item_names.DIAMONDBACK),
+                 parent=item_names.DIAMONDBACK),
     item_names.WARHOUND_RESOURCE_EFFICIENCY:
         ItemData(282 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 13, SC2Race.TERRAN,
-                 parent_item=item_names.WARHOUND),
+                 parent=item_names.WARHOUND),
     item_names.WARHOUND_REINFORCED_PLATING:
         ItemData(283 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 14, SC2Race.TERRAN,
-                 parent_item=item_names.WARHOUND),
+                 parent=item_names.WARHOUND),
     item_names.HERC_RESOURCE_EFFICIENCY:
         ItemData(284 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 15, SC2Race.TERRAN,
-                 parent_item=item_names.HERC),
+                 parent=item_names.HERC),
     item_names.HERC_JUGGERNAUT_PLATING:
         ItemData(285 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 16, SC2Race.TERRAN,
-                 parent_item=item_names.HERC),
+                 parent=item_names.HERC),
     item_names.HERC_KINETIC_FOAM:
         ItemData(286 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 17, SC2Race.TERRAN,
-                 parent_item=item_names.HERC),
+                 parent=item_names.HERC),
     item_names.REAPER_RESOURCE_EFFICIENCY:
         ItemData(287 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 18, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.REAPER),
+                 classification=ItemClassification.progression, parent=item_names.REAPER),
     item_names.REAPER_KINETIC_FOAM:
         ItemData(288 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 19, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.REAPER),
+                 classification=ItemClassification.filler, parent=item_names.REAPER),
     item_names.SIEGE_TANK_PROGRESSIVE_TRANSPORT_HOOK:
         ItemData(289 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive_2, 6, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=parent_names.SIEGE_TANK_AND_TRANSPORT, quantity=2),
+                 classification=ItemClassification.progression, parent=parent_names.SIEGE_TANK_AND_TRANSPORT, quantity=2),
     item_names.SIEGE_TANK_ENHANCED_COMBUSTION_ENGINES:
         ItemData(290 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 20, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.SIEGE_TANK),
+                 classification=ItemClassification.filler, parent=item_names.SIEGE_TANK),
     item_names.MEDIVAC_RAPID_REIGNITION_SYSTEMS:
         ItemData(291 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 21, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MEDIVAC),
+                 classification=ItemClassification.filler, parent=item_names.MEDIVAC),
     item_names.BATTLECRUISER_BEHEMOTH_REACTOR:
         ItemData(292 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 22, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.BATTLECRUISER),
+                 classification=ItemClassification.filler, parent=item_names.BATTLECRUISER),
     item_names.THOR_RAPID_RELOAD:
         ItemData(293 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 23, SC2Race.TERRAN,
-                 parent_item=item_names.THOR),
+                 parent=item_names.THOR),
     item_names.LIBERATOR_GUERILLA_MISSILES:
         ItemData(294 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 24, SC2Race.TERRAN,
-                 parent_item=item_names.LIBERATOR),
+                 parent=item_names.LIBERATOR),
     item_names.WIDOW_MINE_RESOURCE_EFFICIENCY:
         ItemData(295 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 25, SC2Race.TERRAN,
-                 parent_item=item_names.WIDOW_MINE),
+                 parent=item_names.WIDOW_MINE),
     item_names.HERC_GRAPPLE_PULL:
         ItemData(296 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 26, SC2Race.TERRAN,
-                 parent_item=item_names.HERC),
+                 parent=item_names.HERC),
     item_names.COMMAND_CENTER_SCANNER_SWEEP:
         ItemData(297 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 27, SC2Race.TERRAN,
                  classification=ItemClassification.progression),
@@ -567,301 +567,301 @@ item_table = {
                  important_for_filtering=True),
     item_names.HELLION_TWIN_LINKED_FLAMETHROWER:
         ItemData(300 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 16, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.HELLION),
+                 classification=ItemClassification.filler, parent=item_names.HELLION),
     item_names.HELLION_THERMITE_FILAMENTS:
         ItemData(301 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 17, SC2Race.TERRAN,
-                 parent_item=item_names.HELLION),
+                 parent=item_names.HELLION),
     item_names.SPIDER_MINE_CERBERUS_MINE:
         ItemData(302 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 18, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=parent_names.SPIDER_MINE_SOURCE),
+                 classification=ItemClassification.filler, parent=parent_names.SPIDER_MINE_SOURCE),
     item_names.VULTURE_PROGRESSIVE_REPLENISHABLE_MAGAZINE:
         ItemData(303 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 16, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.VULTURE, quantity=2),
+                 classification=ItemClassification.filler, parent=item_names.VULTURE, quantity=2),
     item_names.GOLIATH_MULTI_LOCK_WEAPONS_SYSTEM:
         ItemData(304 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 19, SC2Race.TERRAN,
-                 parent_item=item_names.GOLIATH),
+                 parent=item_names.GOLIATH),
     item_names.GOLIATH_ARES_CLASS_TARGETING_SYSTEM:
         ItemData(305 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 20, SC2Race.TERRAN,
-                 parent_item=item_names.GOLIATH),
+                 parent=item_names.GOLIATH),
     item_names.DIAMONDBACK_PROGRESSIVE_TRI_LITHIUM_POWER_CELL:
         ItemData(306 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive_2, 4, SC2Race.TERRAN,
-                 parent_item=item_names.DIAMONDBACK, quantity=2),
+                 parent=item_names.DIAMONDBACK, quantity=2),
     item_names.DIAMONDBACK_SHAPED_HULL:
         ItemData(307 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 22, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.DIAMONDBACK),
+                 classification=ItemClassification.filler, parent=item_names.DIAMONDBACK),
     item_names.SIEGE_TANK_MAELSTROM_ROUNDS:
         ItemData(308 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 23, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.SIEGE_TANK),
+                 classification=ItemClassification.progression, parent=item_names.SIEGE_TANK),
     item_names.SIEGE_TANK_SHAPED_BLAST:
         ItemData(309 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 24, SC2Race.TERRAN,
-                 parent_item=item_names.SIEGE_TANK),
+                 parent=item_names.SIEGE_TANK),
     item_names.MEDIVAC_RAPID_DEPLOYMENT_TUBE:
         ItemData(310 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 25, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MEDIVAC),
+                 classification=ItemClassification.filler, parent=item_names.MEDIVAC),
     item_names.MEDIVAC_ADVANCED_HEALING_AI:
         ItemData(311 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 26, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MEDIVAC),
+                 classification=ItemClassification.filler, parent=item_names.MEDIVAC),
     item_names.WRAITH_PROGRESSIVE_TOMAHAWK_POWER_CELLS:
         ItemData(312 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 18, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.WRAITH, quantity=2),
+                 classification=ItemClassification.filler, parent=item_names.WRAITH, quantity=2),
     item_names.WRAITH_DISPLACEMENT_FIELD:
         ItemData(313 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 27, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.WRAITH),
+                 classification=ItemClassification.filler, parent=item_names.WRAITH),
     item_names.VIKING_RIPWAVE_MISSILES:
         ItemData(314 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 28, SC2Race.TERRAN,
-                 parent_item=item_names.VIKING),
+                 parent=item_names.VIKING),
     item_names.VIKING_PHOBOS_CLASS_WEAPONS_SYSTEM:
         ItemData(315 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_3, 29, SC2Race.TERRAN,
-                 parent_item=item_names.VIKING),
+                 parent=item_names.VIKING),
     item_names.BANSHEE_PROGRESSIVE_CROSS_SPECTRUM_DAMPENERS:
         ItemData(316 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 2, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.BANSHEE, quantity=2),
+                 classification=ItemClassification.filler, parent=item_names.BANSHEE, quantity=2),
     item_names.BANSHEE_SHOCKWAVE_MISSILE_BATTERY:
         ItemData(317 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 0, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.BANSHEE),
+                 classification=ItemClassification.progression, parent=item_names.BANSHEE),
     item_names.BATTLECRUISER_PROGRESSIVE_MISSILE_PODS:
         ItemData(318 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive_2, 2, SC2Race.TERRAN,
-                 parent_item=item_names.BATTLECRUISER, quantity=2),
+                 parent=item_names.BATTLECRUISER, quantity=2),
     item_names.BATTLECRUISER_PROGRESSIVE_DEFENSIVE_MATRIX:
         ItemData(319 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 20, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.BATTLECRUISER, quantity=2),
+                 classification=ItemClassification.progression, parent=item_names.BATTLECRUISER, quantity=2),
     item_names.GHOST_OCULAR_IMPLANTS:
         ItemData(320 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 2, SC2Race.TERRAN,
-                 parent_item=item_names.GHOST),
+                 parent=item_names.GHOST),
     item_names.GHOST_CRIUS_SUIT:
         ItemData(321 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 3, SC2Race.TERRAN,
-                 parent_item=item_names.GHOST),
+                 parent=item_names.GHOST),
     item_names.SPECTRE_PSIONIC_LASH:
         ItemData(322 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 4, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.SPECTRE),
+                 classification=ItemClassification.progression, parent=item_names.SPECTRE),
     item_names.SPECTRE_NYX_CLASS_CLOAKING_MODULE:
         ItemData(323 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 5, SC2Race.TERRAN,
-                 parent_item=item_names.SPECTRE),
+                 parent=item_names.SPECTRE),
     item_names.THOR_330MM_BARRAGE_CANNON:
         ItemData(324 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 6, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.THOR),
+                 classification=ItemClassification.filler, parent=item_names.THOR),
     item_names.THOR_PROGRESSIVE_IMMORTALITY_PROTOCOL:
         ItemData(325 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 22, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.THOR, quantity=2),
+                 classification=ItemClassification.filler, parent=item_names.THOR, quantity=2),
     item_names.LIBERATOR_ADVANCED_BALLISTICS:
         ItemData(326 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 7, SC2Race.TERRAN,
-                 parent_item=item_names.LIBERATOR),
+                 parent=item_names.LIBERATOR),
     item_names.LIBERATOR_RAID_ARTILLERY:
         ItemData(327 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 8, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.LIBERATOR),
+                 classification=ItemClassification.progression, parent=item_names.LIBERATOR),
     item_names.WIDOW_MINE_DRILLING_CLAWS:
         ItemData(328 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 9, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.WIDOW_MINE),
+                 classification=ItemClassification.filler, parent=item_names.WIDOW_MINE),
     item_names.WIDOW_MINE_CONCEALMENT:
         ItemData(329 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 10, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.WIDOW_MINE),
+                 classification=ItemClassification.progression, parent=item_names.WIDOW_MINE),
     item_names.MEDIVAC_ADVANCED_CLOAKING_FIELD:
         ItemData(330 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 11, SC2Race.TERRAN,
-                 parent_item=item_names.MEDIVAC),
+                 parent=item_names.MEDIVAC),
     item_names.WRAITH_TRIGGER_OVERRIDE:
         ItemData(331 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 12, SC2Race.TERRAN,
-                 parent_item=item_names.WRAITH),
+                 parent=item_names.WRAITH),
     item_names.WRAITH_INTERNAL_TECH_MODULE:
         ItemData(332 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 13, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.WRAITH),
+                 classification=ItemClassification.filler, parent=item_names.WRAITH),
     item_names.WRAITH_RESOURCE_EFFICIENCY:
         ItemData(333 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 14, SC2Race.TERRAN,
-                 parent_item=item_names.WRAITH),
+                 parent=item_names.WRAITH),
     item_names.VIKING_SHREDDER_ROUNDS:
         ItemData(334 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 15, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.VIKING),
+                 classification=ItemClassification.progression, parent=item_names.VIKING),
     item_names.VIKING_WILD_MISSILES:
         ItemData(335 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 16, SC2Race.TERRAN,
-                 parent_item=item_names.VIKING),
+                 parent=item_names.VIKING),
     item_names.BANSHEE_SHAPED_HULL:
         ItemData(336 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 17, SC2Race.TERRAN,
-                 parent_item=item_names.BANSHEE),
+                 parent=item_names.BANSHEE),
     item_names.BANSHEE_ADVANCED_TARGETING_OPTICS:
         ItemData(337 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 18, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.BANSHEE),
+                 classification=ItemClassification.progression, parent=item_names.BANSHEE),
     item_names.BANSHEE_DISTORTION_BLASTERS:
         ItemData(338 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 19, SC2Race.TERRAN,
-                 parent_item=item_names.BANSHEE),
+                 parent=item_names.BANSHEE),
     item_names.BANSHEE_ROCKET_BARRAGE:
         ItemData(339 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 20, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.BANSHEE),
+                 classification=ItemClassification.progression, parent=item_names.BANSHEE),
     item_names.GHOST_RESOURCE_EFFICIENCY:
         ItemData(340 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 21, SC2Race.TERRAN,
-                 parent_item=item_names.GHOST),
+                 parent=item_names.GHOST),
     item_names.SPECTRE_RESOURCE_EFFICIENCY:
         ItemData(341 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 22, SC2Race.TERRAN,
-                 parent_item=item_names.SPECTRE),
+                 parent=item_names.SPECTRE),
     item_names.THOR_BUTTON_WITH_A_SKULL_ON_IT:
         ItemData(342 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 23, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.THOR),
+                 classification=ItemClassification.progression, parent=item_names.THOR),
     item_names.THOR_LASER_TARGETING_SYSTEM:
         ItemData(343 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 24, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.THOR),
+                 classification=ItemClassification.filler, parent=item_names.THOR),
     item_names.THOR_LARGE_SCALE_FIELD_CONSTRUCTION:
         ItemData(344 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 25, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.THOR),
+                 classification=ItemClassification.filler, parent=item_names.THOR),
     item_names.RAVEN_RESOURCE_EFFICIENCY:
         ItemData(345 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 26, SC2Race.TERRAN,
-                 parent_item=item_names.RAVEN),
+                 parent=item_names.RAVEN),
     item_names.RAVEN_DURABLE_MATERIALS:
         ItemData(346 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 27, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.RAVEN),
+                 classification=ItemClassification.filler, parent=item_names.RAVEN),
     item_names.SCIENCE_VESSEL_IMPROVED_NANO_REPAIR:
         ItemData(347 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 28, SC2Race.TERRAN,
-                 parent_item=item_names.SCIENCE_VESSEL),
+                 parent=item_names.SCIENCE_VESSEL),
     item_names.SCIENCE_VESSEL_ADVANCED_AI_SYSTEMS:
         ItemData(348 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 29, SC2Race.TERRAN,
-                 parent_item=item_names.SCIENCE_VESSEL),
+                 parent=item_names.SCIENCE_VESSEL),
     item_names.CYCLONE_RESOURCE_EFFICIENCY:
         ItemData(349 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 0, SC2Race.TERRAN,
-                 parent_item=item_names.CYCLONE),
+                 parent=item_names.CYCLONE),
     item_names.BANSHEE_HYPERFLIGHT_ROTORS:
         ItemData(350 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 1, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.BANSHEE),
+                 classification=ItemClassification.filler, parent=item_names.BANSHEE),
     item_names.BANSHEE_LASER_TARGETING_SYSTEM:
         ItemData(351 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 2, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.BANSHEE),
+                 classification=ItemClassification.filler, parent=item_names.BANSHEE),
     item_names.BANSHEE_INTERNAL_TECH_MODULE:
         ItemData(352 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 3, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.BANSHEE),
+                 classification=ItemClassification.filler, parent=item_names.BANSHEE),
     item_names.BATTLECRUISER_TACTICAL_JUMP:
         ItemData(353 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 4, SC2Race.TERRAN,
-                 parent_item=item_names.BATTLECRUISER),
+                 parent=item_names.BATTLECRUISER),
     item_names.BATTLECRUISER_CLOAK:
         ItemData(354 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 5, SC2Race.TERRAN,
-                 parent_item=item_names.BATTLECRUISER),
+                 parent=item_names.BATTLECRUISER),
     item_names.BATTLECRUISER_ATX_LASER_BATTERY:
         ItemData(355 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 6, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.BATTLECRUISER),
+                 classification=ItemClassification.progression, parent=item_names.BATTLECRUISER),
     item_names.BATTLECRUISER_OPTIMIZED_LOGISTICS:
         ItemData(356 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 7, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.BATTLECRUISER),
+                 classification=ItemClassification.filler, parent=item_names.BATTLECRUISER),
     item_names.BATTLECRUISER_INTERNAL_TECH_MODULE:
         ItemData(357 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 8, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.BATTLECRUISER),
+                 classification=ItemClassification.filler, parent=item_names.BATTLECRUISER),
     item_names.GHOST_EMP_ROUNDS:
         ItemData(358 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 9, SC2Race.TERRAN,
-                 parent_item=item_names.GHOST),
+                 parent=item_names.GHOST),
     item_names.GHOST_LOCKDOWN:
         ItemData(359 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 10, SC2Race.TERRAN,
-                 parent_item=item_names.GHOST),
+                 parent=item_names.GHOST),
     item_names.SPECTRE_IMPALER_ROUNDS:
         ItemData(360 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 11, SC2Race.TERRAN,
-                 parent_item=item_names.SPECTRE),
+                 parent=item_names.SPECTRE),
     item_names.THOR_PROGRESSIVE_HIGH_IMPACT_PAYLOAD:
         ItemData(361 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 14, SC2Race.TERRAN,
-                 parent_item=item_names.THOR, quantity=2),
+                 parent=item_names.THOR, quantity=2),
     item_names.RAVEN_BIO_MECHANICAL_REPAIR_DRONE:
         ItemData(363 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 12, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.RAVEN),
+                 classification=ItemClassification.progression, parent=item_names.RAVEN),
     item_names.RAVEN_SPIDER_MINES:
         ItemData(364 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 13, SC2Race.TERRAN,
-                 parent_item=item_names.RAVEN, important_for_filtering=True),
+                 parent=item_names.RAVEN, important_for_filtering=True),
     item_names.RAVEN_RAILGUN_TURRET:
         ItemData(365 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 14, SC2Race.TERRAN,
-                 parent_item=item_names.RAVEN),
+                 parent=item_names.RAVEN),
     item_names.RAVEN_HUNTER_SEEKER_WEAPON:
         ItemData(366 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 15, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.RAVEN),
+                 classification=ItemClassification.progression, parent=item_names.RAVEN),
     item_names.RAVEN_INTERFERENCE_MATRIX:
         ItemData(367 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 16, SC2Race.TERRAN,
-                 parent_item=item_names.RAVEN),
+                 parent=item_names.RAVEN),
     item_names.RAVEN_ANTI_ARMOR_MISSILE:
         ItemData(368 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 17, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.RAVEN),
+                 classification=ItemClassification.filler, parent=item_names.RAVEN),
     item_names.RAVEN_INTERNAL_TECH_MODULE:
         ItemData(369 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 18, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.RAVEN),
+                 classification=ItemClassification.filler, parent=item_names.RAVEN),
     item_names.SCIENCE_VESSEL_EMP_SHOCKWAVE:
         ItemData(370 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 19, SC2Race.TERRAN,
-                 parent_item=item_names.SCIENCE_VESSEL),
+                 parent=item_names.SCIENCE_VESSEL),
     item_names.SCIENCE_VESSEL_DEFENSIVE_MATRIX:
         ItemData(371 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 20, SC2Race.TERRAN,
-                 parent_item=item_names.SCIENCE_VESSEL),
+                 parent=item_names.SCIENCE_VESSEL),
     item_names.CYCLONE_TARGETING_OPTICS:
         ItemData(372 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 21, SC2Race.TERRAN,
-                 parent_item=item_names.CYCLONE),
+                 parent=item_names.CYCLONE),
     item_names.CYCLONE_RAPID_FIRE_LAUNCHERS:
         ItemData(373 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 22, SC2Race.TERRAN,
-                 parent_item=item_names.CYCLONE),
+                 parent=item_names.CYCLONE),
     item_names.LIBERATOR_CLOAK:
         ItemData(374 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 23, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.LIBERATOR),
+                 classification=ItemClassification.filler, parent=item_names.LIBERATOR),
     item_names.LIBERATOR_LASER_TARGETING_SYSTEM:
         ItemData(375 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 24, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.LIBERATOR),
+                 classification=ItemClassification.filler, parent=item_names.LIBERATOR),
     item_names.LIBERATOR_OPTIMIZED_LOGISTICS:
         ItemData(376 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 25, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.LIBERATOR),
+                 classification=ItemClassification.filler, parent=item_names.LIBERATOR),
     item_names.WIDOW_MINE_BLACK_MARKET_LAUNCHERS:
         ItemData(377 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 26, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.WIDOW_MINE),
+                 classification=ItemClassification.filler, parent=item_names.WIDOW_MINE),
     item_names.WIDOW_MINE_EXECUTIONER_MISSILES:
         ItemData(378 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 27, SC2Race.TERRAN,
-                 parent_item=item_names.WIDOW_MINE),
+                 parent=item_names.WIDOW_MINE),
     item_names.VALKYRIE_ENHANCED_CLUSTER_LAUNCHERS:
         ItemData(379 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 28,
-                 SC2Race.TERRAN, parent_item=item_names.VALKYRIE),
+                 SC2Race.TERRAN, parent=item_names.VALKYRIE),
     item_names.VALKYRIE_SHAPED_HULL:
         ItemData(380 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_5, 29, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.VALKYRIE),
+                 classification=ItemClassification.filler, parent=item_names.VALKYRIE),
     item_names.VALKYRIE_FLECHETTE_MISSILES:
         ItemData(381 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 0, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.VALKYRIE),
+                 classification=ItemClassification.progression, parent=item_names.VALKYRIE),
     item_names.VALKYRIE_AFTERBURNERS:
         ItemData(382 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 1, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.VALKYRIE),
+                 classification=ItemClassification.filler, parent=item_names.VALKYRIE),
     item_names.CYCLONE_INTERNAL_TECH_MODULE:
         ItemData(383 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 2, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.CYCLONE),
+                 classification=ItemClassification.filler, parent=item_names.CYCLONE),
     item_names.LIBERATOR_SMART_SERVOS:
         ItemData(384 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 3, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.LIBERATOR),
+                 classification=ItemClassification.progression, parent=item_names.LIBERATOR),
     item_names.LIBERATOR_RESOURCE_EFFICIENCY:
         ItemData(385 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 4, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.LIBERATOR),
+                 classification=ItemClassification.filler, parent=item_names.LIBERATOR),
     item_names.HERCULES_INTERNAL_FUSION_MODULE:
         ItemData(386 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 5, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.HERCULES),
+                 classification=ItemClassification.filler, parent=item_names.HERCULES),
     item_names.HERCULES_TACTICAL_JUMP:
         ItemData(387 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 6, SC2Race.TERRAN,
-                 parent_item=item_names.HERCULES),
+                 parent=item_names.HERCULES),
     item_names.PLANETARY_FORTRESS_PROGRESSIVE_AUGMENTED_THRUSTERS:
         ItemData(388 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 28, SC2Race.TERRAN,
-                 parent_item=item_names.PLANETARY_FORTRESS, quantity=2),
+                 parent=item_names.PLANETARY_FORTRESS, quantity=2),
     item_names.PLANETARY_FORTRESS_ADVANCED_TARGETING:
         ItemData(389 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 7, SC2Race.TERRAN,
-                 parent_item=item_names.PLANETARY_FORTRESS),
+                 parent=item_names.PLANETARY_FORTRESS),
     item_names.VALKYRIE_LAUNCHING_VECTOR_COMPENSATOR:
         ItemData(390 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 8, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.VALKYRIE),
+                 classification=ItemClassification.filler, parent=item_names.VALKYRIE),
     item_names.VALKYRIE_RESOURCE_EFFICIENCY:
         ItemData(391 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 9, SC2Race.TERRAN,
-                 parent_item=item_names.VALKYRIE),
+                 parent=item_names.VALKYRIE),
     item_names.PREDATOR_VESPENE_SYNTHESIS:
         ItemData(392 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 10, SC2Race.TERRAN,
-                 parent_item=item_names.PREDATOR),
+                 parent=item_names.PREDATOR),
     item_names.BATTLECRUISER_BEHEMOTH_PLATING:
         ItemData(393 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 11, SC2Race.TERRAN,
-                 parent_item=item_names.BATTLECRUISER),
+                 parent=item_names.BATTLECRUISER),
     item_names.BATTLECRUISER_COVERT_OPS_ENGINES:
         ItemData(394 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 12, SC2Race.TERRAN,
-                 classification=ItemClassification.progression, parent_item=item_names.BATTLECRUISER),
+                 classification=ItemClassification.progression, parent=item_names.BATTLECRUISER),
     item_names.PLANETARY_FORTRESS_ORBITAL_MODULE:
         ItemData(395 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 1, SC2Race.TERRAN,
-                 parent_item=parent_names.ORBITAL_COMMAND_AND_PLANETARY),
+                 parent=parent_names.ORBITAL_COMMAND_AND_PLANETARY),
     item_names.DEVASTATOR_TURRET_CONCUSSIVE_GRENADES:
         ItemData(396 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 0, SC2Race.TERRAN,
-                 parent_item=item_names.DEVASTATOR_TURRET),
+                 parent=item_names.DEVASTATOR_TURRET),
     item_names.DEVASTATOR_TURRET_ANTI_ARMOR_MUNITIONS:
         ItemData(397 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 1, SC2Race.TERRAN,
-                 parent_item=item_names.DEVASTATOR_TURRET),
+                 parent=item_names.DEVASTATOR_TURRET),
     item_names.DEVASTATOR_TURRET_RESOURCE_EFFICIENCY:
         ItemData(398 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 2, SC2Race.TERRAN,
-                 parent_item=item_names.DEVASTATOR_TURRET),
+                 parent=item_names.DEVASTATOR_TURRET),
     item_names.MISSILE_TURRET_RESOURCE_EFFICENCY:
         ItemData(399 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 3, SC2Race.TERRAN,
-                 classification=ItemClassification.filler, parent_item=item_names.MISSILE_TURRET),
+                 classification=ItemClassification.filler, parent=item_names.MISSILE_TURRET),
 
     #Buildings
     item_names.BUNKER:
@@ -937,13 +937,13 @@ item_table = {
         ItemData(608 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 6, SC2Race.TERRAN),
     item_names.ORBITAL_STRIKE:
         ItemData(609 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 7, SC2Race.TERRAN,
-                parent_item=parent_names.INFANTRY_UNITS),
+                parent=parent_names.INFANTRY_UNITS),
     item_names.BUNKER_SHRIKE_TURRET:
         ItemData(610 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 6, SC2Race.TERRAN,
-                 parent_item=item_names.BUNKER),
+                 parent=item_names.BUNKER),
     item_names.BUNKER_FORTIFIED_BUNKER:
         ItemData(611 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_1, 7, SC2Race.TERRAN,
-                 parent_item=item_names.BUNKER),
+                 parent=item_names.BUNKER),
     item_names.PLANETARY_FORTRESS:
         ItemData(612 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Building, 3, SC2Race.TERRAN,
                  classification=ItemClassification.progression),
@@ -1017,45 +1017,45 @@ item_table = {
 
     item_names.SCIENCE_VESSEL_TACTICAL_JUMP:
         ItemData(750 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 4, SC2Race.TERRAN,
-                 parent_item=item_names.SCIENCE_VESSEL),
+                 parent=item_names.SCIENCE_VESSEL),
     item_names.LIBERATOR_COMPRESSED_ROCKET_FUEL:
         ItemData(751 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 5, SC2Race.TERRAN,
-                 parent_item=item_names.LIBERATOR),
+                 parent=item_names.LIBERATOR),
     item_names.BATTLECRUISER_FIELD_ASSIST_TARGETING_SYSTEM:
         ItemData(752 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 6, SC2Race.TERRAN,
-                 parent_item=item_names.BATTLECRUISER),
+                 parent=item_names.BATTLECRUISER),
     item_names.PREDATOR_ADAPTIVE_DEFENSES:
         ItemData(753 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 7, SC2Race.TERRAN,
-                 parent_item=item_names.PREDATOR),
+                 parent=item_names.PREDATOR),
     item_names.VIKING_AESIR_TURBINES:
         ItemData(754 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 8, SC2Race.TERRAN,
-                 parent_item=item_names.VIKING),
+                 parent=item_names.VIKING),
     item_names.MEDIVAC_RESOURCE_EFFICIENCY:
         ItemData(755 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 9, SC2Race.TERRAN,
-                 parent_item=item_names.MEDIVAC),
+                 parent=item_names.MEDIVAC),
     item_names.EMPERORS_SHADOW_SOVEREIGN_TACTICAL_MISSILES:
         ItemData(756 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 10, SC2Race.TERRAN,
-                 parent_item=item_names.EMPERORS_SHADOW),
+                 parent=item_names.EMPERORS_SHADOW),
     item_names.DOMINION_TROOPER_B2_HIGH_CAL_LMG:
         ItemData(757 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 11, SC2Race.TERRAN,
-                 parent_item=item_names.DOMINION_TROOPER, important_for_filtering=True),
+                 parent=item_names.DOMINION_TROOPER, important_for_filtering=True),
     item_names.DOMINION_TROOPER_HAILSTORM_LAUNCHER:
         ItemData(758 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 12, SC2Race.TERRAN,
-                 parent_item=item_names.DOMINION_TROOPER, important_for_filtering=True),
+                 parent=item_names.DOMINION_TROOPER, important_for_filtering=True),
     item_names.DOMINION_TROOPER_CPO7_SALAMANDER_FLAMETHROWER:
         ItemData(759 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 13, SC2Race.TERRAN,
-                 parent_item=item_names.DOMINION_TROOPER, important_for_filtering=True),
+                 parent=item_names.DOMINION_TROOPER, important_for_filtering=True),
     item_names.DOMINION_TROOPER_ADVANCED_ALLOYS:
         ItemData(760 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 14, SC2Race.TERRAN,
-                 parent_item=parent_names.DOMINION_TROOPER_WEAPONS),
+                 parent=parent_names.DOMINION_TROOPER_WEAPONS),
     item_names.DOMINION_TROOPER_OPTIMIZED_LOGISTICS:
         ItemData(761 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 15, SC2Race.TERRAN,
-                 parent_item=item_names.DOMINION_TROOPER, classification=ItemClassification.filler),
+                 parent=item_names.DOMINION_TROOPER, classification=ItemClassification.filler),
     item_names.SCV_CONSTRUCTION_JUMP_JETS:
         ItemData(762 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 16, SC2Race.TERRAN),
     item_names.WIDOW_MINE_DEMOLITION_ARMAMENTS:
         ItemData(763 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 17, SC2Race.TERRAN,
-                 parent_item=item_names.WIDOW_MINE),
+                 parent=item_names.WIDOW_MINE),
 
     # Filler items to fill remaining spots
     item_names.STARTING_MINERALS:
@@ -1143,7 +1143,7 @@ item_table = {
                  classification=ItemClassification.progression),
     item_names.ZERGLING_BANELING_ASPECT:
         ItemData(4 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 5, SC2Race.ZERG,
-                 classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_ZERGLING),
+                 classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_ZERGLING),
     item_names.ABERRATION:
         ItemData(5 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 5, SC2Race.ZERG,
                  classification=ItemClassification.progression),
@@ -1208,360 +1208,360 @@ item_table = {
         ItemData(25 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 24, SC2Race.ZERG,
                  classification=ItemClassification.progression),
 
-    item_names.PROGRESSIVE_ZERG_MELEE_ATTACK: ItemData(100 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 0, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_MELEE_ATTACKER),
-    item_names.PROGRESSIVE_ZERG_MISSILE_ATTACK: ItemData(101 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 4, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_MISSILE_ATTACKER),
-    item_names.PROGRESSIVE_ZERG_GROUND_CARAPACE: ItemData(102 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 8, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_CARAPACE_UNIT),
-    item_names.PROGRESSIVE_ZERG_FLYER_ATTACK: ItemData(103 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 12, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_FLYING_UNIT),
-    item_names.PROGRESSIVE_ZERG_FLYER_CARAPACE: ItemData(104 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 16, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_FLYING_UNIT),
+    item_names.PROGRESSIVE_ZERG_MELEE_ATTACK: ItemData(100 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 0, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.ZERG_MELEE_ATTACKER),
+    item_names.PROGRESSIVE_ZERG_MISSILE_ATTACK: ItemData(101 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 4, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.ZERG_MISSILE_ATTACKER),
+    item_names.PROGRESSIVE_ZERG_GROUND_CARAPACE: ItemData(102 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 8, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.ZERG_CARAPACE_UNIT),
+    item_names.PROGRESSIVE_ZERG_FLYER_ATTACK: ItemData(103 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 12, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.ZERG_FLYING_UNIT),
+    item_names.PROGRESSIVE_ZERG_FLYER_CARAPACE: ItemData(104 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 16, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.ZERG_FLYING_UNIT),
     # Bundles
     item_names.PROGRESSIVE_ZERG_WEAPON_UPGRADE: ItemData(105 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
     item_names.PROGRESSIVE_ZERG_ARMOR_UPGRADE: ItemData(106 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
-    item_names.PROGRESSIVE_ZERG_GROUND_UPGRADE: ItemData(107 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_CARAPACE_UNIT),
-    item_names.PROGRESSIVE_ZERG_FLYER_UPGRADE: ItemData(108 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent_item=parent_names.ZERG_FLYING_UNIT),
+    item_names.PROGRESSIVE_ZERG_GROUND_UPGRADE: ItemData(107 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.ZERG_CARAPACE_UNIT),
+    item_names.PROGRESSIVE_ZERG_FLYER_UPGRADE: ItemData(108 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.ZERG_FLYING_UNIT),
     item_names.PROGRESSIVE_ZERG_WEAPON_ARMOR_UPGRADE: ItemData(109 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, -1, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL),
 
     item_names.ZERGLING_HARDENED_CARAPACE:
-        ItemData(200 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 0, SC2Race.ZERG, parent_item=item_names.ZERGLING),
+        ItemData(200 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 0, SC2Race.ZERG, parent=item_names.ZERGLING),
     item_names.ZERGLING_ADRENAL_OVERLOAD:
-        ItemData(201 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 1, SC2Race.ZERG, parent_item=item_names.ZERGLING, classification=ItemClassification.progression),
+        ItemData(201 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 1, SC2Race.ZERG, parent=item_names.ZERGLING, classification=ItemClassification.progression),
     item_names.ZERGLING_METABOLIC_BOOST:
-        ItemData(202 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 2, SC2Race.ZERG, parent_item=item_names.ZERGLING, classification=ItemClassification.filler),
+        ItemData(202 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 2, SC2Race.ZERG, parent=item_names.ZERGLING, classification=ItemClassification.filler),
     item_names.ROACH_HYDRIODIC_BILE:
-        ItemData(203 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 3, SC2Race.ZERG, parent_item=item_names.ROACH, classification=ItemClassification.progression),
+        ItemData(203 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 3, SC2Race.ZERG, parent=item_names.ROACH, classification=ItemClassification.progression),
     item_names.ROACH_ADAPTIVE_PLATING:
-        ItemData(204 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 4, SC2Race.ZERG, parent_item=item_names.ROACH, classification=ItemClassification.progression),
+        ItemData(204 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 4, SC2Race.ZERG, parent=item_names.ROACH, classification=ItemClassification.progression),
     item_names.ROACH_TUNNELING_CLAWS:
-        ItemData(205 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 5, SC2Race.ZERG, parent_item=item_names.ROACH, classification=ItemClassification.filler),
+        ItemData(205 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 5, SC2Race.ZERG, parent=item_names.ROACH, classification=ItemClassification.filler),
     item_names.HYDRALISK_FRENZY:
-        ItemData(206 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 6, SC2Race.ZERG, parent_item=item_names.HYDRALISK, classification=ItemClassification.progression),
+        ItemData(206 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 6, SC2Race.ZERG, parent=item_names.HYDRALISK, classification=ItemClassification.progression),
     item_names.HYDRALISK_ANCILLARY_CARAPACE:
-        ItemData(207 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 7, SC2Race.ZERG, parent_item=item_names.HYDRALISK, classification=ItemClassification.filler),
+        ItemData(207 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 7, SC2Race.ZERG, parent=item_names.HYDRALISK, classification=ItemClassification.filler),
     item_names.HYDRALISK_GROOVED_SPINES:
-        ItemData(208 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 8, SC2Race.ZERG, parent_item=item_names.HYDRALISK),
+        ItemData(208 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 8, SC2Race.ZERG, parent=item_names.HYDRALISK),
     item_names.BANELING_CORROSIVE_ACID:
         ItemData(209 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 9, SC2Race.ZERG,
-                 parent_item=parent_names.BANELING_SOURCE, classification=ItemClassification.progression),
+                 parent=parent_names.BANELING_SOURCE, classification=ItemClassification.progression),
     item_names.BANELING_RUPTURE:
         ItemData(210 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 10, SC2Race.ZERG,
-                 parent_item=parent_names.BANELING_SOURCE,
+                 parent=parent_names.BANELING_SOURCE,
                  classification=ItemClassification.filler),
     item_names.BANELING_REGENERATIVE_ACID:
         ItemData(211 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 11, SC2Race.ZERG,
-                 parent_item=parent_names.BANELING_SOURCE,
+                 parent=parent_names.BANELING_SOURCE,
                  classification=ItemClassification.filler),
     item_names.MUTALISK_VICIOUS_GLAIVE:
-        ItemData(212 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 12, SC2Race.ZERG, parent_item=item_names.MUTALISK, classification=ItemClassification.progression),
+        ItemData(212 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 12, SC2Race.ZERG, parent=item_names.MUTALISK, classification=ItemClassification.progression),
     item_names.MUTALISK_RAPID_REGENERATION:
-        ItemData(213 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 13, SC2Race.ZERG, parent_item=item_names.MUTALISK),
+        ItemData(213 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 13, SC2Race.ZERG, parent=item_names.MUTALISK),
     item_names.MUTALISK_SUNDERING_GLAIVE:
-        ItemData(214 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 14, SC2Race.ZERG, parent_item=item_names.MUTALISK, classification=ItemClassification.progression),
+        ItemData(214 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 14, SC2Race.ZERG, parent=item_names.MUTALISK, classification=ItemClassification.progression),
     item_names.SWARM_HOST_BURROW:
-        ItemData(215 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 15, SC2Race.ZERG, parent_item=item_names.SWARM_HOST, classification=ItemClassification.filler),
+        ItemData(215 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 15, SC2Race.ZERG, parent=item_names.SWARM_HOST, classification=ItemClassification.filler),
     item_names.SWARM_HOST_RAPID_INCUBATION:
-        ItemData(216 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 16, SC2Race.ZERG, parent_item=item_names.SWARM_HOST),
+        ItemData(216 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 16, SC2Race.ZERG, parent=item_names.SWARM_HOST),
     item_names.SWARM_HOST_PRESSURIZED_GLANDS:
-        ItemData(217 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 17, SC2Race.ZERG, parent_item=item_names.SWARM_HOST, classification=ItemClassification.progression),
+        ItemData(217 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 17, SC2Race.ZERG, parent=item_names.SWARM_HOST, classification=ItemClassification.progression),
     item_names.ULTRALISK_BURROW_CHARGE:
-        ItemData(218 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 18, SC2Race.ZERG, parent_item=item_names.ULTRALISK),
+        ItemData(218 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 18, SC2Race.ZERG, parent=item_names.ULTRALISK),
     item_names.ULTRALISK_TISSUE_ASSIMILATION:
-        ItemData(219 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 19, SC2Race.ZERG, parent_item=item_names.ULTRALISK),
+        ItemData(219 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 19, SC2Race.ZERG, parent=item_names.ULTRALISK),
     item_names.ULTRALISK_MONARCH_BLADES:
-        ItemData(220 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 20, SC2Race.ZERG, parent_item=item_names.ULTRALISK, classification=ItemClassification.progression),
+        ItemData(220 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 20, SC2Race.ZERG, parent=item_names.ULTRALISK, classification=ItemClassification.progression),
     item_names.CORRUPTOR_CAUSTIC_SPRAY:
-        ItemData(221 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 21, SC2Race.ZERG, parent_item=item_names.CORRUPTOR),
+        ItemData(221 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 21, SC2Race.ZERG, parent=item_names.CORRUPTOR),
     item_names.CORRUPTOR_CORRUPTION:
-        ItemData(222 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 22, SC2Race.ZERG, parent_item=item_names.CORRUPTOR),
+        ItemData(222 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 22, SC2Race.ZERG, parent=item_names.CORRUPTOR),
     item_names.SCOURGE_VIRULENT_SPORES:
-        ItemData(223 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 23, SC2Race.ZERG, parent_item=item_names.SCOURGE),
+        ItemData(223 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 23, SC2Race.ZERG, parent=item_names.SCOURGE),
     item_names.SCOURGE_RESOURCE_EFFICIENCY:
-        ItemData(224 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 24, SC2Race.ZERG, parent_item=item_names.SCOURGE, classification=ItemClassification.progression),
+        ItemData(224 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 24, SC2Race.ZERG, parent=item_names.SCOURGE, classification=ItemClassification.progression),
     item_names.SCOURGE_SWARM_SCOURGE:
-        ItemData(225 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 25, SC2Race.ZERG, parent_item=item_names.SCOURGE),
+        ItemData(225 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 25, SC2Race.ZERG, parent=item_names.SCOURGE),
     item_names.ZERGLING_SHREDDING_CLAWS:
-        ItemData(226 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 26, SC2Race.ZERG, parent_item=item_names.ZERGLING),
+        ItemData(226 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 26, SC2Race.ZERG, parent=item_names.ZERGLING),
     item_names.ROACH_GLIAL_RECONSTITUTION:
-        ItemData(227 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 27, SC2Race.ZERG, parent_item=item_names.ROACH, classification=ItemClassification.progression),
+        ItemData(227 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 27, SC2Race.ZERG, parent=item_names.ROACH, classification=ItemClassification.progression),
     item_names.ROACH_ORGANIC_CARAPACE:
-        ItemData(228 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 28, SC2Race.ZERG, parent_item=item_names.ROACH),
+        ItemData(228 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 28, SC2Race.ZERG, parent=item_names.ROACH),
     item_names.HYDRALISK_MUSCULAR_AUGMENTS:
-        ItemData(229 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 29, SC2Race.ZERG, parent_item=item_names.HYDRALISK),
+        ItemData(229 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_1, 29, SC2Race.ZERG, parent=item_names.HYDRALISK),
     item_names.HYDRALISK_RESOURCE_EFFICIENCY:
-        ItemData(230 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 0, SC2Race.ZERG, parent_item=item_names.HYDRALISK, classification=ItemClassification.progression),
+        ItemData(230 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 0, SC2Race.ZERG, parent=item_names.HYDRALISK, classification=ItemClassification.progression),
     item_names.BANELING_CENTRIFUGAL_HOOKS:
         ItemData(231 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 1, SC2Race.ZERG,
-                 parent_item=parent_names.BANELING_SOURCE),
+                 parent=parent_names.BANELING_SOURCE),
     item_names.BANELING_TUNNELING_JAWS:
         ItemData(232 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 2, SC2Race.ZERG,
-                 parent_item=parent_names.BANELING_SOURCE),
+                 parent=parent_names.BANELING_SOURCE),
     item_names.BANELING_RAPID_METAMORPH:
         ItemData(233 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 3, SC2Race.ZERG,
-                 parent_item=parent_names.MORPH_SOURCE_ZERGLING),
+                 parent=parent_names.MORPH_SOURCE_ZERGLING),
     item_names.MUTALISK_SEVERING_GLAIVE:
-        ItemData(234 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 4, SC2Race.ZERG, parent_item=item_names.MUTALISK, classification=ItemClassification.progression),
+        ItemData(234 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 4, SC2Race.ZERG, parent=item_names.MUTALISK, classification=ItemClassification.progression),
     item_names.MUTALISK_AERODYNAMIC_GLAIVE_SHAPE:
-        ItemData(235 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 5, SC2Race.ZERG, parent_item=item_names.MUTALISK, classification=ItemClassification.progression),
+        ItemData(235 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 5, SC2Race.ZERG, parent=item_names.MUTALISK, classification=ItemClassification.progression),
     item_names.SWARM_HOST_LOCUST_METABOLIC_BOOST:
-        ItemData(236 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 6, SC2Race.ZERG, parent_item=item_names.SWARM_HOST, classification=ItemClassification.filler),
+        ItemData(236 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 6, SC2Race.ZERG, parent=item_names.SWARM_HOST, classification=ItemClassification.filler),
     item_names.SWARM_HOST_ENDURING_LOCUSTS:
-        ItemData(237 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 7, SC2Race.ZERG, parent_item=item_names.SWARM_HOST),
+        ItemData(237 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 7, SC2Race.ZERG, parent=item_names.SWARM_HOST),
     item_names.SWARM_HOST_ORGANIC_CARAPACE:
-        ItemData(238 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 8, SC2Race.ZERG, parent_item=item_names.SWARM_HOST),
+        ItemData(238 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 8, SC2Race.ZERG, parent=item_names.SWARM_HOST),
     item_names.SWARM_HOST_RESOURCE_EFFICIENCY:
-        ItemData(239 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 9, SC2Race.ZERG, parent_item=item_names.SWARM_HOST, classification=ItemClassification.progression),
+        ItemData(239 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 9, SC2Race.ZERG, parent=item_names.SWARM_HOST, classification=ItemClassification.progression),
     item_names.ULTRALISK_ANABOLIC_SYNTHESIS:
-        ItemData(240 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 10, SC2Race.ZERG, parent_item=item_names.ULTRALISK, classification=ItemClassification.filler),
+        ItemData(240 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 10, SC2Race.ZERG, parent=item_names.ULTRALISK, classification=ItemClassification.filler),
     item_names.ULTRALISK_CHITINOUS_PLATING:
-        ItemData(241 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 11, SC2Race.ZERG, parent_item=item_names.ULTRALISK, classification=ItemClassification.progression),
+        ItemData(241 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 11, SC2Race.ZERG, parent=item_names.ULTRALISK, classification=ItemClassification.progression),
     item_names.ULTRALISK_ORGANIC_CARAPACE:
-        ItemData(242 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 12, SC2Race.ZERG, parent_item=item_names.ULTRALISK),
+        ItemData(242 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 12, SC2Race.ZERG, parent=item_names.ULTRALISK),
     item_names.ULTRALISK_RESOURCE_EFFICIENCY:
-        ItemData(243 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 13, SC2Race.ZERG, parent_item=item_names.ULTRALISK),
+        ItemData(243 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 13, SC2Race.ZERG, parent=item_names.ULTRALISK),
     item_names.DEVOURER_CORROSIVE_SPRAY:
         ItemData(244 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 14, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT),
+                 parent=item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT),
     item_names.DEVOURER_GAPING_MAW:
         ItemData(245 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 15, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT),
+                 parent=item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT),
     item_names.DEVOURER_IMPROVED_OSMOSIS:
         ItemData(246 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 16, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT,
+                 parent=item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT,
                  classification=ItemClassification.filler),
     item_names.DEVOURER_PRESCIENT_SPORES:
         ItemData(247 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 17, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT,
+                 parent=item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT,
                  classification=ItemClassification.progression),
     item_names.GUARDIAN_PROLONGED_DISPERSION:
         ItemData(248 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 18, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT),
+                 parent=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT),
     item_names.GUARDIAN_PRIMAL_ADAPTATION:
         ItemData(249 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 19, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT,
+                 parent=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT,
                  classification=ItemClassification.progression),
     item_names.GUARDIAN_SORONAN_ACID:
         ItemData(250 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 20, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT, classification=ItemClassification.progression),
+                 parent=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT, classification=ItemClassification.progression),
     item_names.IMPALER_ADAPTIVE_TALONS:
         ItemData(251 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 21, SC2Race.ZERG,
-                 parent_item=item_names.HYDRALISK_IMPALER_ASPECT,
+                 parent=item_names.HYDRALISK_IMPALER_ASPECT,
                  classification=ItemClassification.filler),
     item_names.IMPALER_SECRETION_GLANDS:
         ItemData(252 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 22, SC2Race.ZERG,
-                 parent_item=item_names.HYDRALISK_IMPALER_ASPECT),
+                 parent=item_names.HYDRALISK_IMPALER_ASPECT),
     item_names.IMPALER_HARDENED_TENTACLE_SPINES:
         ItemData(253 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 23, SC2Race.ZERG,
-                 parent_item=item_names.HYDRALISK_IMPALER_ASPECT, classification=ItemClassification.progression),
+                 parent=item_names.HYDRALISK_IMPALER_ASPECT, classification=ItemClassification.progression),
     item_names.LURKER_SEISMIC_SPINES:
         ItemData(254 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 24, SC2Race.ZERG,
-                 parent_item=item_names.HYDRALISK_LURKER_ASPECT, classification=ItemClassification.progression),
+                 parent=item_names.HYDRALISK_LURKER_ASPECT, classification=ItemClassification.progression),
     item_names.LURKER_ADAPTED_SPINES:
         ItemData(255 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 25, SC2Race.ZERG,
-                 parent_item=item_names.HYDRALISK_LURKER_ASPECT, classification=ItemClassification.progression),
+                 parent=item_names.HYDRALISK_LURKER_ASPECT, classification=ItemClassification.progression),
     item_names.RAVAGER_POTENT_BILE:
         ItemData(256 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 26, SC2Race.ZERG,
-                 parent_item=item_names.ROACH_RAVAGER_ASPECT),
+                 parent=item_names.ROACH_RAVAGER_ASPECT),
     item_names.RAVAGER_BLOATED_BILE_DUCTS:
         ItemData(257 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 27, SC2Race.ZERG,
-                 parent_item=item_names.ROACH_RAVAGER_ASPECT),
+                 parent=item_names.ROACH_RAVAGER_ASPECT),
     item_names.RAVAGER_DEEP_TUNNEL:
         ItemData(258 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 28, SC2Race.ZERG,
-                 parent_item=item_names.ROACH_RAVAGER_ASPECT),
+                 parent=item_names.ROACH_RAVAGER_ASPECT),
     item_names.VIPER_PARASITIC_BOMB:
         ItemData(259 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_2, 29, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_VIPER_ASPECT,
+                 parent=item_names.MUTALISK_CORRUPTOR_VIPER_ASPECT,
                  classification=ItemClassification.progression),
     item_names.VIPER_PARALYTIC_BARBS:
         ItemData(260 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 0, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_VIPER_ASPECT),
+                 parent=item_names.MUTALISK_CORRUPTOR_VIPER_ASPECT),
     item_names.VIPER_VIRULENT_MICROBES:
         ItemData(261 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 1, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_VIPER_ASPECT),
+                 parent=item_names.MUTALISK_CORRUPTOR_VIPER_ASPECT),
     item_names.BROOD_LORD_POROUS_CARTILAGE:
         ItemData(262 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 2, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_BROOD_LORD_ASPECT),
+                 parent=item_names.MUTALISK_CORRUPTOR_BROOD_LORD_ASPECT),
     item_names.BROOD_LORD_EVOLVED_CARAPACE:
         ItemData(263 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 3, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_BROOD_LORD_ASPECT),
+                 parent=item_names.MUTALISK_CORRUPTOR_BROOD_LORD_ASPECT),
     item_names.BROOD_LORD_SPLITTER_MITOSIS:
         ItemData(264 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 4, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_BROOD_LORD_ASPECT),
+                 parent=item_names.MUTALISK_CORRUPTOR_BROOD_LORD_ASPECT),
     item_names.BROOD_LORD_RESOURCE_EFFICIENCY:
         ItemData(265 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 5, SC2Race.ZERG,
-                 parent_item=item_names.MUTALISK_CORRUPTOR_BROOD_LORD_ASPECT),
+                 parent=item_names.MUTALISK_CORRUPTOR_BROOD_LORD_ASPECT),
     item_names.INFESTOR_INFESTED_TERRAN:
-        ItemData(266 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 6, SC2Race.ZERG, parent_item=item_names.INFESTOR, classification=ItemClassification.progression),
+        ItemData(266 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 6, SC2Race.ZERG, parent=item_names.INFESTOR, classification=ItemClassification.progression),
     item_names.INFESTOR_MICROBIAL_SHROUD:
-        ItemData(267 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 7, SC2Race.ZERG, parent_item=item_names.INFESTOR),
+        ItemData(267 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 7, SC2Race.ZERG, parent=item_names.INFESTOR),
     item_names.SWARM_QUEEN_SPAWN_LARVAE:
-        ItemData(268 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 8, SC2Race.ZERG, parent_item=item_names.SWARM_QUEEN),
+        ItemData(268 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 8, SC2Race.ZERG, parent=item_names.SWARM_QUEEN),
     item_names.SWARM_QUEEN_DEEP_TUNNEL:
-        ItemData(269 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 9, SC2Race.ZERG, parent_item=item_names.SWARM_QUEEN),
+        ItemData(269 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 9, SC2Race.ZERG, parent=item_names.SWARM_QUEEN),
     item_names.SWARM_QUEEN_ORGANIC_CARAPACE:
-        ItemData(270 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 10, SC2Race.ZERG, parent_item=item_names.SWARM_QUEEN, classification=ItemClassification.filler),
+        ItemData(270 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 10, SC2Race.ZERG, parent=item_names.SWARM_QUEEN, classification=ItemClassification.filler),
     item_names.SWARM_QUEEN_BIO_MECHANICAL_TRANSFUSION:
-        ItemData(271 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 11, SC2Race.ZERG, parent_item=item_names.SWARM_QUEEN, classification=ItemClassification.progression),
+        ItemData(271 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 11, SC2Race.ZERG, parent=item_names.SWARM_QUEEN, classification=ItemClassification.progression),
     item_names.SWARM_QUEEN_RESOURCE_EFFICIENCY:
-        ItemData(272 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 12, SC2Race.ZERG, parent_item=item_names.SWARM_QUEEN, classification=ItemClassification.progression),
+        ItemData(272 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 12, SC2Race.ZERG, parent=item_names.SWARM_QUEEN, classification=ItemClassification.progression),
     item_names.SWARM_QUEEN_INCUBATOR_CHAMBER:
-        ItemData(273 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 13, SC2Race.ZERG, parent_item=item_names.SWARM_QUEEN),
+        ItemData(273 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 13, SC2Race.ZERG, parent=item_names.SWARM_QUEEN),
     item_names.BROOD_QUEEN_FUNGAL_GROWTH:
-        ItemData(274 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 14, SC2Race.ZERG, parent_item=item_names.BROOD_QUEEN),
+        ItemData(274 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 14, SC2Race.ZERG, parent=item_names.BROOD_QUEEN),
     item_names.BROOD_QUEEN_ENSNARE:
-        ItemData(275 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 15, SC2Race.ZERG, parent_item=item_names.BROOD_QUEEN),
+        ItemData(275 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 15, SC2Race.ZERG, parent=item_names.BROOD_QUEEN),
     item_names.BROOD_QUEEN_ENHANCED_MITOCHONDRIA:
-        ItemData(276 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 16, SC2Race.ZERG, parent_item=item_names.BROOD_QUEEN),
+        ItemData(276 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 16, SC2Race.ZERG, parent=item_names.BROOD_QUEEN),
     item_names.DEFILER_PATHOGEN_PROJECTORS:
-        ItemData(277 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 17, SC2Race.ZERG, parent_item=item_names.DEFILER),
+        ItemData(277 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 17, SC2Race.ZERG, parent=item_names.DEFILER),
     item_names.DEFILER_TRAPDOOR_ADAPTATION:
-        ItemData(278 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 18, SC2Race.ZERG, parent_item=item_names.DEFILER),
+        ItemData(278 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 18, SC2Race.ZERG, parent=item_names.DEFILER),
     item_names.DEFILER_PREDATORY_CONSUMPTION:
-        ItemData(279 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 19, SC2Race.ZERG, parent_item=item_names.DEFILER),
+        ItemData(279 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 19, SC2Race.ZERG, parent=item_names.DEFILER),
     item_names.DEFILER_COMORBIDITY:
-        ItemData(280 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 20, SC2Race.ZERG, parent_item=item_names.DEFILER),
+        ItemData(280 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 20, SC2Race.ZERG, parent=item_names.DEFILER),
     item_names.ABERRATION_MONSTROUS_RESILIENCE:
-        ItemData(281 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 21, SC2Race.ZERG, parent_item=item_names.ABERRATION),
+        ItemData(281 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 21, SC2Race.ZERG, parent=item_names.ABERRATION),
     item_names.ABERRATION_CONSTRUCT_REGENERATION:
-        ItemData(282 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 22, SC2Race.ZERG, parent_item=item_names.ABERRATION),
+        ItemData(282 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 22, SC2Race.ZERG, parent=item_names.ABERRATION),
     item_names.ABERRATION_BANELING_INCUBATION:
-        ItemData(283 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 23, SC2Race.ZERG, parent_item=item_names.ABERRATION),
+        ItemData(283 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 23, SC2Race.ZERG, parent=item_names.ABERRATION),
     item_names.ABERRATION_PROTECTIVE_COVER:
-        ItemData(284 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 24, SC2Race.ZERG, parent_item=item_names.ABERRATION),
+        ItemData(284 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 24, SC2Race.ZERG, parent=item_names.ABERRATION),
     item_names.ABERRATION_RESOURCE_EFFICIENCY:
-        ItemData(285 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 25, SC2Race.ZERG, parent_item=item_names.ABERRATION),
+        ItemData(285 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 25, SC2Race.ZERG, parent=item_names.ABERRATION),
     item_names.CORRUPTOR_MONSTROUS_RESILIENCE:
-        ItemData(286 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 26, SC2Race.ZERG, parent_item=item_names.CORRUPTOR),
+        ItemData(286 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 26, SC2Race.ZERG, parent=item_names.CORRUPTOR),
     item_names.CORRUPTOR_CONSTRUCT_REGENERATION:
-        ItemData(287 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 27, SC2Race.ZERG, parent_item=item_names.CORRUPTOR),
+        ItemData(287 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 27, SC2Race.ZERG, parent=item_names.CORRUPTOR),
     item_names.CORRUPTOR_SCOURGE_INCUBATION:
-        ItemData(288 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 28, SC2Race.ZERG, parent_item=item_names.CORRUPTOR),
+        ItemData(288 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 28, SC2Race.ZERG, parent=item_names.CORRUPTOR),
     item_names.CORRUPTOR_RESOURCE_EFFICIENCY:
-        ItemData(289 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 29, SC2Race.ZERG, parent_item=item_names.CORRUPTOR),
+        ItemData(289 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_3, 29, SC2Race.ZERG, parent=item_names.CORRUPTOR),
     item_names.PRIMAL_IGNITER_CONCENTRATED_FIRE:
-        ItemData(290 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 0, SC2Race.ZERG, parent_item=item_names.ROACH_PRIMAL_IGNITER_ASPECT),
+        ItemData(290 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 0, SC2Race.ZERG, parent=item_names.ROACH_PRIMAL_IGNITER_ASPECT),
     item_names.PRIMAL_IGNITER_PRIMAL_TENACITY:
-        ItemData(291 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 1, SC2Race.ZERG, parent_item=item_names.ROACH_PRIMAL_IGNITER_ASPECT, classification=ItemClassification.progression),
+        ItemData(291 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 1, SC2Race.ZERG, parent=item_names.ROACH_PRIMAL_IGNITER_ASPECT, classification=ItemClassification.progression),
     item_names.INFESTED_SCV_BUILD_CHARGES:
-        ItemData(292 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 2, SC2Race.ZERG, parent_item=parent_names.INFESTED_UNITS),
+        ItemData(292 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 2, SC2Race.ZERG, parent=parent_names.INFESTED_UNITS),
     item_names.INFESTED_MARINE_PLAGUED_MUNITIONS:
-        ItemData(293 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 3, SC2Race.ZERG, parent_item=item_names.INFESTED_MARINE),
+        ItemData(293 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 3, SC2Race.ZERG, parent=item_names.INFESTED_MARINE),
     item_names.INFESTED_MARINE_RETINAL_AUGMENTATION:
-        ItemData(294 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 4, SC2Race.ZERG, parent_item=item_names.INFESTED_MARINE),
+        ItemData(294 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 4, SC2Race.ZERG, parent=item_names.INFESTED_MARINE),
     item_names.INFESTED_BUNKER_CALCIFIED_ARMOR:
-        ItemData(295 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 6, SC2Race.ZERG, parent_item=item_names.INFESTED_BUNKER),
+        ItemData(295 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 6, SC2Race.ZERG, parent=item_names.INFESTED_BUNKER),
     item_names.INFESTED_BUNKER_REGENERATIVE_PLATING:
-        ItemData(296 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 5, SC2Race.ZERG, parent_item=item_names.INFESTED_BUNKER),
+        ItemData(296 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 5, SC2Race.ZERG, parent=item_names.INFESTED_BUNKER),
     item_names.INFESTED_BUNKER_ENGORGED_BUNKERS:
-        ItemData(297 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 7, SC2Race.ZERG, parent_item=item_names.INFESTED_BUNKER),
+        ItemData(297 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 7, SC2Race.ZERG, parent=item_names.INFESTED_BUNKER),
     item_names.INFESTED_MISSILE_TURRET_BIOELECTRIC_PAYLOAD:
-        ItemData(298 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 6, SC2Race.ZERG, parent_item=item_names.INFESTED_MISSILE_TURRET),
+        ItemData(298 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 6, SC2Race.ZERG, parent=item_names.INFESTED_MISSILE_TURRET),
     item_names.INFESTED_MISSILE_TURRET_ACID_SPORE_VENTS:
-        ItemData(299 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 7, SC2Race.ZERG, parent_item=item_names.INFESTED_MISSILE_TURRET),
+        ItemData(299 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 7, SC2Race.ZERG, parent=item_names.INFESTED_MISSILE_TURRET),
 
     item_names.ZERGLING_RAPTOR_STRAIN:
-        ItemData(300 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 0, SC2Race.ZERG, parent_item=item_names.ZERGLING, classification=ItemClassification.progression),
+        ItemData(300 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 0, SC2Race.ZERG, parent=item_names.ZERGLING, classification=ItemClassification.progression),
     item_names.ZERGLING_SWARMLING_STRAIN:
-        ItemData(301 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 1, SC2Race.ZERG, parent_item=item_names.ZERGLING),
+        ItemData(301 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 1, SC2Race.ZERG, parent=item_names.ZERGLING),
     item_names.ROACH_VILE_STRAIN:
-        ItemData(302 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 2, SC2Race.ZERG, parent_item=item_names.ROACH),
+        ItemData(302 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 2, SC2Race.ZERG, parent=item_names.ROACH),
     item_names.ROACH_CORPSER_STRAIN:
-        ItemData(303 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 3, SC2Race.ZERG, parent_item=item_names.ROACH, classification=ItemClassification.progression),
+        ItemData(303 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 3, SC2Race.ZERG, parent=item_names.ROACH, classification=ItemClassification.progression),
     item_names.HYDRALISK_IMPALER_ASPECT:
         ItemData(304 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 0, SC2Race.ZERG,
-                 classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_HYDRALISK),
+                 classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_HYDRALISK),
     item_names.HYDRALISK_LURKER_ASPECT:
         ItemData(305 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 1, SC2Race.ZERG,
-                 classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_HYDRALISK),
+                 classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_HYDRALISK),
     item_names.BANELING_SPLITTER_STRAIN:
-        ItemData(306 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 6, SC2Race.ZERG, parent_item=parent_names.BANELING_SOURCE),
+        ItemData(306 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 6, SC2Race.ZERG, parent=parent_names.BANELING_SOURCE),
     item_names.BANELING_HUNTER_STRAIN:
-        ItemData(307 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 7, SC2Race.ZERG, parent_item=parent_names.BANELING_SOURCE),
+        ItemData(307 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 7, SC2Race.ZERG, parent=parent_names.BANELING_SOURCE),
     item_names.MUTALISK_CORRUPTOR_BROOD_LORD_ASPECT:
         ItemData(308 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 2, SC2Race.ZERG,
-                 classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_AIR),
+                 classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_AIR),
     item_names.MUTALISK_CORRUPTOR_VIPER_ASPECT:
         ItemData(309 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 3, SC2Race.ZERG,
-                 classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_AIR),
+                 classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_AIR),
     item_names.SWARM_HOST_CARRION_STRAIN:
-        ItemData(310 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 10, SC2Race.ZERG, parent_item=item_names.SWARM_HOST),
+        ItemData(310 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 10, SC2Race.ZERG, parent=item_names.SWARM_HOST),
     item_names.SWARM_HOST_CREEPER_STRAIN:
-        ItemData(311 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 11, SC2Race.ZERG, parent_item=item_names.SWARM_HOST, classification=ItemClassification.filler),
+        ItemData(311 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 11, SC2Race.ZERG, parent=item_names.SWARM_HOST, classification=ItemClassification.filler),
     item_names.ULTRALISK_NOXIOUS_STRAIN:
-        ItemData(312 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 12, SC2Race.ZERG, parent_item=item_names.ULTRALISK, classification=ItemClassification.filler),
+        ItemData(312 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 12, SC2Race.ZERG, parent=item_names.ULTRALISK, classification=ItemClassification.filler),
     item_names.ULTRALISK_TORRASQUE_STRAIN:
-        ItemData(313 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 13, SC2Race.ZERG, parent_item=item_names.ULTRALISK, classification=ItemClassification.progression),
+        ItemData(313 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 13, SC2Race.ZERG, parent=item_names.ULTRALISK, classification=ItemClassification.progression),
 
     item_names.TYRANNOZOR_TYRANTS_PROTECTION:
-        ItemData(350 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 8, SC2Race.ZERG, parent_item=item_names.ULTRALISK_TYRANNOZOR_ASPECT),
+        ItemData(350 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 8, SC2Race.ZERG, parent=item_names.ULTRALISK_TYRANNOZOR_ASPECT),
     item_names.TYRANNOZOR_BARRAGE_OF_SPIKES:
-        ItemData(351 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 9, SC2Race.ZERG, parent_item=item_names.ULTRALISK_TYRANNOZOR_ASPECT),
+        ItemData(351 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 9, SC2Race.ZERG, parent=item_names.ULTRALISK_TYRANNOZOR_ASPECT),
     item_names.TYRANNOZOR_IMPALING_STRIKE:
-        ItemData(352 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 10, SC2Race.ZERG, parent_item=item_names.ULTRALISK_TYRANNOZOR_ASPECT),
+        ItemData(352 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 10, SC2Race.ZERG, parent=item_names.ULTRALISK_TYRANNOZOR_ASPECT),
     item_names.TYRANNOZOR_HEALING_ADAPTATION:
-        ItemData(353 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 11, SC2Race.ZERG, parent_item=item_names.ULTRALISK_TYRANNOZOR_ASPECT),
+        ItemData(353 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 11, SC2Race.ZERG, parent=item_names.ULTRALISK_TYRANNOZOR_ASPECT),
     item_names.NYDUS_WORM_ECHIDNA_WORM_SUBTERRANEAN_SCALES:
-        ItemData(354 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 12, SC2Race.ZERG, parent_item=parent_names.ANY_NYDUS_WORM, classification=ItemClassification.filler),
+        ItemData(354 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 12, SC2Race.ZERG, parent=parent_names.ANY_NYDUS_WORM, classification=ItemClassification.filler),
     item_names.NYDUS_WORM_ECHIDNA_WORM_JORMUNGANDR_STRAIN:
-        ItemData(355 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 13, SC2Race.ZERG, parent_item=parent_names.ANY_NYDUS_WORM, classification=ItemClassification.useful),
+        ItemData(355 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 13, SC2Race.ZERG, parent=parent_names.ANY_NYDUS_WORM, classification=ItemClassification.useful),
     item_names.NYDUS_WORM_ECHIDNA_WORM_RESOURCE_EFFICIENCY:
-        ItemData(356 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 14, SC2Race.ZERG, parent_item=parent_names.ANY_NYDUS_WORM, classification=ItemClassification.useful),
+        ItemData(356 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 14, SC2Race.ZERG, parent=parent_names.ANY_NYDUS_WORM, classification=ItemClassification.useful),
     item_names.ECHIDNA_WORM_OUROBOROS_STRAIN:
-        ItemData(357 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 15, SC2Race.ZERG, parent_item=item_names.ECHIDNA_WORM, classification=ItemClassification.useful),
+        ItemData(357 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 15, SC2Race.ZERG, parent=item_names.ECHIDNA_WORM, classification=ItemClassification.useful),
     item_names.NYDUS_WORM_RAVENOUS_APPETITE:
-        ItemData(358 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 16, SC2Race.ZERG, parent_item=item_names.NYDUS_WORM, classification=ItemClassification.useful),
+        ItemData(358 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 16, SC2Race.ZERG, parent=item_names.NYDUS_WORM, classification=ItemClassification.useful),
     item_names.INFESTED_SIEGE_TANK_PROGRESSIVE_AUTOMATED_MITOSIS:
         ItemData(359 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Progressive, 0, SC2Race.ZERG,
-                 parent_item=item_names.INFESTED_SIEGE_TANK, quantity=2, classification=ItemClassification.progression),
+                 parent=item_names.INFESTED_SIEGE_TANK, quantity=2, classification=ItemClassification.progression),
     item_names.INFESTED_SIEGE_TANK_ACIDIC_ENZYMES:
-        ItemData(360 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 17, SC2Race.ZERG, parent_item=item_names.INFESTED_SIEGE_TANK),
+        ItemData(360 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 17, SC2Race.ZERG, parent=item_names.INFESTED_SIEGE_TANK),
     item_names.INFESTED_SIEGE_TANK_DEEP_TUNNEL:
-        ItemData(361 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 18, SC2Race.ZERG, parent_item=item_names.INFESTED_SIEGE_TANK),
+        ItemData(361 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 18, SC2Race.ZERG, parent=item_names.INFESTED_SIEGE_TANK),
     item_names.INFESTED_DIAMONDBACK_CAUSTIC_MUCUS:
-        ItemData(362 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 19, SC2Race.ZERG, parent_item=item_names.INFESTED_DIAMONDBACK),
+        ItemData(362 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 19, SC2Race.ZERG, parent=item_names.INFESTED_DIAMONDBACK),
     item_names.INFESTED_DIAMONDBACK_VIOLENT_ENZYMES:
-        ItemData(363 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 20, SC2Race.ZERG, parent_item=item_names.INFESTED_DIAMONDBACK),
+        ItemData(363 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 20, SC2Race.ZERG, parent=item_names.INFESTED_DIAMONDBACK),
     item_names.INFESTED_BANSHEE_BRACED_EXOSKELETON:
-        ItemData(364 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 21, SC2Race.ZERG, parent_item=item_names.INFESTED_BANSHEE),
+        ItemData(364 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 21, SC2Race.ZERG, parent=item_names.INFESTED_BANSHEE),
     item_names.INFESTED_BANSHEE_RAPID_HIBERNATION:
-        ItemData(365 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 22, SC2Race.ZERG, parent_item=item_names.INFESTED_BANSHEE),
+        ItemData(365 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 22, SC2Race.ZERG, parent=item_names.INFESTED_BANSHEE),
     item_names.INFESTED_LIBERATOR_CLOUD_DISPERSAL:
-        ItemData(366 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 23, SC2Race.ZERG, parent_item=item_names.INFESTED_LIBERATOR, classification=ItemClassification.progression),
+        ItemData(366 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 23, SC2Race.ZERG, parent=item_names.INFESTED_LIBERATOR, classification=ItemClassification.progression),
     item_names.INFESTED_LIBERATOR_VIRAL_CONTAMINATION:
-        ItemData(367 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 24, SC2Race.ZERG, parent_item=item_names.INFESTED_LIBERATOR),
+        ItemData(367 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 24, SC2Race.ZERG, parent=item_names.INFESTED_LIBERATOR),
     item_names.GUARDIAN_PROPELLANT_SACS:
-        ItemData(368 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 25, SC2Race.ZERG, parent_item=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT, classification=ItemClassification.progression),
+        ItemData(368 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 25, SC2Race.ZERG, parent=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT, classification=ItemClassification.progression),
     item_names.GUARDIAN_EXPLOSIVE_SPORES:
-        ItemData(369 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 26, SC2Race.ZERG, parent_item=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT),
+        ItemData(369 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 26, SC2Race.ZERG, parent=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT),
     item_names.GUARDIAN_PRIMORDIAL_FURY:
-        ItemData(370 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 27, SC2Race.ZERG, parent_item=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT),
+        ItemData(370 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 27, SC2Race.ZERG, parent=item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT),
     item_names.INFESTED_SIEGE_TANK_SEISMIC_SONAR:
-        ItemData(371 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 28, SC2Race.ZERG, parent_item=item_names.INFESTED_SIEGE_TANK),
+        ItemData(371 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 28, SC2Race.ZERG, parent=item_names.INFESTED_SIEGE_TANK),
     item_names.INFESTED_BANSHEE_ADVANCED_TARGETING_OPTICS:
-        ItemData(372 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 29, SC2Race.ZERG, parent_item=item_names.INFESTED_BANSHEE),
+        ItemData(372 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 29, SC2Race.ZERG, parent=item_names.INFESTED_BANSHEE),
     item_names.INFESTED_SIEGE_TANK_BALANCED_ROOTS:
-        ItemData(373 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 0, SC2Race.ZERG, parent_item=item_names.INFESTED_SIEGE_TANK),
+        ItemData(373 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 0, SC2Race.ZERG, parent=item_names.INFESTED_SIEGE_TANK),
     item_names.INFESTED_DIAMONDBACK_PROGRESSIVE_FUNGAL_SNARE:
         ItemData(374 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Progressive, 2, SC2Race.ZERG,
-                 parent_item=item_names.INFESTED_DIAMONDBACK, classification=ItemClassification.progression, quantity=2),
+                 parent=item_names.INFESTED_DIAMONDBACK, classification=ItemClassification.progression, quantity=2),
     item_names.INFESTED_DIAMONDBACK_CONCENTRATED_SPEW:
-        ItemData(375 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 1, SC2Race.ZERG, parent_item=item_names.INFESTED_DIAMONDBACK),
+        ItemData(375 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 1, SC2Race.ZERG, parent=item_names.INFESTED_DIAMONDBACK),
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_SIEGE_TANK:
-        ItemData(376 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 2, SC2Race.ZERG, parent_item=item_names.INFESTED_SIEGE_TANK),
+        ItemData(376 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 2, SC2Race.ZERG, parent=item_names.INFESTED_SIEGE_TANK),
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_DIAMONDBACK:
-        ItemData(377 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 3, SC2Race.ZERG, parent_item=item_names.INFESTED_DIAMONDBACK),
+        ItemData(377 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 3, SC2Race.ZERG, parent=item_names.INFESTED_DIAMONDBACK),
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_BANSHEE:
-        ItemData(378 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 4, SC2Race.ZERG, parent_item=item_names.INFESTED_BANSHEE),
+        ItemData(378 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 4, SC2Race.ZERG, parent=item_names.INFESTED_BANSHEE),
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_LIBERATOR:
-        ItemData(379 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 5, SC2Race.ZERG, parent_item=item_names.INFESTED_LIBERATOR),
+        ItemData(379 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 5, SC2Race.ZERG, parent=item_names.INFESTED_LIBERATOR),
     item_names.INFESTED_LIBERATOR_DEFENDER_MODE:
-        ItemData(380 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 8, SC2Race.ZERG, parent_item=item_names.INFESTED_LIBERATOR,
+        ItemData(380 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 8, SC2Race.ZERG, parent=item_names.INFESTED_LIBERATOR,
                  classification=ItemClassification.progression),
     item_names.ABERRATION_PROGRESSIVE_BANELING_LAUNCH:
-        ItemData(381 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Progressive, 4, SC2Race.ZERG, parent_item=item_names.ABERRATION, quantity=2),
+        ItemData(381 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Progressive, 4, SC2Race.ZERG, parent=item_names.ABERRATION, quantity=2),
     item_names.PYGALISK_STIM:
-        ItemData(382 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 9, SC2Race.ZERG, parent_item=item_names.PYGALISK),
+        ItemData(382 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 9, SC2Race.ZERG, parent=item_names.PYGALISK),
     item_names.PYGALISK_DUCAL_BLADES:
-        ItemData(383 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 10, SC2Race.ZERG, parent_item=item_names.PYGALISK),
+        ItemData(383 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 10, SC2Race.ZERG, parent=item_names.PYGALISK),
     item_names.PYGALISK_COMBAT_CARAPACE:
-        ItemData(384 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 11, SC2Race.ZERG, parent_item=item_names.PYGALISK),
+        ItemData(384 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 11, SC2Race.ZERG, parent=item_names.PYGALISK),
 
     item_names.KERRIGAN_KINETIC_BLAST: ItemData(400 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 0, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.KERRIGAN_HEROIC_FORTITUDE: ItemData(401 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 1, SC2Race.ZERG, classification=ItemClassification.progression),
@@ -1620,7 +1620,7 @@ item_table = {
     item_names.OVERLORD_GENERATE_CREEP: ItemData(701 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 7, SC2Race.ZERG),
     item_names.OVERLORD_ANTENNAE: ItemData(702 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 8, SC2Race.ZERG, classification=ItemClassification.filler),
     item_names.OVERLORD_PNEUMATIZED_CARAPACE: ItemData(703 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 9, SC2Race.ZERG),
-    item_names.ZERG_EXCAVATING_CLAWS: ItemData(704 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 11, SC2Race.ZERG, parent_item=parent_names.ZERG_UPROOTABLE_BUILDINGS),
+    item_names.ZERG_EXCAVATING_CLAWS: ItemData(704 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 11, SC2Race.ZERG, parent=parent_names.ZERG_UPROOTABLE_BUILDINGS),
     item_names.ZERG_CREEP_STOMACH: ItemData(705 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 10, SC2Race.ZERG),
     item_names.HIVE_CLUSTER_MATURATION: ItemData(706 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 12, SC2Race.ZERG),
     item_names.MACROSCOPIC_RECUPERATION: ItemData(707 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 13, SC2Race.ZERG),
@@ -1628,12 +1628,12 @@ item_table = {
     item_names.BROODLING_PACKING: ItemData(709 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 15, SC2Race.ZERG),
 
     # Morphs
-    item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT: ItemData(800 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 6, SC2Race.ZERG, classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_AIR),
-    item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT: ItemData(801 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 7, SC2Race.ZERG, classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_AIR),
-    item_names.ROACH_RAVAGER_ASPECT: ItemData(802 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 8, SC2Race.ZERG, classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_ROACH),
+    item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT: ItemData(800 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 6, SC2Race.ZERG, classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_AIR),
+    item_names.MUTALISK_CORRUPTOR_DEVOURER_ASPECT: ItemData(801 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 7, SC2Race.ZERG, classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_AIR),
+    item_names.ROACH_RAVAGER_ASPECT: ItemData(802 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 8, SC2Race.ZERG, classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_ROACH),
     item_names.OVERLORD_OVERSEER_ASPECT: ItemData(803 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 4, SC2Race.ZERG, classification=ItemClassification.progression),
-    item_names.ROACH_PRIMAL_IGNITER_ASPECT: ItemData(804 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 9, SC2Race.ZERG, classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_ROACH),
-    item_names.ULTRALISK_TYRANNOZOR_ASPECT: ItemData(805 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 10, SC2Race.ZERG, classification=ItemClassification.progression, parent_item=parent_names.MORPH_SOURCE_ULTRALISK),
+    item_names.ROACH_PRIMAL_IGNITER_ASPECT: ItemData(804 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 9, SC2Race.ZERG, classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_ROACH),
+    item_names.ULTRALISK_TYRANNOZOR_ASPECT: ItemData(805 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 10, SC2Race.ZERG, classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_ULTRALISK),
 
 
     # Protoss Units (those that aren't as items in WoL (Prophecy))
@@ -1764,149 +1764,149 @@ item_table = {
     item_names.SHIELD_BATTERY: ItemData(202 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Building, 2, SC2Race.PROTOSS, classification=ItemClassification.progression),
 
     # Protoss Unit Upgrades
-    item_names.SUPPLICANT_BLOOD_SHIELD: ItemData(300 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 0, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.SUPPLICANT),
-    item_names.SUPPLICANT_SOUL_AUGMENTATION: ItemData(301 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 1, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.SUPPLICANT),
-    item_names.SUPPLICANT_SHIELD_REGENERATION: ItemData(302 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 2, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.SUPPLICANT),
-    item_names.ADEPT_SHOCKWAVE: ItemData(303 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 3, SC2Race.PROTOSS, parent_item=item_names.ADEPT),
-    item_names.ADEPT_RESONATING_GLAIVES: ItemData(304 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 4, SC2Race.PROTOSS, parent_item=item_names.ADEPT),
-    item_names.ADEPT_PHASE_BULWARK: ItemData(305 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 5, SC2Race.PROTOSS, parent_item=item_names.ADEPT),
-    item_names.STALKER_INSTIGATOR_SLAYER_DISINTEGRATING_PARTICLES: ItemData(306 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 6, SC2Race.PROTOSS, classification=ItemClassification.useful, parent_item=parent_names.STALKER_CLASS),
-    item_names.STALKER_INSTIGATOR_SLAYER_PARTICLE_REFLECTION: ItemData(307 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 7, SC2Race.PROTOSS, classification=ItemClassification.useful, parent_item=parent_names.STALKER_CLASS),
-    item_names.DRAGOON_HIGH_IMPACT_PHASE_DISRUPTORS: ItemData(308 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 8, SC2Race.PROTOSS, parent_item=item_names.DRAGOON),
-    item_names.DRAGOON_TRILLIC_COMPRESSION_SYSTEM: ItemData(309 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 9, SC2Race.PROTOSS, parent_item=item_names.DRAGOON),
-    item_names.DRAGOON_SINGULARITY_CHARGE: ItemData(310 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 10, SC2Race.PROTOSS, parent_item=item_names.DRAGOON),
-    item_names.DRAGOON_ENHANCED_STRIDER_SERVOS: ItemData(311 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 11, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.DRAGOON),
-    item_names.SCOUT_COMBAT_SENSOR_ARRAY: ItemData(312 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 12, SC2Race.PROTOSS, parent_item=item_names.SCOUT),
-    item_names.SCOUT_APIAL_SENSORS: ItemData(313 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 13, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.SCOUT),
-    item_names.SCOUT_GRAVITIC_THRUSTERS: ItemData(314 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 14, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.SCOUT),
-    item_names.SCOUT_ADVANCED_PHOTON_BLASTERS: ItemData(315 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 15, SC2Race.PROTOSS, parent_item=item_names.SCOUT),
-    item_names.TEMPEST_TECTONIC_DESTABILIZERS: ItemData(316 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 16, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.TEMPEST),
-    item_names.TEMPEST_QUANTIC_REACTOR: ItemData(317 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 17, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.TEMPEST),
-    item_names.TEMPEST_GRAVITY_SLING: ItemData(318 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 18, SC2Race.PROTOSS, parent_item=item_names.TEMPEST),
-    item_names.PHOENIX_CLASS_IONIC_WAVELENGTH_FLUX: ItemData(319 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 19, SC2Race.PROTOSS, parent_item=parent_names.PHOENIX_CLASS),
-    item_names.PHOENIX_CLASS_ANION_PULSE_CRYSTALS: ItemData(320 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 20, SC2Race.PROTOSS, parent_item=parent_names.PHOENIX_CLASS),
-    item_names.CORSAIR_STEALTH_DRIVE: ItemData(321 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 21, SC2Race.PROTOSS, parent_item=item_names.CORSAIR),
-    item_names.CORSAIR_ARGUS_JEWEL: ItemData(322 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 22, SC2Race.PROTOSS, parent_item=item_names.CORSAIR),
-    item_names.CORSAIR_SUSTAINING_DISRUPTION: ItemData(323 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 23, SC2Race.PROTOSS, parent_item=item_names.CORSAIR),
-    item_names.CORSAIR_NEUTRON_SHIELDS: ItemData(324 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 24, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.CORSAIR),
-    item_names.ORACLE_STEALTH_DRIVE: ItemData(325 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 25, SC2Race.PROTOSS, parent_item=item_names.ORACLE),
-    item_names.ORACLE_STASIS_CALIBRATION: ItemData(326 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 26, SC2Race.PROTOSS, parent_item=item_names.ORACLE),
-    item_names.ORACLE_TEMPORAL_ACCELERATION_BEAM: ItemData(327 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 27, SC2Race.PROTOSS, parent_item=item_names.ORACLE),
-    item_names.ARBITER_CHRONOSTATIC_REINFORCEMENT: ItemData(328 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 28, SC2Race.PROTOSS, parent_item=item_names.ARBITER),
-    item_names.ARBITER_KHAYDARIN_CORE: ItemData(329 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 29, SC2Race.PROTOSS, parent_item=item_names.ARBITER),
-    item_names.ARBITER_SPACETIME_ANCHOR: ItemData(330 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 0, SC2Race.PROTOSS, parent_item=item_names.ARBITER),
-    item_names.ARBITER_RESOURCE_EFFICIENCY: ItemData(331 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 1, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.ARBITER),
-    item_names.ARBITER_ENHANCED_CLOAK_FIELD: ItemData(332 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 2, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.ARBITER),
+    item_names.SUPPLICANT_BLOOD_SHIELD: ItemData(300 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 0, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.SUPPLICANT),
+    item_names.SUPPLICANT_SOUL_AUGMENTATION: ItemData(301 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 1, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.SUPPLICANT),
+    item_names.SUPPLICANT_SHIELD_REGENERATION: ItemData(302 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 2, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.SUPPLICANT),
+    item_names.ADEPT_SHOCKWAVE: ItemData(303 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 3, SC2Race.PROTOSS, parent=item_names.ADEPT),
+    item_names.ADEPT_RESONATING_GLAIVES: ItemData(304 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 4, SC2Race.PROTOSS, parent=item_names.ADEPT),
+    item_names.ADEPT_PHASE_BULWARK: ItemData(305 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 5, SC2Race.PROTOSS, parent=item_names.ADEPT),
+    item_names.STALKER_INSTIGATOR_SLAYER_DISINTEGRATING_PARTICLES: ItemData(306 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 6, SC2Race.PROTOSS, classification=ItemClassification.useful, parent=parent_names.STALKER_CLASS),
+    item_names.STALKER_INSTIGATOR_SLAYER_PARTICLE_REFLECTION: ItemData(307 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 7, SC2Race.PROTOSS, classification=ItemClassification.useful, parent=parent_names.STALKER_CLASS),
+    item_names.DRAGOON_HIGH_IMPACT_PHASE_DISRUPTORS: ItemData(308 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 8, SC2Race.PROTOSS, parent=item_names.DRAGOON),
+    item_names.DRAGOON_TRILLIC_COMPRESSION_SYSTEM: ItemData(309 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 9, SC2Race.PROTOSS, parent=item_names.DRAGOON),
+    item_names.DRAGOON_SINGULARITY_CHARGE: ItemData(310 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 10, SC2Race.PROTOSS, parent=item_names.DRAGOON),
+    item_names.DRAGOON_ENHANCED_STRIDER_SERVOS: ItemData(311 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 11, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.DRAGOON),
+    item_names.SCOUT_COMBAT_SENSOR_ARRAY: ItemData(312 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 12, SC2Race.PROTOSS, parent=item_names.SCOUT),
+    item_names.SCOUT_APIAL_SENSORS: ItemData(313 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 13, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.SCOUT),
+    item_names.SCOUT_GRAVITIC_THRUSTERS: ItemData(314 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 14, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.SCOUT),
+    item_names.SCOUT_ADVANCED_PHOTON_BLASTERS: ItemData(315 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 15, SC2Race.PROTOSS, parent=item_names.SCOUT),
+    item_names.TEMPEST_TECTONIC_DESTABILIZERS: ItemData(316 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 16, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.TEMPEST),
+    item_names.TEMPEST_QUANTIC_REACTOR: ItemData(317 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 17, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.TEMPEST),
+    item_names.TEMPEST_GRAVITY_SLING: ItemData(318 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 18, SC2Race.PROTOSS, parent=item_names.TEMPEST),
+    item_names.PHOENIX_CLASS_IONIC_WAVELENGTH_FLUX: ItemData(319 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 19, SC2Race.PROTOSS, parent=parent_names.PHOENIX_CLASS),
+    item_names.PHOENIX_CLASS_ANION_PULSE_CRYSTALS: ItemData(320 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 20, SC2Race.PROTOSS, parent=parent_names.PHOENIX_CLASS),
+    item_names.CORSAIR_STEALTH_DRIVE: ItemData(321 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 21, SC2Race.PROTOSS, parent=item_names.CORSAIR),
+    item_names.CORSAIR_ARGUS_JEWEL: ItemData(322 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 22, SC2Race.PROTOSS, parent=item_names.CORSAIR),
+    item_names.CORSAIR_SUSTAINING_DISRUPTION: ItemData(323 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 23, SC2Race.PROTOSS, parent=item_names.CORSAIR),
+    item_names.CORSAIR_NEUTRON_SHIELDS: ItemData(324 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 24, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.CORSAIR),
+    item_names.ORACLE_STEALTH_DRIVE: ItemData(325 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 25, SC2Race.PROTOSS, parent=item_names.ORACLE),
+    item_names.ORACLE_STASIS_CALIBRATION: ItemData(326 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 26, SC2Race.PROTOSS, parent=item_names.ORACLE),
+    item_names.ORACLE_TEMPORAL_ACCELERATION_BEAM: ItemData(327 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 27, SC2Race.PROTOSS, parent=item_names.ORACLE),
+    item_names.ARBITER_CHRONOSTATIC_REINFORCEMENT: ItemData(328 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 28, SC2Race.PROTOSS, parent=item_names.ARBITER),
+    item_names.ARBITER_KHAYDARIN_CORE: ItemData(329 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_1, 29, SC2Race.PROTOSS, parent=item_names.ARBITER),
+    item_names.ARBITER_SPACETIME_ANCHOR: ItemData(330 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 0, SC2Race.PROTOSS, parent=item_names.ARBITER),
+    item_names.ARBITER_RESOURCE_EFFICIENCY: ItemData(331 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 1, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.ARBITER),
+    item_names.ARBITER_ENHANCED_CLOAK_FIELD: ItemData(332 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 2, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.ARBITER),
     item_names.CARRIER_TRIREME_GRAVITON_CATAPULT:
-        ItemData(333 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 3, SC2Race.PROTOSS, parent_item=parent_names.CARRIER_OR_TRIREME),
+        ItemData(333 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 3, SC2Race.PROTOSS, parent=parent_names.CARRIER_OR_TRIREME),
     item_names.CARRIER_SKYLORD_TRIREME_HULL_OF_PAST_GLORIES:
-        ItemData(334 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 4, SC2Race.PROTOSS, parent_item=parent_names.CARRIER_CLASS),
+        ItemData(334 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 4, SC2Race.PROTOSS, parent=parent_names.CARRIER_CLASS),
     item_names.VOID_RAY_DESTROYER_WARP_RAY_DAWNBRINGER_FLUX_VANES:
-        ItemData(335 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 5, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=parent_names.VOID_RAY_CLASS),
-    item_names.DESTROYER_RESOURCE_EFFICIENCY: ItemData(535 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 6, SC2Race.PROTOSS, parent_item=item_names.DESTROYER),
+        ItemData(335 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 5, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=parent_names.VOID_RAY_CLASS),
+    item_names.DESTROYER_RESOURCE_EFFICIENCY: ItemData(535 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 6, SC2Race.PROTOSS, parent=item_names.DESTROYER),
     item_names.WARP_PRISM_GRAVITIC_DRIVE:
-        ItemData(337 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 7, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.WARP_PRISM),
+        ItemData(337 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 7, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.WARP_PRISM),
     item_names.WARP_PRISM_PHASE_BLASTER:
         ItemData(338 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 8, SC2Race.PROTOSS,
-                 classification=ItemClassification.progression, parent_item=item_names.WARP_PRISM),
-    item_names.WARP_PRISM_WAR_CONFIGURATION: ItemData(339 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 9, SC2Race.PROTOSS, parent_item=item_names.WARP_PRISM),
-    item_names.OBSERVER_GRAVITIC_BOOSTERS: ItemData(340 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 10, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.OBSERVER),
-    item_names.OBSERVER_SENSOR_ARRAY: ItemData(341 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 11, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.OBSERVER),
-    item_names.REAVER_SCARAB_DAMAGE: ItemData(342 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 12, SC2Race.PROTOSS, parent_item=item_names.REAVER),
-    item_names.REAVER_SOLARITE_PAYLOAD: ItemData(343 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 13, SC2Race.PROTOSS, parent_item=item_names.REAVER),
-    item_names.REAVER_REAVER_CAPACITY: ItemData(344 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 14, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.REAVER),
-    item_names.REAVER_RESOURCE_EFFICIENCY: ItemData(345 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 15, SC2Race.PROTOSS, parent_item=item_names.REAVER),
-    item_names.VANGUARD_AGONY_LAUNCHERS: ItemData(346 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 16, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
-    item_names.VANGUARD_MATTER_DISPERSION: ItemData(347 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 17, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
-    item_names.IMMORTAL_ANNIHILATOR_SINGULARITY_CHARGE: ItemData(348 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 18, SC2Race.PROTOSS, parent_item=parent_names.IMMORTAL_OR_ANNIHILATOR),
-    item_names.IMMORTAL_ANNIHILATOR_ADVANCED_TARGETING_MECHANICS: ItemData(349 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 19, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=parent_names.IMMORTAL_OR_ANNIHILATOR),
-    item_names.COLOSSUS_PACIFICATION_PROTOCOL: ItemData(350 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 20, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.COLOSSUS),
-    item_names.WRATHWALKER_RAPID_POWER_CYCLING: ItemData(351 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 21, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.WRATHWALKER),
-    item_names.WRATHWALKER_EYE_OF_WRATH: ItemData(352 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 22, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.WRATHWALKER),
-    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_SHROUD_OF_ADUN: ItemData(353 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 23, SC2Race.PROTOSS, parent_item=parent_names.DARK_TEMPLAR_CLASS),
-    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_SHADOW_GUARD_TRAINING: ItemData(354 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 24, SC2Race.PROTOSS, parent_item=parent_names.DARK_TEMPLAR_CLASS),
-    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_BLINK: ItemData(355 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 25, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=parent_names.DARK_TEMPLAR_CLASS),
-    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_RESOURCE_EFFICIENCY: ItemData(356 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 26, SC2Race.PROTOSS, parent_item=parent_names.DARK_TEMPLAR_CLASS),
-    item_names.DARK_TEMPLAR_DARK_ARCHON_MELD: ItemData(357 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 27, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.DARK_TEMPLAR),
-    item_names.HIGH_TEMPLAR_SIGNIFIER_UNSHACKLED_PSIONIC_STORM: ItemData(358 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 28, SC2Race.PROTOSS, parent_item=parent_names.STORM_CASTER),
-    item_names.HIGH_TEMPLAR_SIGNIFIER_HALLUCINATION: ItemData(359 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 29, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=parent_names.STORM_CASTER),
-    item_names.HIGH_TEMPLAR_SIGNIFIER_KHAYDARIN_AMULET: ItemData(360 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 0, SC2Race.PROTOSS, parent_item=parent_names.STORM_CASTER),
-    item_names.ARCHON_HIGH_ARCHON: ItemData(361 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 1, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=parent_names.ARCHON_SOURCE),
-    item_names.DARK_ARCHON_FEEDBACK: ItemData(362 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 2, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=parent_names.DARK_ARCHON_SOURCE),
-    item_names.DARK_ARCHON_MAELSTROM: ItemData(363 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 3, SC2Race.PROTOSS, parent_item=parent_names.DARK_ARCHON_SOURCE),
-    item_names.DARK_ARCHON_ARGUS_TALISMAN: ItemData(364 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 4, SC2Race.PROTOSS, parent_item=parent_names.DARK_ARCHON_SOURCE),
-    item_names.ASCENDANT_POWER_OVERWHELMING: ItemData(365 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 5, SC2Race.PROTOSS, parent_item=parent_names.SUPPLICANT_AND_ASCENDANT),
-    item_names.ASCENDANT_CHAOTIC_ATTUNEMENT: ItemData(366 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 6, SC2Race.PROTOSS, parent_item=item_names.ASCENDANT),
-    item_names.ASCENDANT_BLOOD_AMULET: ItemData(367 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 7, SC2Race.PROTOSS, parent_item=item_names.ASCENDANT),
-    item_names.SENTRY_ENERGIZER_HAVOC_CLOAKING_MODULE: ItemData(368 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 8, SC2Race.PROTOSS, parent_item=parent_names.SENTRY_CLASS),
-    item_names.SENTRY_ENERGIZER_HAVOC_SHIELD_BATTERY_RAPID_RECHARGING: ItemData(369 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 9, SC2Race.PROTOSS, parent_item=parent_names.SENTRY_CLASS_OR_SHIELD_BATTERY),
-    item_names.SENTRY_FORCE_FIELD: ItemData(370 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 10, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.SENTRY),
-    item_names.SENTRY_HALLUCINATION: ItemData(371 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 11, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.SENTRY),
-    item_names.ENERGIZER_RECLAMATION: ItemData(372 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 12, SC2Race.PROTOSS, parent_item=item_names.ENERGIZER),
-    item_names.ENERGIZER_FORGED_CHASSIS: ItemData(373 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 13, SC2Race.PROTOSS, parent_item=item_names.ENERGIZER),
-    item_names.HAVOC_DETECT_WEAKNESS: ItemData(374 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 14, SC2Race.PROTOSS, parent_item=item_names.HAVOC),
-    item_names.HAVOC_BLOODSHARD_RESONANCE: ItemData(375 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 15, SC2Race.PROTOSS, parent_item=item_names.HAVOC),
-    item_names.ZEALOT_SENTINEL_CENTURION_LEG_ENHANCEMENTS: ItemData(376 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 16, SC2Race.PROTOSS, parent_item=parent_names.ZEALOT_OR_SENTINEL_OR_CENTURION),
-    item_names.ZEALOT_SENTINEL_CENTURION_SHIELD_CAPACITY: ItemData(377 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 17, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=parent_names.ZEALOT_OR_SENTINEL_OR_CENTURION),
-    item_names.ORACLE_BOSONIC_CORE: ItemData(378 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 18, SC2Race.PROTOSS, parent_item=item_names.ORACLE),
-    item_names.SCOUT_RESOURCE_EFFICIENCY: ItemData(379 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 19, SC2Race.PROTOSS, parent_item=item_names.SCOUT),
-    item_names.IMMORTAL_ANNIHILATOR_DISRUPTOR_DISPERSION: ItemData(380 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 20, SC2Race.PROTOSS, parent_item=parent_names.IMMORTAL_OR_ANNIHILATOR),
-    item_names.DISRUPTOR_CLOAKING_MODULE: ItemData(381 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 21, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.DISRUPTOR),
-    item_names.DISRUPTOR_PERFECTED_POWER:  ItemData(382 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 22, SC2Race.PROTOSS, parent_item=item_names.DISRUPTOR, classification=ItemClassification.progression),
-    item_names.DISRUPTOR_RESTRAINED_DESTRUCTION: ItemData(383 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 23, SC2Race.PROTOSS, classification=ItemClassification.filler, parent_item=item_names.DISRUPTOR),
-    item_names.TEMPEST_INTERPLANETARY_RANGE: ItemData(384 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 24, SC2Race.PROTOSS, parent_item=item_names.TEMPEST),
-    item_names.DAWNBRINGER_ANTI_SURFACE_COUNTERMEASURES: ItemData(385 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 25, SC2Race.PROTOSS, parent_item=item_names.DAWNBRINGER),
-    item_names.DAWNBRINGER_ENHANCED_SHIELD_GENERATOR: ItemData(386 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 26, SC2Race.PROTOSS, parent_item=item_names.DAWNBRINGER),
-    item_names.STALWART_HIGH_VOLTAGE_CAPACITORS: ItemData(387 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 27, SC2Race.PROTOSS, parent_item=item_names.STALWART),
-    item_names.STALWART_STRUT_ENHANCEMENTS: ItemData(388 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 28, SC2Race.PROTOSS, parent_item=item_names.STALWART),
-    item_names.STALWART_STABILIZED_ELECTRODES: ItemData(389 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 29, SC2Race.PROTOSS, parent_item=item_names.STALWART),
-    item_names.STALWART_LATTICED_SHIELDING: ItemData(390 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_4, 0, SC2Race.PROTOSS, parent_item=item_names.STALWART),
+                 classification=ItemClassification.progression, parent=item_names.WARP_PRISM),
+    item_names.WARP_PRISM_WAR_CONFIGURATION: ItemData(339 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 9, SC2Race.PROTOSS, parent=item_names.WARP_PRISM),
+    item_names.OBSERVER_GRAVITIC_BOOSTERS: ItemData(340 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 10, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.OBSERVER),
+    item_names.OBSERVER_SENSOR_ARRAY: ItemData(341 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 11, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.OBSERVER),
+    item_names.REAVER_SCARAB_DAMAGE: ItemData(342 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 12, SC2Race.PROTOSS, parent=item_names.REAVER),
+    item_names.REAVER_SOLARITE_PAYLOAD: ItemData(343 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 13, SC2Race.PROTOSS, parent=item_names.REAVER),
+    item_names.REAVER_REAVER_CAPACITY: ItemData(344 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 14, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.REAVER),
+    item_names.REAVER_RESOURCE_EFFICIENCY: ItemData(345 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 15, SC2Race.PROTOSS, parent=item_names.REAVER),
+    item_names.VANGUARD_AGONY_LAUNCHERS: ItemData(346 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 16, SC2Race.PROTOSS, parent=item_names.VANGUARD),
+    item_names.VANGUARD_MATTER_DISPERSION: ItemData(347 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 17, SC2Race.PROTOSS, parent=item_names.VANGUARD),
+    item_names.IMMORTAL_ANNIHILATOR_SINGULARITY_CHARGE: ItemData(348 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 18, SC2Race.PROTOSS, parent=parent_names.IMMORTAL_OR_ANNIHILATOR),
+    item_names.IMMORTAL_ANNIHILATOR_ADVANCED_TARGETING_MECHANICS: ItemData(349 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 19, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=parent_names.IMMORTAL_OR_ANNIHILATOR),
+    item_names.COLOSSUS_PACIFICATION_PROTOCOL: ItemData(350 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 20, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.COLOSSUS),
+    item_names.WRATHWALKER_RAPID_POWER_CYCLING: ItemData(351 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 21, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.WRATHWALKER),
+    item_names.WRATHWALKER_EYE_OF_WRATH: ItemData(352 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 22, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.WRATHWALKER),
+    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_SHROUD_OF_ADUN: ItemData(353 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 23, SC2Race.PROTOSS, parent=parent_names.DARK_TEMPLAR_CLASS),
+    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_SHADOW_GUARD_TRAINING: ItemData(354 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 24, SC2Race.PROTOSS, parent=parent_names.DARK_TEMPLAR_CLASS),
+    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_BLINK: ItemData(355 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 25, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=parent_names.DARK_TEMPLAR_CLASS),
+    item_names.DARK_TEMPLAR_AVENGER_BLOOD_HUNTER_RESOURCE_EFFICIENCY: ItemData(356 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 26, SC2Race.PROTOSS, parent=parent_names.DARK_TEMPLAR_CLASS),
+    item_names.DARK_TEMPLAR_DARK_ARCHON_MELD: ItemData(357 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 27, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.DARK_TEMPLAR),
+    item_names.HIGH_TEMPLAR_SIGNIFIER_UNSHACKLED_PSIONIC_STORM: ItemData(358 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 28, SC2Race.PROTOSS, parent=parent_names.STORM_CASTER),
+    item_names.HIGH_TEMPLAR_SIGNIFIER_HALLUCINATION: ItemData(359 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_2, 29, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=parent_names.STORM_CASTER),
+    item_names.HIGH_TEMPLAR_SIGNIFIER_KHAYDARIN_AMULET: ItemData(360 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 0, SC2Race.PROTOSS, parent=parent_names.STORM_CASTER),
+    item_names.ARCHON_HIGH_ARCHON: ItemData(361 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 1, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=parent_names.ARCHON_SOURCE),
+    item_names.DARK_ARCHON_FEEDBACK: ItemData(362 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 2, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=parent_names.DARK_ARCHON_SOURCE),
+    item_names.DARK_ARCHON_MAELSTROM: ItemData(363 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 3, SC2Race.PROTOSS, parent=parent_names.DARK_ARCHON_SOURCE),
+    item_names.DARK_ARCHON_ARGUS_TALISMAN: ItemData(364 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 4, SC2Race.PROTOSS, parent=parent_names.DARK_ARCHON_SOURCE),
+    item_names.ASCENDANT_POWER_OVERWHELMING: ItemData(365 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 5, SC2Race.PROTOSS, parent=parent_names.SUPPLICANT_AND_ASCENDANT),
+    item_names.ASCENDANT_CHAOTIC_ATTUNEMENT: ItemData(366 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 6, SC2Race.PROTOSS, parent=item_names.ASCENDANT),
+    item_names.ASCENDANT_BLOOD_AMULET: ItemData(367 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 7, SC2Race.PROTOSS, parent=item_names.ASCENDANT),
+    item_names.SENTRY_ENERGIZER_HAVOC_CLOAKING_MODULE: ItemData(368 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 8, SC2Race.PROTOSS, parent=parent_names.SENTRY_CLASS),
+    item_names.SENTRY_ENERGIZER_HAVOC_SHIELD_BATTERY_RAPID_RECHARGING: ItemData(369 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 9, SC2Race.PROTOSS, parent=parent_names.SENTRY_CLASS_OR_SHIELD_BATTERY),
+    item_names.SENTRY_FORCE_FIELD: ItemData(370 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 10, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.SENTRY),
+    item_names.SENTRY_HALLUCINATION: ItemData(371 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 11, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.SENTRY),
+    item_names.ENERGIZER_RECLAMATION: ItemData(372 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 12, SC2Race.PROTOSS, parent=item_names.ENERGIZER),
+    item_names.ENERGIZER_FORGED_CHASSIS: ItemData(373 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 13, SC2Race.PROTOSS, parent=item_names.ENERGIZER),
+    item_names.HAVOC_DETECT_WEAKNESS: ItemData(374 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 14, SC2Race.PROTOSS, parent=item_names.HAVOC),
+    item_names.HAVOC_BLOODSHARD_RESONANCE: ItemData(375 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 15, SC2Race.PROTOSS, parent=item_names.HAVOC),
+    item_names.ZEALOT_SENTINEL_CENTURION_LEG_ENHANCEMENTS: ItemData(376 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 16, SC2Race.PROTOSS, parent=parent_names.ZEALOT_OR_SENTINEL_OR_CENTURION),
+    item_names.ZEALOT_SENTINEL_CENTURION_SHIELD_CAPACITY: ItemData(377 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 17, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=parent_names.ZEALOT_OR_SENTINEL_OR_CENTURION),
+    item_names.ORACLE_BOSONIC_CORE: ItemData(378 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 18, SC2Race.PROTOSS, parent=item_names.ORACLE),
+    item_names.SCOUT_RESOURCE_EFFICIENCY: ItemData(379 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 19, SC2Race.PROTOSS, parent=item_names.SCOUT),
+    item_names.IMMORTAL_ANNIHILATOR_DISRUPTOR_DISPERSION: ItemData(380 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 20, SC2Race.PROTOSS, parent=parent_names.IMMORTAL_OR_ANNIHILATOR),
+    item_names.DISRUPTOR_CLOAKING_MODULE: ItemData(381 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 21, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.DISRUPTOR),
+    item_names.DISRUPTOR_PERFECTED_POWER:  ItemData(382 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 22, SC2Race.PROTOSS, parent=item_names.DISRUPTOR, classification=ItemClassification.progression),
+    item_names.DISRUPTOR_RESTRAINED_DESTRUCTION: ItemData(383 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 23, SC2Race.PROTOSS, classification=ItemClassification.filler, parent=item_names.DISRUPTOR),
+    item_names.TEMPEST_INTERPLANETARY_RANGE: ItemData(384 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 24, SC2Race.PROTOSS, parent=item_names.TEMPEST),
+    item_names.DAWNBRINGER_ANTI_SURFACE_COUNTERMEASURES: ItemData(385 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 25, SC2Race.PROTOSS, parent=item_names.DAWNBRINGER),
+    item_names.DAWNBRINGER_ENHANCED_SHIELD_GENERATOR: ItemData(386 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 26, SC2Race.PROTOSS, parent=item_names.DAWNBRINGER),
+    item_names.STALWART_HIGH_VOLTAGE_CAPACITORS: ItemData(387 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 27, SC2Race.PROTOSS, parent=item_names.STALWART),
+    item_names.STALWART_STRUT_ENHANCEMENTS: ItemData(388 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 28, SC2Race.PROTOSS, parent=item_names.STALWART),
+    item_names.STALWART_STABILIZED_ELECTRODES: ItemData(389 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_3, 29, SC2Race.PROTOSS, parent=item_names.STALWART),
+    item_names.STALWART_LATTICED_SHIELDING: ItemData(390 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_4, 0, SC2Race.PROTOSS, parent=item_names.STALWART),
 
     # War Council
-    item_names.ZEALOT_WHIRLWIND: ItemData(500 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 0, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.ZEALOT),
-    item_names.CENTURION_RESOURCE_EFFICIENCY: ItemData(501 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 1, SC2Race.PROTOSS, parent_item=item_names.CENTURION),
-    item_names.SENTINEL_RESOURCE_EFFICIENCY: ItemData(502 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 2, SC2Race.PROTOSS, parent_item=item_names.SENTINEL),
-    item_names.STALKER_PHASE_REACTOR: ItemData(503 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 3, SC2Race.PROTOSS, parent_item=item_names.STALKER),
-    item_names.DRAGOON_PHALANX_SUIT: ItemData(504 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 4, SC2Race.PROTOSS, parent_item=item_names.DRAGOON),
-    item_names.INSTIGATOR_RESOURCE_EFFICIENCY: ItemData(505 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 5, SC2Race.PROTOSS, parent_item=item_names.INSTIGATOR),
-    item_names.ADEPT_DISRUPTIVE_TRANSFER: ItemData(506 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 6, SC2Race.PROTOSS, parent_item=item_names.ADEPT),
-    item_names.SLAYER_PHASE_BLINK: ItemData(507 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 7, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.SLAYER),
-    item_names.AVENGER_KRYHAS_CLOAK: ItemData(508 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 8, SC2Race.PROTOSS, parent_item=item_names.AVENGER),
-    item_names.DARK_TEMPLAR_LESSER_SHADOW_FURY: ItemData(509 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 9, SC2Race.PROTOSS, parent_item=item_names.DARK_TEMPLAR),
-    item_names.DARK_TEMPLAR_GREATER_SHADOW_FURY: ItemData(510 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 10, SC2Race.PROTOSS, parent_item=item_names.DARK_TEMPLAR),
-    item_names.BLOOD_HUNTER_BRUTAL_EFFICIENCY: ItemData(511 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 11, SC2Race.PROTOSS, parent_item=item_names.BLOOD_HUNTER),
-    item_names.SENTRY_DOUBLE_SHIELD_RECHARGE: ItemData(512 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 12, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.SENTRY),
-    item_names.ENERGIZER_MOBILE_CHRONO_BEAM: ItemData(513 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 13, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.ENERGIZER),
-    item_names.HAVOC_ENDURING_SIGHT: ItemData(514 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 14, SC2Race.PROTOSS, parent_item=item_names.HAVOC),
-    item_names.HIGH_TEMPLAR_PLASMA_SURGE: ItemData(515 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 15, SC2Race.PROTOSS, parent_item=item_names.HIGH_TEMPLAR),
-    item_names.SIGNIFIER_FEEDBACK: ItemData(516 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 16, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.SIGNIFIER),
-    item_names.ASCENDANT_ABILITY_EFFICIENCY: ItemData(517 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 17, SC2Race.PROTOSS, parent_item=item_names.ASCENDANT),
-    item_names.DARK_ARCHON_INDOMITABLE_WILL: ItemData(518 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 18, SC2Race.PROTOSS, parent_item=parent_names.DARK_ARCHON_SOURCE),
-    item_names.IMMORTAL_IMPROVED_BARRIER: ItemData(519 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 19, SC2Race.PROTOSS, parent_item=item_names.IMMORTAL),
-    item_names.VANGUARD_RAPIDFIRE_CANNON: ItemData(520 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 20, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.VANGUARD),
-    item_names.VANGUARD_FUSION_MORTARS: ItemData(521 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 21, SC2Race.PROTOSS, parent_item=item_names.VANGUARD),
-    item_names.ANNIHILATOR_AERIAL_TRACKING: ItemData(522 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 22, SC2Race.PROTOSS, parent_item=item_names.ANNIHILATOR),
-    item_names.STALWART_ARC_INDUCERS: ItemData(523 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 23, SC2Race.PROTOSS, parent_item=item_names.STALWART),
-    item_names.COLOSSUS_FIRE_LANCE: ItemData(524 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 24, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.COLOSSUS),
-    item_names.WRATHWALKER_AERIAL_TRACKING: ItemData(525 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 25, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.WRATHWALKER),
-    item_names.REAVER_KHALAI_REPLICATORS: ItemData(526 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 26, SC2Race.PROTOSS, parent_item=item_names.REAVER),
-    item_names.DISRUPTOR_RESTRUCTURED_THRUSTERS: ItemData(527 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 27, SC2Race.PROTOSS, parent_item=item_names.DISRUPTOR),
-    item_names.WARP_PRISM_WARP_REFRACTION: ItemData(528 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 28, SC2Race.PROTOSS, parent_item=item_names.WARP_PRISM),
-    item_names.OBSERVER_INDUCE_SCOPOPHOBIA: ItemData(529 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 29, SC2Race.PROTOSS, parent_item=item_names.OBSERVER),
-    item_names.PHOENIX_DOUBLE_GRAVITON_BEAM: ItemData(530 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 0, SC2Race.PROTOSS, parent_item=item_names.PHOENIX),
-    item_names.CORSAIR_NETWORK_DISRUPTION: ItemData(531 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 1, SC2Race.PROTOSS, parent_item=item_names.CORSAIR),
-    item_names.MIRAGE_GRAVITON_BEAM: ItemData(532 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 2, SC2Race.PROTOSS, parent_item=item_names.MIRAGE),
-    item_names.SKIRMISHER_PEER_CONTEMPT: ItemData(533 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 3, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.SKIRMISHER),
-    item_names.VOID_RAY_PRISMATIC_RANGE: ItemData(534 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 4, SC2Race.PROTOSS, parent_item=item_names.VOID_RAY),
-    item_names.DESTROYER_REFORGED_BLOODSHARD_CORE: ItemData(336 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 5, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.DESTROYER),
+    item_names.ZEALOT_WHIRLWIND: ItemData(500 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 0, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.ZEALOT),
+    item_names.CENTURION_RESOURCE_EFFICIENCY: ItemData(501 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 1, SC2Race.PROTOSS, parent=item_names.CENTURION),
+    item_names.SENTINEL_RESOURCE_EFFICIENCY: ItemData(502 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 2, SC2Race.PROTOSS, parent=item_names.SENTINEL),
+    item_names.STALKER_PHASE_REACTOR: ItemData(503 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 3, SC2Race.PROTOSS, parent=item_names.STALKER),
+    item_names.DRAGOON_PHALANX_SUIT: ItemData(504 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 4, SC2Race.PROTOSS, parent=item_names.DRAGOON),
+    item_names.INSTIGATOR_RESOURCE_EFFICIENCY: ItemData(505 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 5, SC2Race.PROTOSS, parent=item_names.INSTIGATOR),
+    item_names.ADEPT_DISRUPTIVE_TRANSFER: ItemData(506 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 6, SC2Race.PROTOSS, parent=item_names.ADEPT),
+    item_names.SLAYER_PHASE_BLINK: ItemData(507 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 7, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.SLAYER),
+    item_names.AVENGER_KRYHAS_CLOAK: ItemData(508 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 8, SC2Race.PROTOSS, parent=item_names.AVENGER),
+    item_names.DARK_TEMPLAR_LESSER_SHADOW_FURY: ItemData(509 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 9, SC2Race.PROTOSS, parent=item_names.DARK_TEMPLAR),
+    item_names.DARK_TEMPLAR_GREATER_SHADOW_FURY: ItemData(510 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 10, SC2Race.PROTOSS, parent=item_names.DARK_TEMPLAR),
+    item_names.BLOOD_HUNTER_BRUTAL_EFFICIENCY: ItemData(511 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 11, SC2Race.PROTOSS, parent=item_names.BLOOD_HUNTER),
+    item_names.SENTRY_DOUBLE_SHIELD_RECHARGE: ItemData(512 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 12, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.SENTRY),
+    item_names.ENERGIZER_MOBILE_CHRONO_BEAM: ItemData(513 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 13, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.ENERGIZER),
+    item_names.HAVOC_ENDURING_SIGHT: ItemData(514 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 14, SC2Race.PROTOSS, parent=item_names.HAVOC),
+    item_names.HIGH_TEMPLAR_PLASMA_SURGE: ItemData(515 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 15, SC2Race.PROTOSS, parent=item_names.HIGH_TEMPLAR),
+    item_names.SIGNIFIER_FEEDBACK: ItemData(516 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 16, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.SIGNIFIER),
+    item_names.ASCENDANT_ABILITY_EFFICIENCY: ItemData(517 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 17, SC2Race.PROTOSS, parent=item_names.ASCENDANT),
+    item_names.DARK_ARCHON_INDOMITABLE_WILL: ItemData(518 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 18, SC2Race.PROTOSS, parent=parent_names.DARK_ARCHON_SOURCE),
+    item_names.IMMORTAL_IMPROVED_BARRIER: ItemData(519 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 19, SC2Race.PROTOSS, parent=item_names.IMMORTAL),
+    item_names.VANGUARD_RAPIDFIRE_CANNON: ItemData(520 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 20, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.VANGUARD),
+    item_names.VANGUARD_FUSION_MORTARS: ItemData(521 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 21, SC2Race.PROTOSS, parent=item_names.VANGUARD),
+    item_names.ANNIHILATOR_AERIAL_TRACKING: ItemData(522 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 22, SC2Race.PROTOSS, parent=item_names.ANNIHILATOR),
+    item_names.STALWART_ARC_INDUCERS: ItemData(523 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 23, SC2Race.PROTOSS, parent=item_names.STALWART),
+    item_names.COLOSSUS_FIRE_LANCE: ItemData(524 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 24, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.COLOSSUS),
+    item_names.WRATHWALKER_AERIAL_TRACKING: ItemData(525 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 25, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.WRATHWALKER),
+    item_names.REAVER_KHALAI_REPLICATORS: ItemData(526 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 26, SC2Race.PROTOSS, parent=item_names.REAVER),
+    item_names.DISRUPTOR_RESTRUCTURED_THRUSTERS: ItemData(527 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 27, SC2Race.PROTOSS, parent=item_names.DISRUPTOR),
+    item_names.WARP_PRISM_WARP_REFRACTION: ItemData(528 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 28, SC2Race.PROTOSS, parent=item_names.WARP_PRISM),
+    item_names.OBSERVER_INDUCE_SCOPOPHOBIA: ItemData(529 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council, 29, SC2Race.PROTOSS, parent=item_names.OBSERVER),
+    item_names.PHOENIX_DOUBLE_GRAVITON_BEAM: ItemData(530 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 0, SC2Race.PROTOSS, parent=item_names.PHOENIX),
+    item_names.CORSAIR_NETWORK_DISRUPTION: ItemData(531 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 1, SC2Race.PROTOSS, parent=item_names.CORSAIR),
+    item_names.MIRAGE_GRAVITON_BEAM: ItemData(532 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 2, SC2Race.PROTOSS, parent=item_names.MIRAGE),
+    item_names.SKIRMISHER_PEER_CONTEMPT: ItemData(533 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 3, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.SKIRMISHER),
+    item_names.VOID_RAY_PRISMATIC_RANGE: ItemData(534 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 4, SC2Race.PROTOSS, parent=item_names.VOID_RAY),
+    item_names.DESTROYER_REFORGED_BLOODSHARD_CORE: ItemData(336 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 5, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.DESTROYER),
     # 536 reserved for Warp Ray
-    item_names.DAWNBRINGER_SOLARITE_LENS: ItemData(537 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 7, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.DAWNBRINGER),
-    item_names.CARRIER_REPAIR_DRONES: ItemData(538 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 8, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.CARRIER),
-    item_names.SKYLORD_HYPERJUMP: ItemData(539 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 9, SC2Race.PROTOSS, parent_item=item_names.SKYLORD),
-    item_names.TRIREME_SOLAR_BEAM: ItemData(540 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 10, SC2Race.PROTOSS, classification=ItemClassification.progression, parent_item=item_names.TRIREME),
-    item_names.TEMPEST_DISINTEGRATION: ItemData(541 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 11, SC2Race.PROTOSS, parent_item=item_names.TEMPEST),
+    item_names.DAWNBRINGER_SOLARITE_LENS: ItemData(537 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 7, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.DAWNBRINGER),
+    item_names.CARRIER_REPAIR_DRONES: ItemData(538 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 8, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.CARRIER),
+    item_names.SKYLORD_HYPERJUMP: ItemData(539 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 9, SC2Race.PROTOSS, parent=item_names.SKYLORD),
+    item_names.TRIREME_SOLAR_BEAM: ItemData(540 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 10, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.TRIREME),
+    item_names.TEMPEST_DISINTEGRATION: ItemData(541 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 11, SC2Race.PROTOSS, parent=item_names.TEMPEST),
     # 542 reserved for Scout
-    item_names.ARBITER_ABILITY_EFFICIENCY: ItemData(543 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 13, SC2Race.PROTOSS, parent_item=item_names.ARBITER),
+    item_names.ARBITER_ABILITY_EFFICIENCY: ItemData(543 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 13, SC2Race.PROTOSS, parent=item_names.ARBITER),
     # 544 reserved for Oracle
     # 545 reserved for Mothership
 
@@ -1946,9 +1946,9 @@ item_table = {
     item_names.SUPERIOR_WARP_GATES:
         ItemData(808 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 8, SC2Race.PROTOSS),
     item_names.ENHANCED_TARGETING:
-        ItemData(809 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 9, SC2Race.PROTOSS, parent_item=parent_names.PROTOSS_STATIC_DEFENSE),
+        ItemData(809 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 9, SC2Race.PROTOSS, parent=parent_names.PROTOSS_STATIC_DEFENSE),
     item_names.OPTIMIZED_ORDNANCE:
-        ItemData(810 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 10, SC2Race.PROTOSS, parent_item=parent_names.PROTOSS_ATTACKING_BUILDING),
+        ItemData(810 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 10, SC2Race.PROTOSS, parent=parent_names.PROTOSS_ATTACKING_BUILDING),
     item_names.KHALAI_INGENUITY:
         ItemData(811 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 11, SC2Race.PROTOSS),
     item_names.AMPLIFIED_ASSIMILATORS:

--- a/worlds/sc2/item/parent_names.py
+++ b/worlds/sc2/item/parent_names.py
@@ -1,0 +1,51 @@
+"""
+Identifiers for complex item parent structures.
+Defined separately from item_parents to avoid a circular import
+item_names -> item_parent_names -> item_tables -> item_parents
+"""
+
+# Terran
+DOMINION_TROOPER_WEAPONS = "Dominion Trooper Weapons"
+INFANTRY_UNITS = "Infantry Units"
+INFANTRY_WEAPON_UNITS = "Infantry Weapon Units"
+ORBITAL_COMMAND_AND_PLANETARY = "Orbital Command Abilities + Planetary Fortress"  # MULE | Scan | Supply Drop
+SIEGE_TANK_AND_TRANSPORT = "Siege Tank + Transport"
+SIEGE_TANK_AND_MEDIVAC = "Siege Tank + Medivac"
+SPIDER_MINE_SOURCE = "Spider Mine Source"
+STARSHIP_UNITS = "Starship Units"
+STARSHIP_WEAPON_UNITS = "Starship Weapon Units"
+VEHICLE_UNITS = "Vehicle Units"
+VEHICLE_WEAPON_UNITS = "Vehicle Weapon Units"
+
+# Zerg
+ANY_NYDUS_WORM = "Any Nydus Worm"
+BANELING_SOURCE = "Any Baneling Source"  # Baneling aspect | Kerrigan Spawn Banelings
+INFESTED_UNITS = "Infested Units"
+MORPH_SOURCE_AIR = "Air Morph Source"  # Morphling | Mutalisk | Corruptor
+MORPH_SOURCE_ROACH = "Roach Morph Source"  # Morphling | Roach
+MORPH_SOURCE_ZERGLING = "Zergling Morph Source"  # Morphling | Zergling | Zergling Reconstitution
+MORPH_SOURCE_HYDRALISK = "Hydralisk Morph Source"  # Morphling | Hydralisk
+MORPH_SOURCE_ULTRALISK = "Ultralisk Morph Source"  # Morphling | Ultralisk
+ZERG_UPROOTABLE_BUILDINGS = "Zerg Uprootable Buildings"
+ZERG_MELEE_ATTACKER = "Zerg Melee Attacker"
+ZERG_MISSILE_ATTACKER = "Zerg Missile Attacker"
+ZERG_CARAPACE_UNIT = "Zerg Carapace Unit"
+ZERG_FLYING_UNIT = "Zerg Flying Unit"
+
+# Protoss
+ARCHON_SOURCE = "Any Archon Source"
+CARRIER_CLASS = "Carrier Class"
+CARRIER_OR_TRIREME = "Carrier | Trireme"
+DARK_ARCHON_SOURCE = "Dark Archon Source"
+DARK_TEMPLAR_CLASS = "Dark Templar Class"
+STORM_CASTER = "Storm Caster"
+IMMORTAL_OR_ANNIHILATOR = "Immortal | Annihilator"
+PHOENIX_CLASS = "Phoenix Class"
+SENTRY_CLASS = "Sentry Class"
+SENTRY_CLASS_OR_SHIELD_BATTERY = "Sentry Class | Shield Battery"
+STALKER_CLASS = "Stalker Class"
+SUPPLICANT_AND_ASCENDANT = "Supplicant + Ascendant"
+VOID_RAY_CLASS = "Void Ray Class"
+ZEALOT_OR_SENTINEL_OR_CENTURION = "Zealot | Sentinel | Centurion"
+PROTOSS_STATIC_DEFENSE = "Protoss Static Defense"
+PROTOSS_ATTACKING_BUILDING = "Protoss Attacking Structure"

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -440,7 +440,7 @@ class VanillaItemsOnly(Toggle):
 
 
 # Current maximum number of upgrades for a unit
-MAX_UPGRADES_OPTION = 14
+MAX_UPGRADES_OPTION = 13
 
 
 class EnsureGenericItems(Range):

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -820,6 +820,11 @@ class Sc2ItemDict(Option[Dict[str, int]], VerifyKeys, Mapping[str, int]):
         return self.value.__len__()
 
 
+class Sc2StartInventory(Sc2ItemDict):
+    """Start with these items."""
+    display_name = StartInventory.display_name
+
+
 class LockedItems(Sc2ItemDict):
     """Guarantees that these items will be unlockable, in the amount specified.
     Specify an amount of 0 to lock all copies of an item."""
@@ -1007,6 +1012,7 @@ class StartingSupplyPerItem(Range):
 
 @dataclass
 class Starcraft2Options(PerGameCommonOptions):
+    start_inventory: Sc2StartInventory
     game_difficulty: GameDifficulty
     game_speed: GameSpeed
     disable_forced_camera: DisableForcedCamera

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -356,8 +356,9 @@ class ValidInventory:
         if item_names.MEDIVAC not in self.logical_inventory:
             # Don't allow L2 Siege Tank Transport Hook without Medivac
             inventory_transport_hooks = [item for item in inventory if item.name == item_names.SIEGE_TANK_PROGRESSIVE_TRANSPORT_HOOK]
-            if len(inventory_transport_hooks) > 1:
-                inventory.remove(inventory_transport_hooks[0])
+            removable_transport_hooks = [item for item in inventory_transport_hooks if not (ItemFilterFlags.Unexcludable & item.flags)]
+            if len(inventory_transport_hooks) > 1 and removable_transport_hooks:
+                inventory.remove(removable_transport_hooks[0])
 
         return inventory
 

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -302,14 +302,14 @@ class ValidInventory:
             return False
 
         def item_included(item: StarcraftItem) -> bool:
-            return (
+            return bool(
                 ItemFilterFlags.Removed not in item.filter_flags
                 or (ItemFilterFlags.Unexcludable & item.filter_flags)
                 or (not (ItemFilterFlags.Excluded & item.filter_flags)
                     and (ItemFilterFlags.Requested & item.filter_flags)
                 )
                 or not (ItemFilterFlags.Culled & item.filter_flags)
-            ) != 0
+            )
 
         # Part 1: Remove items that are not requested
         start_inventory_size = len([item for item in inventory if ItemFilterFlags.StartInventory in item.filter_flags])

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -387,7 +387,8 @@ class ValidInventory:
         
         # Part 4: Last-ditch effort to reduce inventory size; upgrades can go in start inventory
         current_inventory_size = len(inventory)
-        if current_inventory_size - start_inventory_size > inventory_size:
+        precollect_items = current_inventory_size - inventory_size - start_inventory_size
+        if precollect_items > 0:
             promotable = [
                 item
                 for item in inventory

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -267,7 +267,7 @@ class ValidInventory:
                 group_name = None
                 parent = item_table[item.name].parent
                 if parent is not None:
-                    group_name = item_parents.parent_present[parent].main_item
+                    group_name = item_parents.parent_present[parent].constraint_group
                 if group_name is not None:
                     children = group_to_item.get(group_name, [])
                     children = [x for x in children if not (ItemFilterFlags.CulledOrBetter & x.filter_flags)]

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -192,7 +192,7 @@ class ValidInventory:
             for child_item in child_items:
                 if (ItemFilterFlags.AllowedOrphan|ItemFilterFlags.Unexcludable) & child_item.filter_flags:
                     continue
-                parent_id = item_table[child_item.name].parent_item
+                parent_id = item_table[child_item.name].parent
                 assert parent_id is not None
                 if item_parents.parent_present[parent_id](self.logical_inventory, self.world.options):
                     continue
@@ -267,7 +267,7 @@ class ValidInventory:
         # Make an index from child to parent
         child_to_main_parent: Dict[str, StarcraftItem] = {}
         for item in inventory:
-            parent_id = item_table[item.name].parent_item
+            parent_id = item_table[item.name].parent
             if parent_id is None:
                 continue
             parent_item_name = item_parents.parent_present[parent_id].main_item

--- a/worlds/sc2/test/test_custom_mission_orders.py
+++ b/worlds/sc2/test/test_custom_mission_orders.py
@@ -102,7 +102,7 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
         self.assertEqual(flags.get(MissionFlag.Zerg, 0), 0)
         sc2_regions = set(self.multiworld.regions.region_cache[self.player]) - {"Menu"}
         self.assertEqual(len(self.world.custom_mission_order.get_used_missions()), len(sc2_regions))
-    
+
     def test_locked_and_necessary_item_appears_once(self):
         # This is a filler upgrade with a parent
         test_item = item_names.ZERGLING_METABOLIC_BOOST
@@ -127,7 +127,6 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
         self.assertNotEqual(item_tables.item_table[test_item].classification, ItemClassification.progression, f"Test item {test_item} won't change classification")
 
         self.generate_world(world_options)
-        print(self.multiworld.seed)
         test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
         test_items_in_pool += [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
         self.assertEqual(len(test_items_in_pool), 1)

--- a/worlds/sc2/test/test_custom_mission_orders.py
+++ b/worlds/sc2/test/test_custom_mission_orders.py
@@ -8,208 +8,209 @@ from ..item import item_tables, item_names
 from BaseClasses import ItemClassification
 
 class TestCustomMissionOrders(Sc2SetupTestBase):
-   
-   def test_mini_wol_generates(self):
-      world_options = {
-         'mission_order': 'custom',
-         'custom_mission_order': {
-            'Mini Wings of Liberty': {
-               'global': {
-                  'type': 'column',
-                  'mission_pool': [
-                     'terran missions',
-                     '^ wol missions'
-                  ]
-               },
-               'Mar Sara': {
-                  'size': 1
-               },
-               'Colonist': {
-                  'size': 2,
-                  'entry_rules': [{
-                     'scope': '../Mar Sara'
-                  }]
-               },
-               'Artifact': {
-                  'size': 3,
-                  'entry_rules': [{
-                     'scope': '../Mar Sara'
-                  }],
-                  'missions': [
-                     {
-                        'index': 1,
+    def test_mini_wol_generates(self):
+        world_options = {
+            'mission_order': 'custom',
+            'custom_mission_order': {
+                'Mini Wings of Liberty': {
+                    'global': {
+                        'type': 'column',
+                        'mission_pool': [
+                            'terran missions',
+                            '^ wol missions'
+                        ]
+                    },
+                    'Mar Sara': {
+                        'size': 1
+                    },
+                    'Colonist': {
+                        'size': 2,
                         'entry_rules': [{
-                           'scope': 'Mini Wings of Liberty',
-                           'amount': 4
+                            'scope': '../Mar Sara'
                         }]
-                     },
-                     {
-                        'index': 2,
+                    },
+                    'Artifact': {
+                        'size': 3,
                         'entry_rules': [{
-                           'scope': 'Mini Wings of Liberty',
-                           'amount': 8
+                            'scope': '../Mar Sara'
+                        }],
+                        'missions': [
+                            {
+                                'index': 1,
+                                'entry_rules': [{
+                                'scope': 'Mini Wings of Liberty',
+                                'amount': 4
+                                }]
+                            },
+                            {
+                                'index': 2,
+                                'entry_rules': [{
+                                'scope': 'Mini Wings of Liberty',
+                                'amount': 8
+                                }]
+                            }
+                        ]
+                    },
+                    'Prophecy': {
+                        'size': 2,
+                        'entry_rules': [{
+                            'scope': '../Artifact/1'
+                            }],
+                        'mission_pool': [
+                            'protoss missions',
+                            '^ prophecy missions'
+                        ]
+                    },
+                    'Covert': {
+                        'size': 2,
+                        'entry_rules': [{
+                            'scope': 'Mini Wings of Liberty',
+                            'amount': 2
                         }]
-                     }
-                  ]
-               },
-               'Prophecy': {
-                  'size': 2,
-                  'entry_rules': [{
-                     'scope': '../Artifact/1'
-                     }],
-                  'mission_pool': [
-                     'protoss missions',
-                     '^ prophecy missions'
-                  ]
-               },
-               'Covert': {
-                  'size': 2,
-                  'entry_rules': [{
-                     'scope': 'Mini Wings of Liberty',
-                     'amount': 2
-                  }]
-               },
-               'Rebellion': {
-                  'size': 2,
-                  'entry_rules': [{
-                     'scope': 'Mini Wings of Liberty',
-                     'amount': 3
-                  }]
-               },
-               'Char': {
-                  'size': 3,
-                  'entry_rules': [{
-                     'scope': '../Artifact/2'
-                  }],
-                  'missions': [
-                     {
-                        'index': 0,
-                        'next': [2]
-                     },
-                     {
-                        'index': 1,
-                        'entrance': True
-                     }
-                  ]
-               }
+                    },
+                    'Rebellion': {
+                        'size': 2,
+                        'entry_rules': [{
+                            'scope': 'Mini Wings of Liberty',
+                            'amount': 3
+                        }]
+                    },
+                    'Char': {
+                        'size': 3,
+                        'entry_rules': [{
+                            'scope': '../Artifact/2'
+                        }],
+                        'missions': [
+                            {
+                                'index': 0,
+                                'next': [2]
+                            },
+                            {
+                                'index': 1,
+                                'entrance': True
+                            }
+                        ]
+                    }
+                }
             }
-         }
-      }
+        }
 
-      self.generate_world(world_options)
-      flags = self.world.custom_mission_order.get_used_flags()
-      self.assertEqual(flags[MissionFlag.Terran], 13)
-      self.assertEqual(flags[MissionFlag.Protoss], 2)
-      self.assertEqual(flags.get(MissionFlag.Zerg, 0), 0)
-      sc2_regions = set(self.multiworld.regions.region_cache[self.player]) - {"Menu"}
-      self.assertEqual(len(self.world.custom_mission_order.get_used_missions()), len(sc2_regions))
-
-   def test_locked_and_necessary_item_appears_once(self):
-      # This is a filler upgrade with a parent
-      test_item = item_names.ZERGLING_METABOLIC_BOOST
-      world_options = {
-         'mission_order': 'custom',
-         'locked_items': { test_item: 1 },
-         'custom_mission_order': {
-            'test': {
-               'type': 'column',
-               'size': 5, # Give the generator some space to place the key
-               'max_difficulty': 'easy',
-               'missions': [{
-                  'index': 4,
-                  'entry_rules': [{
-                     'items': { test_item: 1 }
-                  }]
-               }]
+        self.generate_world(world_options)
+        flags = self.world.custom_mission_order.get_used_flags()
+        self.assertEqual(flags[MissionFlag.Terran], 13)
+        self.assertEqual(flags[MissionFlag.Protoss], 2)
+        self.assertEqual(flags.get(MissionFlag.Zerg, 0), 0)
+        sc2_regions = set(self.multiworld.regions.region_cache[self.player]) - {"Menu"}
+        self.assertEqual(len(self.world.custom_mission_order.get_used_missions()), len(sc2_regions))
+    
+    def test_locked_and_necessary_item_appears_once(self):
+        # This is a filler upgrade with a parent
+        test_item = item_names.ZERGLING_METABOLIC_BOOST
+        world_options = {
+            'mission_order': 'custom',
+            'locked_items': { test_item: 1 },
+            'custom_mission_order': {
+                'test': {
+                    'type': 'column',
+                    'size': 5, # Give the generator some space to place the key
+                    'max_difficulty': 'easy',
+                    'missions': [{
+                        'index': 4,
+                        'entry_rules': [{
+                            'items': { test_item: 1 }
+                        }]
+                    }]
+                }
             }
-         }
-      }
+        }
 
-      self.assertNotEqual(item_tables.item_table[test_item].classification, ItemClassification.progression, f"Test item {test_item} won't change classification")
+        self.assertNotEqual(item_tables.item_table[test_item].classification, ItemClassification.progression, f"Test item {test_item} won't change classification")
 
-      self.generate_world(world_options)
-      test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
-      self.assertEqual(len(test_items_in_pool), 1)
-      self.assertEqual(test_items_in_pool[0].classification, ItemClassification.progression)
+        self.generate_world(world_options)
+        print(self.multiworld.seed)
+        test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
+        test_items_in_pool += [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
+        self.assertEqual(len(test_items_in_pool), 1)
+        self.assertEqual(test_items_in_pool[0].classification, ItemClassification.progression)
 
-   def test_start_inventory_and_necessary_item_appears_once(self):
-      # This is a filler upgrade with a parent
-      test_item = item_names.ZERGLING_METABOLIC_BOOST
-      world_options = {
-         'mission_order': 'custom',
-         'start_inventory': { test_item: 1 },
-         'custom_mission_order': {
-            'test': {
-               'type': 'column',
-               'size': 5, # Give the generator some space to place the key
-               'max_difficulty': 'easy',
-               'missions': [{
-                  'index': 4,
-                  'entry_rules': [{
-                     'items': { test_item: 1 }
-                  }]
-               }]
+    def test_start_inventory_and_necessary_item_appears_once(self):
+        # This is a filler upgrade with a parent
+        test_item = item_names.ZERGLING_METABOLIC_BOOST
+        world_options = {
+            'mission_order': 'custom',
+            'start_inventory': { test_item: 1 },
+            'custom_mission_order': {
+                'test': {
+                    'type': 'column',
+                    'size': 5, # Give the generator some space to place the key
+                    'max_difficulty': 'easy',
+                    'missions': [{
+                        'index': 4,
+                        'entry_rules': [{
+                            'items': { test_item: 1 }
+                        }]
+                    }]
+                }
             }
-         }
-      }
+        }
 
-      self.generate_world(world_options)
-      test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
-      self.assertEqual(len(test_items_in_pool), 0)
-      test_items_in_start_inventory = [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
-      self.assertEqual(len(test_items_in_start_inventory), 1)
+        self.generate_world(world_options)
+        test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
+        self.assertEqual(len(test_items_in_pool), 0)
+        test_items_in_start_inventory = [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
+        self.assertEqual(len(test_items_in_start_inventory), 1)
 
-   def test_start_inventory_and_locked_and_necessary_item_appears_once(self):
-      # This is a filler upgrade with a parent
-      test_item = item_names.ZERGLING_METABOLIC_BOOST
-      world_options = {
-         'mission_order': 'custom',
-         'start_inventory': { test_item: 1 },
-         'locked_items': { test_item: 1 },
-         'custom_mission_order': {
-            'test': {
-               'type': 'column',
-               'size': 5, # Give the generator some space to place the key
-               'max_difficulty': 'easy',
-               'missions': [{
-                  'index': 4,
-                  'entry_rules': [{
-                     'items': { test_item: 1 }
-                  }]
-               }]
+    def test_start_inventory_and_locked_and_necessary_item_appears_once(self):
+        # This is a filler upgrade with a parent
+        test_item = item_names.ZERGLING_METABOLIC_BOOST
+        world_options = {
+            'mission_order': 'custom',
+            'start_inventory': { test_item: 1 },
+            'locked_items': { test_item: 1 },
+            'custom_mission_order': {
+                'test': {
+                    'type': 'column',
+                    'size': 5, # Give the generator some space to place the key
+                    'max_difficulty': 'easy',
+                    'missions': [{
+                        'index': 4,
+                        'entry_rules': [{
+                            'items': { test_item: 1 }
+                        }]
+                    }]
+                }
             }
-         }
-      }
+        }
 
-      self.generate_world(world_options)
-      test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
-      self.assertEqual(len(test_items_in_pool), 0)
-      test_items_in_start_inventory = [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
-      self.assertEqual(len(test_items_in_start_inventory), 1)
+        self.generate_world(world_options)
+        test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
+        self.assertEqual(len(test_items_in_pool), 0)
+        test_items_in_start_inventory = [item for item in self.multiworld.precollected_items[self.player] if item.name == test_item]
+        self.assertEqual(len(test_items_in_start_inventory), 1)
 
-   def test_key_item_rule_creates_correct_item_amount(self):
-      # This is an item that normally only exists once
-      test_item = item_names.ZERGLING
-      test_amount = 3
-      world_options = {
-         'mission_order': 'custom',
-         'locked_items': { test_item: 1 }, # Make sure it is generated as normal
-         'custom_mission_order': {
-            'test': {
-               'type': 'column',
-               'size': 5, # Give the generator some space to place the keys
-               'max_difficulty': 'easy',
-               'mission_pool': ['zerg missions'], # Make sure the item isn't excluded by race selection
-               'missions': [{
-                  'index': 4,
-                  'entry_rules': [{
-                     'items': { test_item: test_amount } # Require more than the usual item amount
-                  }]
-               }]
+    def test_key_item_rule_creates_correct_item_amount(self):
+        # This is an item that normally only exists once
+        test_item = item_names.ZERGLING
+        test_amount = 3
+        world_options = {
+            'mission_order': 'custom',
+            'locked_items': { test_item: 1 }, # Make sure it is generated as normal
+            'custom_mission_order': {
+                'test': {
+                    'type': 'column',
+                    'size': 5, # Give the generator some space to place the keys
+                    'max_difficulty': 'easy',
+                    'mission_pool': ['zerg missions'], # Make sure the item isn't excluded by race selection
+                    'missions': [{
+                        'index': 4,
+                        'entry_rules': [{
+                            'items': { test_item: test_amount } # Require more than the usual item amount
+                        }]
+                    }]
+                }
             }
-         }
-      }
+        }
 
-      self.generate_world(world_options)
-      test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
-      self.assertEqual(len(test_items_in_pool), test_amount)
+        self.generate_world(world_options)
+        test_items_in_pool = [item for item in self.multiworld.itempool if item.name == test_item]
+        self.assertEqual(len(test_items_in_pool), test_amount)

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -615,9 +615,17 @@ class TestItemFiltering(Sc2SetupTestBase):
         itempool = [item.name for item in self.multiworld.itempool]
         world_items = starting_inventory + itempool
         vehicle_weapon_items = [x for x in world_items if x == item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON]
+        other_bundle_items = [
+            x for x in world_items if x in (
+                item_names.PROGRESSIVE_TERRAN_WEAPON_ARMOR_UPGRADE,
+                item_names.PROGRESSIVE_TERRAN_WEAPON_UPGRADE,
+                item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE,
+            )
+        ]
 
         # Under standard tactics you need to place L3 upgrades for available unit classes
         self.assertGreaterEqual(len(vehicle_weapon_items), 3)
+        self.assertEqual(len(other_bundle_items), 0)
 
     def test_weapon_armor_upgrades_with_bundles(self):
         world_options = {
@@ -648,9 +656,17 @@ class TestItemFiltering(Sc2SetupTestBase):
         itempool = [item.name for item in self.multiworld.itempool]
         world_items = starting_inventory + itempool
         vehicle_upgrade_items = [x for x in world_items if x == item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE]
+        other_bundle_items = [
+            x for x in world_items if x in (
+                item_names.PROGRESSIVE_TERRAN_WEAPON_ARMOR_UPGRADE,
+                item_names.PROGRESSIVE_TERRAN_WEAPON_UPGRADE,
+                item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON,
+            )
+        ]
 
         # Under standard tactics you need to place L3 upgrades for available unit classes
         self.assertGreaterEqual(len(vehicle_upgrade_items), 3)
+        self.assertEqual(len(other_bundle_items), 0)
 
     def test_weapon_armor_upgrades_all_in_air(self):
         world_options = {

--- a/worlds/sc2/test/test_item_filtering.py
+++ b/worlds/sc2/test/test_item_filtering.py
@@ -8,12 +8,6 @@ from ..mission_tables import SC2Race
 
 class ItemFilterTests(Sc2SetupTestBase):
     def test_excluding_all_barracks_units_excludes_infantry_upgrades(self) -> None:
-        return
-        # Note(mm): This test currently fails because of the circular logic around has_barracks_unit
-        # For an item to be filtered, logic must be satisfied without the item
-        # Terran logic includes (has_barracks_unit => infantry ups required)
-        # has_barracks_unit is only set to false after the items are culled
-        # Therefore, upgrades are always required by logic and will never be culled
         world_options = {
             'excluded_items': {
                 item_groups.ItemGroupNames.BARRACKS_UNITS: 0
@@ -33,8 +27,8 @@ class ItemFilterTests(Sc2SetupTestBase):
         self.assertNotIn(item_names.MARINE, itempool)
         self.assertNotIn(item_names.MARAUDER, itempool)
 
-        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR, itempool)
         self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON, itempool)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR, itempool)
         self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE, itempool)
 
     def test_excluding_one_item_of_multi_parent_doesnt_filter_children(self) -> None:
@@ -80,4 +74,4 @@ class ItemFilterTests(Sc2SetupTestBase):
         itempool = [item.name for item in self.multiworld.itempool]
         self.assertNotIn(item_names.ZEALOT_SENTINEL_CENTURION_SHIELD_CAPACITY, itempool)
         self.assertNotIn(item_names.ZEALOT_SENTINEL_CENTURION_LEG_ENHANCEMENTS, itempool)
-    
+

--- a/worlds/sc2/test/test_item_filtering.py
+++ b/worlds/sc2/test/test_item_filtering.py
@@ -1,0 +1,77 @@
+"""
+Unit tests for item filtering like pool_filter.py
+"""
+
+from .test_base import Sc2SetupTestBase
+from ..item import item_tables, item_groups, item_names, item_parents
+from ..mission_tables import SC2Race
+
+class ItemFilterTests(Sc2SetupTestBase):
+    def test_excluding_all_barracks_units_excludes_infantry_upgrades(self) -> None:
+        return
+        # Note(mm): This test currently fails because of the circular logic around has_barracks_unit
+        # For an item to be filtered, logic must be satisfied without the item
+        # Terran logic includes (has_barracks_unit => infantry ups required)
+        # has_barracks_unit is only set to false after the items are culled
+        # Therefore, upgrades are always required by logic and will never be culled
+        world_options = {
+            'excluded_items': {
+                item_groups.ItemGroupNames.BARRACKS_UNITS: 0
+            },
+            'required_tactics': 'standard',
+            'min_number_of_upgrades': 1,
+            'selected_races': 'terran',
+            'mission_order': 'grid',
+        }
+        self.generate_world(world_options)
+        self.assertTrue(self.multiworld.itempool)
+        races = {mission.mission.race for mission in self.world.custom_mission_order.get_missions()}
+        self.assertIn(SC2Race.TERRAN, races)
+        self.assertNotIn(SC2Race.ZERG, races)
+        self.assertNotIn(SC2Race.PROTOSS, races)
+        itempool = [item.name for item in self.multiworld.itempool]
+        self.assertNotIn(item_names.MARINE, itempool)
+        self.assertNotIn(item_names.MARAUDER, itempool)
+
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR, itempool)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON, itempool)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE, itempool)
+    
+    def test_excluding_one_item_of_multi_parent_doesnt_filter_children(self) -> None:
+        world_options = {
+            'locked_items': {
+                item_names.SENTINEL: 1,
+                item_names.CENTURION: 1,
+            },
+            'excluded_items': {
+                item_names.ZEALOT: 1,
+            },
+            'min_number_of_upgrades': 2,
+            'required_tactics': 'standard',
+            'selected_races': 'protoss',
+            'mission_order': 'grid',
+        }
+        self.generate_world(world_options)
+        self.assertTrue(self.multiworld.itempool)
+        itempool = [item.name for item in self.multiworld.itempool]
+        self.assertIn(item_names.ZEALOT_SENTINEL_CENTURION_SHIELD_CAPACITY, itempool)
+        self.assertIn(item_names.ZEALOT_SENTINEL_CENTURION_LEG_ENHANCEMENTS, itempool)
+
+    def test_excluding_all_items_in_multiparent_excludes_child_items(self) -> None:
+        world_options = {
+            'excluded_items': {
+                item_names.ZEALOT: 1,
+                item_names.SENTINEL: 1,
+                item_names.CENTURION: 1,
+            },
+            'min_number_of_upgrades': 2,
+            'required_tactics': 'standard',
+            'selected_races': 'protoss',
+            'mission_order': 'grid',
+        }
+        self.generate_world(world_options)
+        self.assertTrue(self.multiworld.itempool)
+        itempool = [item.name for item in self.multiworld.itempool]
+        self.assertNotIn(item_names.ZEALOT_SENTINEL_CENTURION_SHIELD_CAPACITY, itempool)
+        self.assertNotIn(item_names.ZEALOT_SENTINEL_CENTURION_LEG_ENHANCEMENTS, itempool)
+    

--- a/worlds/sc2/test/test_item_filtering.py
+++ b/worlds/sc2/test/test_item_filtering.py
@@ -36,7 +36,7 @@ class ItemFilterTests(Sc2SetupTestBase):
         self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR, itempool)
         self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON, itempool)
         self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE, itempool)
-    
+
     def test_excluding_one_item_of_multi_parent_doesnt_filter_children(self) -> None:
         world_options = {
             'locked_items': {
@@ -45,6 +45,12 @@ class ItemFilterTests(Sc2SetupTestBase):
             },
             'excluded_items': {
                 item_names.ZEALOT: 1,
+                # Exclude more items to make space
+                item_names.WRATHWALKER: 1,
+                item_names.SENTRY: 1,
+                item_names.ENERGIZER: 1,
+                item_names.AVENGER: 1,
+                item_names.ARBITER: 1,
             },
             'min_number_of_upgrades': 2,
             'required_tactics': 'standard',

--- a/worlds/sc2/test/test_itemgroups.py
+++ b/worlds/sc2/test/test_itemgroups.py
@@ -1,5 +1,5 @@
 """
-Unit tests for ItemGroups.py
+Unit tests for item_groups.py
 """
 
 import unittest

--- a/worlds/sc2/test/test_items.py
+++ b/worlds/sc2/test/test_items.py
@@ -8,7 +8,6 @@ class TestItems(unittest.TestCase):
     def test_grouped_upgrades_number(self) -> None:
         """
         Tests if grouped upgrades have set number correctly
-        :return:
         """
         bundled_items = item_tables.upgrade_bundles.keys()
         bundled_item_data = [item_tables.get_full_item_list()[item_name] for item_name in bundled_items]
@@ -21,7 +20,6 @@ class TestItems(unittest.TestCase):
     def test_non_grouped_upgrades_number(self) -> None:
         """
         Checks if non-grouped upgrades number is set correctly thus can be sent into the game.
-        :return:
         """
         check_modulo = 4
         bundled_items = item_tables.upgrade_bundles.keys()
@@ -40,7 +38,6 @@ class TestItems(unittest.TestCase):
     def test_bundles_contain_only_basic_elements(self) -> None:
         """
         Checks if there are no bundles within bundles.
-        :return:
         """
         bundled_items = item_tables.upgrade_bundles.keys()
         bundle_elements: List[str] = [item_name for values in item_tables.upgrade_bundles.values() for item_name in values]
@@ -51,7 +48,6 @@ class TestItems(unittest.TestCase):
     def test_weapon_armor_level(self) -> None:
         """
         Checks if Weapon/Armor upgrade level is correctly set to all Weapon/Armor upgrade items.
-        :return:
         """
         weapon_armor_upgrades = [item for item in item_tables.get_full_item_list() if item_tables.get_item_table()[item].type in item_tables.upgrade_item_types]
 
@@ -61,7 +57,6 @@ class TestItems(unittest.TestCase):
     def test_item_ids_distinct(self) -> None:
         """
         Verifies if there are no duplicates of item ID.
-        :return:
         """
         item_ids: Set[int] = {item_tables.get_full_item_list()[item_name].code for item_name in item_tables.get_full_item_list()}
 
@@ -70,7 +65,6 @@ class TestItems(unittest.TestCase):
     def test_number_distinct_in_item_type(self) -> None:
         """
         Tests if each item is distinct for sending into the mod.
-        :return:
         """
         item_types: List[item_tables.ItemTypeEnum] = [
             *[item.value for item in item_tables.TerranItemType],
@@ -93,7 +87,6 @@ class TestItems(unittest.TestCase):
 
     def test_progressive_has_quantity(self) -> None:
         """
-        Checks if the quantity attribute has been set for progressive items.
         :return:
         """
         progressive_groups: List[item_tables.ItemTypeEnum] = [
@@ -113,7 +106,6 @@ class TestItems(unittest.TestCase):
     def test_non_progressive_quantity(self) -> None:
         """
         Check if non-progressive items have quantity at most 1.
-        :return:
         """
         non_progressive_single_entity_groups: List[item_tables.ItemTypeEnum] = [
             # Terran
@@ -163,7 +155,6 @@ class TestItems(unittest.TestCase):
     def test_item_number_less_than_30(self) -> None:
         """
         Checks if all item numbers are within bounds supported by game mod.
-        :return:
         """
         not_checked_item_types: List[item_tables.ItemTypeEnum] = [
             item_tables.ZergItemType.Level

--- a/worlds/sc2/test/test_options.py
+++ b/worlds/sc2/test/test_options.py
@@ -10,7 +10,7 @@ class TestOptions(unittest.TestCase):
     def test_unit_max_upgrades_matching_items(self) -> None:
         upgrade_group_to_count: Dict[str, int] = {}
         for parent_id, child_list in item_parents.parent_id_to_children.items():
-            main_parent = item_parents.parent_present[parent_id].main_item
+            main_parent = item_parents.parent_present[parent_id].constraint_group
             if main_parent is None:
                 continue
             upgrade_group_to_count.setdefault(main_parent, 0)

--- a/worlds/sc2/test/test_usecases.py
+++ b/worlds/sc2/test/test_usecases.py
@@ -287,3 +287,54 @@ class TestSupportedUseCases(Sc2SetupTestBase):
         self.assertEqual(len(world_regions), NUM_WOL_MISSIONS)
         races = set(mission_tables.lookup_name_to_mission[mission].race for mission in world_regions)
         self.assertTrue(SC2Race.ZERG in races or SC2Race.PROTOSS in races)
+
+    def test_start_inventory_upgrade_level_includes_only_correct_bundle(self) -> None:
+        world_options = {
+            'start_inventory': {
+                item_groups.ItemGroupNames.TERRAN_GENERIC_UPGRADES: 1,
+            },
+            'locked_items': {
+                # One unit of each class to guarantee upgrades are available
+                item_names.MARINE: 1,
+                item_names.VULTURE: 1,
+                item_names.BANSHEE: 1,
+            },
+            'generic_upgrade_items': options.GenericUpgradeItems.option_bundle_unit_class,
+            'selected_races': options.SelectRaces.option_terran,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_disabled,
+            'enable_wol_missions': True,
+            'enable_nco_missions': False,
+            'enable_prophecy_missions': False,
+            'enable_hots_missions': False,
+            'enable_lotv_prologue_missions': False,
+            'enable_lotv_missions': False,
+            'enable_epilogue_missions': False,
+            'mission_order': options.MissionOrder.option_grid,
+        }
+        self.generate_world(world_options)
+        self.assertTrue(self.multiworld.itempool)
+        world_item_names = [item.name for item in self.multiworld.itempool]
+        start_inventory = [item.name for item in self.multiworld.precollected_items[self.player]]
+        # Start inventory
+        self.assertIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE, start_inventory)
+        self.assertIn(item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE, start_inventory)
+        self.assertIn(item_names.PROGRESSIVE_TERRAN_SHIP_UPGRADE, start_inventory)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON, start_inventory)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR, start_inventory)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON, start_inventory)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_VEHICLE_ARMOR, start_inventory)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_SHIP_WEAPON, start_inventory)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_SHIP_ARMOR, start_inventory)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_ARMOR_UPGRADE, start_inventory)
+
+        # Additional items in pool -- standard tactics will require additional levels
+        self.assertIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE, world_item_names)
+        self.assertIn(item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE, world_item_names)
+        self.assertIn(item_names.PROGRESSIVE_TERRAN_SHIP_UPGRADE, world_item_names)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON, world_item_names)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR, world_item_names)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON, world_item_names)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_VEHICLE_ARMOR, world_item_names)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_SHIP_WEAPON, world_item_names)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_SHIP_ARMOR, world_item_names)
+        self.assertNotIn(item_names.PROGRESSIVE_TERRAN_ARMOR_UPGRADE, world_item_names)


### PR DESCRIPTION
## What is this fixing or adding?
Reworking how item parents work, and refactoring pool_filter.py to match. Updating the item filter flags in accordance with the plan in #309. Everything from that case should be completed here except the allow_generation_failures features.

### Item parentage
Item parentage / culling dependencies are now consistently expressed for one or more items.
* item_tables now specifies a rule_id as the parent.
* item_parents maps a rule_id to a presence rule, which:
  * may be an arbitrarily complex function
  * may specify a "main parent" for the purposes of min/max items per unit ("unit" is now "group" under the hood for this reason)
  * automatically generates a simple presence rule for every item, with ID equal to the item name, and just checking if that item is present
* parent_names is like item_names, but for presence rule IDs. I had to separate it off for dependency cycle reasons :P

### pool_filter refactor
ItemFilterFlags are reworked a little:
* Locked is renamed to requested; it has lower priority than any other flag except culled
* Necessary is renamed to locked. User locked_items maps to the new locked
* Excluded is split into UserExcluded and FilterExcluded; the only difference in behaviour should be whether a warning is displayed if logic supercedes the option
* Old "removed" is moved to FilterExcluded
* New "Removed" is used to flag things that are to be imminently removed, with the highest priority (makes reusing functions in pool_filter nicer)
* Items required by logic go to locked
* Items required by min upgrades per unit or generic upgrades count as requested
* Items filtered by max upgrades per unit are marked as culled

The new algorithm culls in stages until the inventory is small enough, treating stages a little differently:
* First it filters out items that aren't requested
* Then it allows filtering items that are requested, but not locked items
* Then it promotes locked items to start inventory

### `/received` update
The new system introduces titles (`display_string` in code) for groups of items that are collectively the parent for an item. Additionally the new system allows arbitrary nesting of parentage, used often with morphs, e.g. Race(Zerg) ->Title(Baneling Sources) -> Item(Centrifugal Hooks).

`/received` was updated with a pair of recursive functions, one to gather data on a tree of nodes, the other to print the data. I didn't do any fancy handling to allow titles to be searchable with received, so that's a fairly low-hanging fruit for a future improvement.

### Other minor fixes
There was old code in there that was requiring a minimum number of terran units per building, based on mission count. However, the mission count wasn't filtered by terran, so it was presumably locking a ton more terran units than other races for larger mission orders. I've removed this check entirely.

Also tried adding a few more warnings in the filtering to notify if a user option was being overridden by logic.

## How was this tested?
Ran all unit tests. Added additional unit tests. Ran a test generation, did some basic checks in the spoiler.

Note one of the added unit tests is commented out as it always fails. This failure seems to be from before the refactor and will likely need further work to fix the issue. See the comment in test_item_filtering.py for details.

Then I remembered to check `/received` and spent way too long tinkering with that. Images below.

## If this makes graphical changes, please attach screenshots.
Changes to received:
![image](https://github.com/user-attachments/assets/1dd01563-a3da-42ea-b2c8-147e198104e6)
![image](https://github.com/user-attachments/assets/4fa4fb13-4494-47ac-853c-1ab3e8870867)
![image](https://github.com/user-attachments/assets/4e78aabd-2132-482b-95e8-9ca3f921d091)
