### PR TITLE
Add progressive key options

### DIFF
--- a/worlds/sc2/docs/custom_mission_orders_en.md
+++ b/worlds/sc2/docs/custom_mission_orders_en.md
@@ -14,6 +14,7 @@
     - [Goal](#goal)
     - [Exit](#exit)
     - [Entry rules](#entry-rules)
+    - [Unique progression track](#unique-progression-track)
     - [Difficulty](#difficulty)
     - [Mission Pool](#mission-pool)
   - [Campaign Options](#campaign-options)
@@ -391,6 +392,20 @@ You can also use one of the following key items for this purpose:
 
 These keys will never be used by the generator unless you specify them yourself.
 
+There is also a special type of key:
+```yaml
+entry_rules:
+  - items:
+      # These two forms are equivalent
+      Progressive Key: 5
+      Progressive Key 5: 1
+```
+Progressive keys come in two forms: `Progressive Key: <track>` and `Progressive Key <track>: 1`. In the latter form the item amount is ignored. Their track is used to group them, so all progressive keys with track 1 belong together, as do all with track 2, and so on. Item rules using progressive keys are sorted by how far into the mission order they appear and have their required amounts set automatically so that deeper rules require more keys, with each track of progressive keys performing its own sorting.
+
+Note that if any Item rule within a track belongs to a mission, the generator will accept ties, in which case the affected rules will require the same number of progressive keys. If a track only contains Item rules belonging to layouts and campaigns, the track will be sorted in definition order (top to bottom in your YAML), so there will be no ties.
+
+If you would prefer not to manually specify the track, use the [`unique_progression_track`](#unique-progression-track) option.
+
 The Beat and Count rules both require a list of scopes. This list accepts addresses towards other parts of the mission order.
 
 The basic form of an address is `<Campaign>/<Layout>/<Mission>`, where `<Campaign>` and `<Layout>` are the definition names (not `display_names`!) of a campaign and a layout within that campaign, and `<Mission>` is the index of a mission slot in that layout or an index function for the layout's type. See the section on your layout's type to find valid indices and functions.
@@ -483,6 +498,38 @@ Below are examples of the available entry rules:
           amount: 1
 ```
 As this last example shows, the Subrule rule is a powerful tool for making arbitrarily complex requirements. Put plainly, the example accomplishes the following: To unlock the `Complicated Access` layout, either beat 5 missions in both the `Wings of Liberty` campaign and the `Some Missions` layout, or beat 10 missions across both of them.
+
+---
+### Unique progression track
+```yaml
+# For campaigns and layouts
+unique_progression_track: 0
+```
+This option specifically affects Item entry rules using progressive keys. Progressive keys used by children of this campaign/layout that are on the given track will automatically be put on a track that is unique to the container instead.
+```yaml
+  custom_mission_order:
+    First Column:
+      type: column
+      size: 3
+      unique_progression_track: 0 # Default
+      missions:
+        - index: [1, 2]
+          entry_rules:
+          - items:
+              Progressive Key: 0
+    Second Column:
+      type: column
+      size: 3
+      unique_progression_track: 0 # Default
+      missions:
+        - index: [1, 2]
+          entry_rules:
+          - items:
+              Progressive Key: 0
+```
+In this example the two columns will use separate progressive keys for their missions.
+
+In the case that a mission slot uses a progressive key whose track matches the `unique_progression_track` of both its containing layout and campaign, the key will use the layout's unique track and not the campaign's. To avoid this behavior simply use different `unique_progression_track` values for the layout and campaign.
 
 ---
 ### Difficulty
@@ -608,7 +655,7 @@ See the following section for available presets.
 
 ## Campaign Presets
 
-There are two kinds of presets: Static presets that are based on vanilla campaigns, and scripted preset that dynamically create a complex campaign based on extra required options.
+There are two kinds of presets: Static presets that are based on vanilla campaigns, and scripted presets that dynamically create a complex campaign based on extra required options.
 
 ---
 ### Static Presets
@@ -649,6 +696,9 @@ The `keys` option accepts these possible values:
 - `none` (default), which does not add any Key Item rules to the preset.
 - `layouts`, which adds Key Item rules to layouts besides the preset's left-most layout, in addition to their regular entry rules.
 - `missions`, which adds Key Item rules to missions besides the preset's starter mission, in addition to their regular entry rules.
+- `progressive_layouts`, which adds Progressive Key Item rules to layouts besides the preset's left-most layout, in addition to their regular entry rules. These progressive keys use track 0, with presets using the default `unique_progression_track: 0`.
+- `progressive_missions`, which adds Progressive Key Item rules to missions besides the preset's starter mission, in addition to their regular entry rules. These progressive keys use track 1 and do not make use of `unique_progression_track`.
+- `progressive_per_layout`, which adds Progressive Key Item rules to all missions within each layout besides the preset's left-most one. These progressive keys use track 0, with presets and their layouts using the default `unique_progression_track: 0`.
 
 ---
 ### Golden Path
@@ -669,6 +719,9 @@ Golden Path also accepts a `keys` option, which works like the same option for s
 - `none` (default), which does not add any Key Item rules to the preset.
 - `layouts`, which adds Key Item rules to all side columns, in addition to their regular entry rules.
 - `missions`, which adds Key Item rules to missions besides the preset's starter mission, in addition to their regular entry rules.
+- `progressive_layouts`, which adds Progressive Key Item rules to all side columns, in addition to their regular entry rules. These progressive keys use track 0, with this preset using the default `unique_progression_track: 0`.
+- `progressive_missions`, which adds Progressive Key Item rules to missions besides the preset's starter mission, in addition to their regular entry rules. These progressive keys use track 1 and do not make use of `unique_progression_track`.
+- `progressive_per_layout`, which adds Progressive Key Item rules to all missions within each side column. These progressive keys use track 0, with this preset and its layouts using the default `unique_progression_track: 0`.
 
 ## Layout Options
 

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -888,12 +888,15 @@ NOTHING                     = "Nothing"
 PROGRESSIVE_ORBITAL_COMMAND         = "Progressive Orbital Command (Deprecated)"
 
 # Keys
-_TEMPLATE_MISSION_KEY            = "{} Mission Key"
-_TEMPLATE_NAMED_LAYOUT_KEY       = "{} ({}) Questline Key"
-_TEMPLATE_NUMBERED_LAYOUT_KEY    = "Questline Key #{}"
-_TEMPLATE_NAMED_CAMPAIGN_KEY     = "{} Campaign Key"
-_TEMPLATE_NUMBERED_CAMPAIGN_KEY  = "Campaign Key #{}"
-_TEMPLATE_FLAVOR_KEY             = "{} Key"
+_TEMPLATE_MISSION_KEY               = "{} Mission Key"
+_TEMPLATE_NAMED_LAYOUT_KEY          = "{} ({}) Questline Key"
+_TEMPLATE_NUMBERED_LAYOUT_KEY       = "Questline Key #{}"
+_TEMPLATE_NAMED_CAMPAIGN_KEY        = "{} Campaign Key"
+_TEMPLATE_NUMBERED_CAMPAIGN_KEY     = "Campaign Key #{}"
+_TEMPLATE_FLAVOR_KEY                = "{} Key"
+PROGRESSIVE_MISSION_KEY             = "Progressive Mission Key"
+PROGRESSIVE_QUESTLINE_KEY           = "Progressive Questline Key"
+_TEMPLATE_PROGRESSIVE_KEY           = "Progressive Key #{}"
 
 # Names for flavor keys, feel free to add more, but add them to the Custom Mission Order docs too
 # These will never be randomly created by the generator

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -2016,12 +2016,22 @@ numbered_campaign_key_item_table = {
     for number in range(len(SC2Mission))
 }
 # Flavor keys (key offset + 3000 - 3999)
+# Generic progressive keys are also in here because flavor keys don't dynamically scale with non-item data anyway
+# and just reserve a range for convenience
 flavor_key_item_table = {
+    item_names.PROGRESSIVE_MISSION_KEY:
+        ItemData(0 + SC2_KEY_ITEM_ID_OFFSET + SC2_KEY_ITEM_SECTION_SIZE * 3, FactionlessItemType.Keys, 0, SC2Race.ANY,
+                 classification=ItemClassification.progression, quantity=0),
+    item_names.PROGRESSIVE_QUESTLINE_KEY:
+        ItemData(1 + SC2_KEY_ITEM_ID_OFFSET + SC2_KEY_ITEM_SECTION_SIZE * 3, FactionlessItemType.Keys, 0, SC2Race.ANY,
+                 classification=ItemClassification.progression, quantity=0),
+}
+flavor_key_item_table.update({
     item_names._TEMPLATE_FLAVOR_KEY.format(name):
-        ItemData(i + SC2_KEY_ITEM_ID_OFFSET + SC2_KEY_ITEM_SECTION_SIZE * 3, FactionlessItemType.Keys, 0, SC2Race.ANY,
+        ItemData(i + 2 + SC2_KEY_ITEM_ID_OFFSET + SC2_KEY_ITEM_SECTION_SIZE * 3, FactionlessItemType.Keys, 0, SC2Race.ANY,
                  classification=ItemClassification.progression, quantity=0)
     for (i, name) in enumerate(item_names._flavor_key_names)
-}
+})
 # Named layout keys (key offset + 4000 - 4999)
 campaign_to_layout_names = get_used_layout_names()
 named_layout_key_item_table = {
@@ -2038,6 +2048,13 @@ named_campaign_key_item_table = {
                  classification=ItemClassification.progression, quantity=0)
     for (i, campaign_name) in enumerate(campaign_names)
 }
+# Numbered progressive keys (key offset + 6000 - 6999)
+numbered_progressive_keys = {
+    item_names._TEMPLATE_PROGRESSIVE_KEY.format(number + 1):
+        ItemData(number + SC2_KEY_ITEM_ID_OFFSET + SC2_KEY_ITEM_SECTION_SIZE * 6, FactionlessItemType.Keys, 0, SC2Race.ANY,
+                 classification=ItemClassification.progression, quantity=0)
+    for number in range(len(SC2Mission))
+}
 key_item_table = {}
 key_item_table.update(mission_key_item_table)
 key_item_table.update(numbered_layout_key_item_table)
@@ -2045,6 +2062,7 @@ key_item_table.update(numbered_campaign_key_item_table)
 key_item_table.update(flavor_key_item_table)
 key_item_table.update(named_layout_key_item_table)
 key_item_table.update(named_campaign_key_item_table)
+key_item_table.update(numbered_progressive_keys)
 item_table.update(key_item_table)
 
 def get_item_table():

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -2016,22 +2016,12 @@ numbered_campaign_key_item_table = {
     for number in range(len(SC2Mission))
 }
 # Flavor keys (key offset + 3000 - 3999)
-# Generic progressive keys are also in here because flavor keys don't dynamically scale with non-item data anyway
-# and just reserve a range for convenience
 flavor_key_item_table = {
-    item_names.PROGRESSIVE_MISSION_KEY:
-        ItemData(0 + SC2_KEY_ITEM_ID_OFFSET + SC2_KEY_ITEM_SECTION_SIZE * 3, FactionlessItemType.Keys, 0, SC2Race.ANY,
-                 classification=ItemClassification.progression, quantity=0),
-    item_names.PROGRESSIVE_QUESTLINE_KEY:
-        ItemData(1 + SC2_KEY_ITEM_ID_OFFSET + SC2_KEY_ITEM_SECTION_SIZE * 3, FactionlessItemType.Keys, 0, SC2Race.ANY,
-                 classification=ItemClassification.progression, quantity=0),
-}
-flavor_key_item_table.update({
     item_names._TEMPLATE_FLAVOR_KEY.format(name):
-        ItemData(i + 2 + SC2_KEY_ITEM_ID_OFFSET + SC2_KEY_ITEM_SECTION_SIZE * 3, FactionlessItemType.Keys, 0, SC2Race.ANY,
+        ItemData(i + SC2_KEY_ITEM_ID_OFFSET + SC2_KEY_ITEM_SECTION_SIZE * 3, FactionlessItemType.Keys, 0, SC2Race.ANY,
                  classification=ItemClassification.progression, quantity=0)
     for (i, name) in enumerate(item_names._flavor_key_names)
-})
+}
 # Named layout keys (key offset + 4000 - 4999)
 campaign_to_layout_names = get_used_layout_names()
 named_layout_key_item_table = {
@@ -2055,6 +2045,15 @@ numbered_progressive_keys = {
                  classification=ItemClassification.progression, quantity=0)
     for number in range(len(SC2Mission))
 }
+# Special keys (key offset + 7000 - 7999)
+special_keys = {
+    item_names.PROGRESSIVE_MISSION_KEY:
+        ItemData(0 + SC2_KEY_ITEM_ID_OFFSET + SC2_KEY_ITEM_SECTION_SIZE * 7, FactionlessItemType.Keys, 0, SC2Race.ANY,
+                 classification=ItemClassification.progression, quantity=0),
+    item_names.PROGRESSIVE_QUESTLINE_KEY:
+        ItemData(1 + SC2_KEY_ITEM_ID_OFFSET + SC2_KEY_ITEM_SECTION_SIZE * 7, FactionlessItemType.Keys, 0, SC2Race.ANY,
+                 classification=ItemClassification.progression, quantity=0),
+}
 key_item_table = {}
 key_item_table.update(mission_key_item_table)
 key_item_table.update(numbered_layout_key_item_table)
@@ -2063,6 +2062,7 @@ key_item_table.update(flavor_key_item_table)
 key_item_table.update(named_layout_key_item_table)
 key_item_table.update(named_campaign_key_item_table)
 key_item_table.update(numbered_progressive_keys)
+key_item_table.update(special_keys)
 item_table.update(key_item_table)
 
 def get_item_table():

--- a/worlds/sc2/mission_order/entry_rules.py
+++ b/worlds/sc2/mission_order/entry_rules.py
@@ -157,7 +157,7 @@ class CountMissionsEntryRule(EntryRule):
     def _get_depth(self, beaten_missions: Set[SC2MOGenMission]) -> int:
         sorted_missions = sorted(beaten_missions.intersection(self.missions_to_count), key = lambda mission: mission.min_depth)
         mission_depth = max(mission.min_depth for mission in sorted_missions[:self.target_amount])
-        return max(mission_depth, self.target_amount - 1)
+        return max(mission_depth, self.target_amount - 1) # -1 because depth is zero-based but amount is one-based
 
     def to_lambda(self, player: int) -> Callable[[CollectionState], bool]:
         return lambda state: self.target_amount <= sum(state.has(mission.beat_item(), player) for mission in self.missions_to_count)
@@ -250,7 +250,7 @@ class SubRuleEntryRule(EntryRule):
         filtered_rules = [rule for rule in self.rules_to_check if rule.get_depth(beaten_missions) > -1]
         sorted_rules = sorted(filtered_rules, key = lambda rule: rule.get_depth(beaten_missions))
         required_depth = max(rule.get_depth(beaten_missions) for rule in sorted_rules[:self.target_amount])
-        return max(required_depth, self.target_amount - 1, self.min_depth)
+        return max(required_depth, self.min_depth)
 
     def to_lambda(self, player: int) -> Callable[[CollectionState], bool]:
         sub_lambdas = [rule.to_lambda(player) for rule in self.rules_to_check]

--- a/worlds/sc2/mission_order/presets_scripted.py
+++ b/worlds/sc2/mission_order/presets_scripted.py
@@ -22,7 +22,8 @@ def make_golden_path(options: Dict[str, Any]) -> Dict[str, Any]:
                           'Azeroth', 'Crouton', 'Draenor', 'Sanctuary']
     
     size = max(_required_option("size", options), 4)
-    keys_option = _validate_option("keys", options, "none", ["none", "layouts", "missions"])
+    keys_option_values = ["none", "layouts", "missions", "progressive_layouts", "progressive_missions", "progressive_per_layout"]
+    keys_option = _validate_option("keys", options, "none", keys_option_values)
     min_chains = 2
     max_chains = 6
 
@@ -78,6 +79,8 @@ def make_golden_path(options: Dict[str, Any]) -> Dict[str, Any]:
     # Optionally add key requirement to layouts
     if keys_option == "layouts":
         layout_base["entry_rules"] = [{ "items": { "Key": 1 }}]
+    elif keys_option == "progressive_layouts":
+        layout_base["entry_rules"] = [{ "items": { "Progressive Key": 0 }}]
     preset = {
         str(chain): copy.deepcopy(layout_base) for chain in range(len(campaign.chain_lengths))
     }
@@ -108,6 +111,10 @@ def make_golden_path(options: Dict[str, Any]) -> Dict[str, Any]:
             if keys_option == "missions":
                 for slot in preset["0"]["missions"]:
                     slot["entry_rules"].append({ "items": { "Key": 1 }})
+            elif keys_option == "progressive_missions":
+                for slot in preset["0"]["missions"]:
+                    slot["entry_rules"].append({ "items": { "Progressive Key": 1 }})
+            # No main chain keys for progressive_per_layout keys
         else:
             # Other paths get main path requirements
             for mission in range(length):
@@ -123,5 +130,13 @@ def make_golden_path(options: Dict[str, Any]) -> Dict[str, Any]:
                 for slot in preset[str(chain)]["missions"]:
                     if "entry_rules" in slot:
                         slot["entry_rules"].append({ "items": { "Key": 1 }})
+            elif keys_option == "progressive_missions":
+                for slot in preset[str(chain)]["missions"]:
+                    if "entry_rules" in slot:
+                        slot["entry_rules"].append({ "items": { "Progressive Key": 1 }})
+            elif keys_option == "progressive_per_layout":
+                for slot in preset[str(chain)]["missions"]:
+                    if "entry_rules" in slot:
+                        slot["entry_rules"].append({ "items": { "Progressive Key": 0 }})
     
     return preset

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -181,15 +181,23 @@ class KeyMode(Choice):
     """
     Optionally creates Key items that must be found in the multiworld to unlock parts of the mission order,
     in addition to any regular requirements a mission may have.
+
+    "Questline" options will only work for Vanilla, Vanilla Shuffled, Mini Campaign, and Golden Path mission orders.
+
     Disabled: Don't create any keys.
     Questlines: Create keys for questlines besides the starter ones, eg. "Colonist (Wings of Liberty) Questline Key".
-    Only works for Vanilla, Vanilla Shuffled, Mini Campaign, and Golden Path mission orders.
     Missions: Create keys for missions besides the starter ones, eg. "Zero Hour Mission Key".
+    Progressive Questlines: Create one type of progressive key for questlines within each campaign, eg. "Progressive Key #1".
+    Progressive Missions: Create one type of progressive key for all missions, "Progressive Mission Key".
+    Progressive Per Questline: All questlines besides the starter ones get a unique progressive key for their missions, eg. "Progressive Key #1".
     """
     display_name = "Key Mode"
     option_disabled = 0
     option_questlines = 1
     option_missions = 2
+    option_progressive_questlines = 3
+    option_progressive_missions = 4
+    option_progressive_per_questline = 5
     default = option_disabled
 
 

--- a/worlds/sc2/regions.py
+++ b/worlds/sc2/regions.py
@@ -180,6 +180,12 @@ def create_static_mission_order(world: 'SC2World', mission_order_type: int, miss
         keys = "missions"
     elif key_mode_option == KeyMode.option_questlines:
         keys = "layouts"
+    elif key_mode_option == KeyMode.option_progressive_missions:
+        keys = "progressive_missions"
+    elif key_mode_option == KeyMode.option_progressive_questlines:
+        keys = "progressive_layouts"
+    elif key_mode_option == KeyMode.option_progressive_per_questline:
+        keys = "progressive_per_layout"
     else:
         keys = "none"
     
@@ -377,6 +383,12 @@ def make_golden_path(world: 'SC2World', size: int) -> Dict[str, Dict[str, Any]]:
         keys = "missions"
     elif key_mode == KeyMode.option_questlines:
         keys = "layouts"
+    elif key_mode == KeyMode.option_progressive_missions:
+        keys = "progressive_missions"
+    elif key_mode == KeyMode.option_progressive_questlines:
+        keys = "progressive_layouts"
+    elif key_mode == KeyMode.option_progressive_per_questline:
+        keys = "progressive_per_layout"
     else:
         keys = "none"
     
@@ -445,6 +457,11 @@ def create_dynamic_mission_order(world: 'SC2World', mission_order_type: int, mis
     if key_mode == KeyMode.option_missions:
         mission_order[list(mission_order.keys())[0]]["missions"] = [
             { "index": "all", "entry_rules": [{ "items": { "Key": 1 }}] },
+            { "index": "entrances", "entry_rules": [] }
+        ]
+    elif key_mode == KeyMode.option_progressive_missions:
+        mission_order[list(mission_order.keys())[0]]["missions"] = [
+            { "index": "all", "entry_rules": [{ "items": { "Progressive Key": 1 }}] },
             { "index": "entrances", "entry_rules": [] }
         ]
     


### PR DESCRIPTION
## What is this fixing or adding?
This adds three new values to the `key_mode` option:
- Progressive Questlines locks questlines within each campaign with increasing key counts from left to right.
- Progressive Missions locks all missions behind key counts that increase with the depth of the slot.
- Progressive Per Questline performs the same locking as Progressive Missions, but with a unique key for each questline.
Custom Mission Order presets have received a similar update for their `keys` option, and layouts/campaigns additionally get the `unique_progression_track` option to automatically make their progression keys unique, with progression keys being usable like regular keys via entry rules.

This also contains a few minor improvements to error messages, as well as one somewhat experimental change:
Previously the depth of a slot was limited to be at least equal to its amount of entry rules, which could slightly increase the difficulty of early slots under some conditions. I believe this was a bandaid fix for a bug with Mission Count entry rules that was itself fixed at some point, but I don't remember for sure. I've tried some generations and everything seems to behave as expected still, but fair warning.

## How was this tested?
Generating a bunch of different mission orders with a bunch of combinations of options (both custom orders and regular), then checking the result in the client.

## If this makes graphical changes, please attach screenshots.
Example of multiple overlaying progression tracks:
![python_CWukF7V8lQ](https://github.com/user-attachments/assets/83c369a9-71dc-4e58-a760-b49f32600e08)
![python_RfUzViorsk](https://github.com/user-attachments/assets/52f81544-ad6c-4af1-9f28-f44ac8f7a0e6)

Example of `unique_progression_track` working across campaigns:
![python_ZFnxMxCOHR](https://github.com/user-attachments/assets/1eba9051-9bfe-4e39-ba4f-b063653648f7)
![python_93tRQZay3O](https://github.com/user-attachments/assets/6df0a60a-8d8c-4fab-977a-b15e4f29945c)
