### PR TITLE
Add trade age limit option

### DIFF
--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -402,6 +402,25 @@ class EnableVoidTrade(Toggle):
     display_name = "Enable Void Trade"
 
 
+class VoidTradeAgeLimit(Choice):
+    """
+    Determines the maximum allowed age for units you can receive from Void Trade.
+    Units that are older than your choice will still be available to other players, but not to you.
+
+    This does not put a time limit on units you send to other players. Your own units are only affected by other players' choices for this option.
+    """
+    display_name = "Void Trade Age Limit"
+    option_disabled = 0
+    option_1_week = 1
+    option_1_day = 2
+    option_4_hours = 3
+    option_2_hours = 4
+    option_1_hour = 5
+    option_30_minutes = 6
+    option_5_minutes = 7
+    default = option_30_minutes
+
+
 class GenericUpgradeMissions(Range):
     """
     Determines the percentage of missions in the mission order that must be completed before
@@ -1234,6 +1253,7 @@ class Starcraft2Options(PerGameCommonOptions):
     starter_unit: StarterUnit
     required_tactics: RequiredTactics
     enable_void_trade: EnableVoidTrade
+    void_trade_age_limit: VoidTradeAgeLimit
     ensure_generic_items: EnsureGenericItems
     min_number_of_upgrades: MinNumberOfUpgrades
     max_number_of_upgrades: MaxNumberOfUpgrades
@@ -1465,3 +1485,13 @@ upgrade_included_names: Dict[int, Set[str]] = {
     }
 }
 
+# Mapping trade age limit options to their millisecond equivalents
+void_trade_age_limits_ms: Dict[int, int] = {
+    VoidTradeAgeLimit.option_5_minutes: 1000 * 60 * 5,
+    VoidTradeAgeLimit.option_30_minutes: 1000 * 60 * 30,
+    VoidTradeAgeLimit.option_1_hour: 1000 * 60 * 60,
+    VoidTradeAgeLimit.option_2_hours: 1000 * 60 * 60 * 2,
+    VoidTradeAgeLimit.option_4_hours: 1000 * 60 * 60 * 4,
+    VoidTradeAgeLimit.option_1_day: 1000 * 60 * 60 * 24,
+    VoidTradeAgeLimit.option_1_week: 1000 * 60 * 60 * 24 * 7,
+}

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -1,5 +1,6 @@
 from dataclasses import fields, Field, dataclass
 from typing import *
+from datetime import timedelta
 
 from Options import (
     Choice, Toggle, DefaultOnToggle, OptionSet, Range,
@@ -1487,11 +1488,11 @@ upgrade_included_names: Dict[int, Set[str]] = {
 
 # Mapping trade age limit options to their millisecond equivalents
 void_trade_age_limits_ms: Dict[int, int] = {
-    VoidTradeAgeLimit.option_5_minutes: 1000 * 60 * 5,
-    VoidTradeAgeLimit.option_30_minutes: 1000 * 60 * 30,
-    VoidTradeAgeLimit.option_1_hour: 1000 * 60 * 60,
-    VoidTradeAgeLimit.option_2_hours: 1000 * 60 * 60 * 2,
-    VoidTradeAgeLimit.option_4_hours: 1000 * 60 * 60 * 4,
-    VoidTradeAgeLimit.option_1_day: 1000 * 60 * 60 * 24,
-    VoidTradeAgeLimit.option_1_week: 1000 * 60 * 60 * 24 * 7,
+    VoidTradeAgeLimit.option_5_minutes: 1000 * int(timedelta(minutes = 5).total_seconds()),
+    VoidTradeAgeLimit.option_30_minutes: 1000 * int(timedelta(minutes = 30).total_seconds()),
+    VoidTradeAgeLimit.option_1_hour: 1000 * int(timedelta(hours = 1).total_seconds()),
+    VoidTradeAgeLimit.option_2_hours: 1000 * int(timedelta(hours = 2).total_seconds()),
+    VoidTradeAgeLimit.option_4_hours: 1000 * int(timedelta(hours = 4).total_seconds()),
+    VoidTradeAgeLimit.option_1_day: 1000 * int(timedelta(days = 1).total_seconds()),
+    VoidTradeAgeLimit.option_1_week: 1000 * int(timedelta(weeks = 1).total_seconds()),
 }


### PR DESCRIPTION
## What is this fixing or adding?
This adds an option to restrict the units you can receive in Void Trade to a maximum age, as in time they've spent in the trade storage. This should allow trades to be a more social back-and-forth, for users that want this. The default 30 minutes is intended to loosely fit sync games.

## How was this tested?
I generated a game with two worlds with trade enabled, with the option set to 5 minutes. I sent units from one world over the course of 5 minutes, then checked that only the more recent of those units could be received from the other world.
I also used `/option void_trade_age_limit 1_hour` and `/option void_trade_age_limit disabled` to check that different age limits also worked.
It's worth noting that I didn't test all the age limit options, and I only eyeballed the time intervals with my system clock. I would appreciate a sanity check on my time conversion math in `options.py`.