### PR TITLE
sc2: Fixed an issue with all items being marked progression

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -823,7 +823,7 @@ def create_item_with_correct_settings(player: int, name: str, filter_flags: Item
     data = item_tables.item_table[name]
 
     item = StarcraftItem(name, data.classification, data.code, player, filter_flags)
-    if ItemFilterFlags.ForceProgression:
+    if ItemFilterFlags.ForceProgression & filter_flags:
         item.classification = ItemClassification.progression
 
     return item


### PR DESCRIPTION
## What is this fixing or adding?
Fixing the issue Venat just reported of all filler appearing as progression. Introduced in #369 

## How was this tested?
Inspection, mostly. Ran unit tests.

Edit: Started a game, lucked out and got a filler for first item. It looks fixed:
![image](https://github.com/user-attachments/assets/193c9f91-7a41-4216-870f-292a438be280)
![image](https://github.com/user-attachments/assets/c85abe66-b278-4c5a-a3ae-293a8e8710e4)


## If this makes graphical changes, please attach screenshots.
None