### PR TITLE
sc2: Fixing a broken import from merge of last two PRs

### DIFF
--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -3,7 +3,7 @@ from typing import *
 
 from Options import (
     Choice, Toggle, DefaultOnToggle, OptionSet, Range,
-    PerGameCommonOptions, Option, VerifyKeys,
+    PerGameCommonOptions, Option, VerifyKeys, StartInventory,
     is_iterable_except_str,
 )
 from Utils import get_fuzzy_results


### PR DESCRIPTION
## What is this fixing or adding?
Fixing an issue from merging #369 and #370 -- one used an import from Options.py, the other removed the star import on Options.py.

## How was this tested?
Ran unit tests. Without the fix, it crashes on import. With the fix, they all pass.

## If this makes graphical changes, please attach screenshots.
None.