### PR TITLE
sc2: Removing uncollected location special-case for victory checks

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1717,9 +1717,6 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             for location in self.ctx.uncollected_locations_in_mission(lookup_id_to_mission[self.mission_id])
             if (location % VICTORY_MODULO) < VICTORY_CACHE_OFFSET
         ]
-        if 0 not in result:
-            # Signal that victory should always send a notification for winning
-            result.append(0)
         return result
 
     def missions_beaten_count(self) -> int:


### PR DESCRIPTION
## What is this fixing or adding?
Removing the special-case of always marking victory (location 0) as uncollected from #389 following the changes to the mod files.

## How was this tested?
Used `/send_location` to get a victory location. Beat the mission with cheats. Verified the victory cache locations still sent.
![image](https://github.com/user-attachments/assets/2a34c2da-7efc-4d5e-a98e-e2f1670a6608)


## If this makes graphical changes, please attach screenshots.
None