### PR TITLE
Mission Bias Option

### DIFF
--- a/worlds/sc2/mission_order/structs.py
+++ b/worlds/sc2/mission_order/structs.py
@@ -469,7 +469,7 @@ class SC2MissionOrder(MissionOrderNode):
         # Pick goal missions first with stricter difficulty matching, and starting with harder goals
         for goal_slot in sorted_goals:
             try:
-                mission = self.mission_pools.pull_random_mission(world, goal_slot)
+                mission = self.mission_pools.pull_random_mission(world, goal_slot, prefer_close_difficulty=True)
                 goal_slot.set_mission(world, mission, locations_per_region, location_cache)
                 regions.append(goal_slot.region)
                 all_slots.remove(goal_slot)
@@ -483,8 +483,7 @@ class SC2MissionOrder(MissionOrderNode):
         remaining_count = len(all_slots)
         for mission_slot in all_slots:
             try:
-                prefer_min_difficulty = Difficulty.STARTER if prefer_easy_missions else mission_slot.option_difficulty
-                mission = self.mission_pools.pull_random_mission(world, mission_slot, prefer_min_difficulty=prefer_min_difficulty)
+                mission = self.mission_pools.pull_random_mission(world, mission_slot, prefer_close_difficulty=not prefer_easy_missions)
                 mission_slot.set_mission(world, mission, locations_per_region, location_cache)
                 regions.append(mission_slot.region)
                 remaining_count -= 1

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -863,6 +863,16 @@ class ExcludedMissions(Sc2MissionSet):
     valid_keys = {mission.mission_name for mission in SC2Mission}
 
 
+class MissionBias(Choice):
+    """
+    When building a campaign, determines whether easy or hard missions are more likely to appear.
+    Only applies to mission orders with fewer missions than those available.
+    """
+    display_name = "Mission Bias"
+    option_easy = 0
+    option_hard = 1
+
+
 class ExcludeVeryHardMissions(Choice):
     """
     Excludes Very Hard missions outside of Epilogue campaign (All-In, The Reckoning, Salvation, and all Epilogue missions are considered Very Hard).
@@ -1207,6 +1217,7 @@ class Starcraft2Options(PerGameCommonOptions):
     excluded_items: ExcludedItems
     unexcluded_items: UnexcludedItems
     excluded_missions: ExcludedMissions
+    mission_bias: MissionBias
     exclude_very_hard_missions: ExcludeVeryHardMissions
     vanilla_items_only: VanillaItemsOnly
     victory_cache: VictoryCache


### PR DESCRIPTION
## What is this fixing or adding?

This adds a Mission Bias option that controls whether missions placed in a campaign tend to be harder or easier.  Enabling it flips the order of slot fill (Very Hard -> Hard...-> Starter) and causes slots to attempt to pick missions of their own difficulty before checking other pools.

**This also changes Goal mission difficulty priority.**

Currently, it goes Slot Diff -> Slot Diff -> Slot Diff -1 -> Slot Diff +1 -> Slot Diff - 2 -> Slot Diff  + 2...

In this PR, it goes Slot Diff -> Slot Diff + 1 -> Slot Diff - 1 -> Slot Diff +2 -> Slot Diff -2...

Checking the slot difficulty twice seems weird?  And this allows the same method to be used for Hard Bias general fill and Goals.  The main difference is that we now check the higher difficulty before the lower difficulty when alternating.  It should be pretty unlikely for this to affect Goals, since they get filled fairly early, and it is intuitive for Goals to prefer harder missions over easier ones?

## How was this tested?

Generated a WoL Vanilla Shuffled with The Outlaws excluded, a full Grid, a shortened Grid, a shortened Golden Path, and a custom mission order with delineated difficulty columns.

## If this makes graphical changes, please attach screenshots.

Easy Bias (Default)

![image](https://github.com/user-attachments/assets/742ea761-d437-4b6d-8cc0-bd2da46b51d3)


Hard Bias

![image](https://github.com/user-attachments/assets/6cf54b91-93ff-45d2-aaba-0eac1aad642c)
