### PR TITLE
Make War Council nerf option respect item exclusions

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -734,12 +734,16 @@ def flag_user_excluded_item_sets(world: SC2World, item_list: List[FilterItem]) -
             vanilla_nonprogressive_count[item.name] += 1
 
 def flag_war_council_items(world: SC2World, item_list: List[FilterItem]) -> None:
-    """Excludes / start-inventories items based on `nerf_unit_baselines` option"""
+    """Excludes / start-inventories items based on `nerf_unit_baselines` option.
+    Will skip items that are excluded by other sources."""
     if world.options.nerf_unit_baselines:
         return
 
     for item in item_list:
-        if item.data.type in (ProtossItemType.War_Council, ProtossItemType.War_Council_2):
+        if (
+            item.data.type in (ProtossItemType.War_Council, ProtossItemType.War_Council_2)
+            and not ItemFilterFlags.Excluded & item.flags
+        ):
             item.flags |= ItemFilterFlags.StartInventory
 
 

--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -729,12 +729,20 @@ item_name_groups[ItemGroupNames.LOTV_GLOBAL_UPGRADES] = lotv_global_upgrades = [
     item_names.GUARDIAN_SHELL,
     item_names.RECONSTRUCTION_BEAM,
 ]
+lotv_war_council_upgrades = [
+    item_name for item_name, item_data in item_tables.item_table.items()
+    if (
+        item_data.type in (item_tables.ProtossItemType.War_Council, item_tables.ProtossItemType.War_Council_2)
+        and item_data.parent in item_name_groups[ItemGroupNames.LOTV_UNITS]
+    )
+]
 item_name_groups[ItemGroupNames.LOTV_ITEMS] = vanilla_lotv_items = (
     lotv_units
     + protoss_buildings
     + lotv_soa_items
     + lotv_global_upgrades
     + protoss_generic_upgrades
+    + lotv_war_council_upgrades
 )
 
 item_name_groups[ItemGroupNames.VANILLA_ITEMS] = vanilla_items = (

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -297,6 +297,9 @@ class TestItemFiltering(Sc2SetupTestBase):
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'accessibility': 'locations',
             'vanilla_items_only': True,
+            # Move the unit nerf items from the start inventory to the pool,
+            # else this option could push non-vanilla items past this test
+            'nerf_unit_baselines': True,
         }
         self.generate_world(world_options)
         world_items = [(item.name, item_tables.item_table[item.name]) for item in self.multiworld.itempool]


### PR DESCRIPTION
## What is this fixing or adding?
This changes the `nerf_unit_baselines` option to not put items in the start inventory if they're excluded by any source. The result is that user exclusions now actually affect the option and automatic exclusions (eg. race culling) don't leave useless clutter in the start inventory and /received.

I opted for a local change rather than adding this as general functionality because I believe other places that can automatically place items in the start inventory already consider exclusions, and I didn't want to create a two-tiered start inventory flag without prior discussion.

The `nerf_unit_baselines` option will currently dump 44 items in your start inventory for no reason other than "you left the option at default", so I consider it an outlier as far as start inventory options go.

## How was this tested?
I generated a 3-player world with a Protoss, Zerg, and Terran player. The Protoss YAML additionally had `Whirlwind (Zealot)` excluded. Then I checked /received in the client for each of them: The Zerg and Terran player had no Protoss items, the Protoss player had 43 Protoss upgrades and no Whirlwind.
