### PR TITLE
war council scout

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -1035,7 +1035,7 @@ item_descriptions = {
     item_names.SKYLORD_HYPERJUMP: "Skylord War Council upgrade. " + _ability_desc("Skylords", "Hyperjump", "teleports the skylord to any location on the map"),
     item_names.TRIREME_SOLAR_BEAM: "Trireme War Council upgrade. Triremes gain an anti-air laser attack that deals more damage over time.",
     item_names.TEMPEST_DISINTEGRATION: "Tempest War Council upgrade. " + _ability_desc("Tempests", "Disintegration", "deals 500 damage to a target unit or structure over 20 seconds"),
-    item_names.SCOUT_EXPEDITIONARY_HULL: "Scout War Council upgrade. Scouts gain +25 shields, +25 health, +1 shield armor, and reduced shield regeneration delay.",
+    item_names.SCOUT_EXPEDITIONARY_HULL: "Scout War Council upgrade. Scouts gain +25 shields, +50 health, +1 shield armor, and reduced shield regeneration delay.",
     item_names.ARBITER_ABILITY_EFFICIENCY: "Arbiter War Council upgrade. Reduces the energy cost of Recall by 50 and Stasis Field by 100.",
     # Oracle
     item_names.MOTHERSHIP_INTEGRATED_POWER: "Mothership War Council upgrade. Allows Motherships to move at full speed outside pylon power.",

--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -1035,7 +1035,7 @@ item_descriptions = {
     item_names.SKYLORD_HYPERJUMP: "Skylord War Council upgrade. " + _ability_desc("Skylords", "Hyperjump", "teleports the skylord to any location on the map"),
     item_names.TRIREME_SOLAR_BEAM: "Trireme War Council upgrade. Triremes gain an anti-air laser attack that deals more damage over time.",
     item_names.TEMPEST_DISINTEGRATION: "Tempest War Council upgrade. " + _ability_desc("Tempests", "Disintegration", "deals 500 damage to a target unit or structure over 20 seconds"),
-    # Scout
+    item_names.SCOUT_EXPEDITIONARY_HULL: "Scout War Council upgrade. Scouts gain +25 shields, +25 health, +1 shield armor, and reduced shield regeneration delay.",
     item_names.ARBITER_ABILITY_EFFICIENCY: "Arbiter War Council upgrade. Reduces the energy cost of Recall by 50 and Stasis Field by 100.",
     # Oracle
     item_names.MOTHERSHIP_INTEGRATED_POWER: "Mothership War Council upgrade. Allows Motherships to move at full speed outside pylon power.",

--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -66,7 +66,7 @@ resource_efficiency_cost_reduction = {
     item_names.ARBITER:       (50, 0, 0),
     item_names.REAVER:        (100, 100, 2),
     DISPLAY_NAME_CLOAKED_ASSASSIN: (0, 50, 0),
-    item_names.SCOUT:         (125, 25, 1),
+    item_names.SCOUT:         (75, 25, 0),
     item_names.DESTROYER:     (50, 25, 1),
     DISPLAY_NAME_WORMS:       (50, 75, 0),
 

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -837,7 +837,7 @@ CARRIER_REPAIR_DRONES                                   = "Repair Drones (Carrie
 SKYLORD_HYPERJUMP                                       = "Hyperjump (Skylord)"
 TRIREME_SOLAR_BEAM                                      = "Solar Beam (Trireme)"
 TEMPEST_DISINTEGRATION                                  = "Disintegration (Tempest)"
-# Scout
+SCOUT_EXPEDITIONARY_HULL                                = "Expeditionary Hull (Scout)"
 ARBITER_ABILITY_EFFICIENCY                              = "Ability Efficiency (Arbiter)"
 # Oracle
 MOTHERSHIP_INTEGRATED_POWER                             = "Integrated Power (Mothership)"

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1939,7 +1939,7 @@ item_table = {
     item_names.SKYLORD_HYPERJUMP: ItemData(539 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 9, SC2Race.PROTOSS, parent=item_names.SKYLORD),
     item_names.TRIREME_SOLAR_BEAM: ItemData(540 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 10, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.TRIREME),
     item_names.TEMPEST_DISINTEGRATION: ItemData(541 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 11, SC2Race.PROTOSS, parent=item_names.TEMPEST),
-    # 542 reserved for Scout
+    item_names.SCOUT_EXPEDITIONARY_HULL: ItemData(542 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 12, SC2Race.PROTOSS, parent=item_names.SCOUT),
     item_names.ARBITER_ABILITY_EFFICIENCY: ItemData(543 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 13, SC2Race.PROTOSS, parent=item_names.ARBITER),
     # 544 reserved for Oracle
     item_names.MOTHERSHIP_INTEGRATED_POWER: ItemData(545 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 15, SC2Race.PROTOSS, parent=item_names.MOTHERSHIP),


### PR DESCRIPTION
## What is this fixing or adding?
Adds Scout War Council upgrade -- Expeditionary Hull. Bonus health
Pairs with [data PR #349](https://github.com/Ziktofel/Archipelago-SC2-data/pull/349)

## How was this tested?
The usual -- gen'd a world, started a mission, checked the unit, used `/send` in the server, checked the correct upgrade was unlocked.

## If this makes graphical changes, please attach screenshots.
See data PR.