### PR TITLE
SC2: Make Psi Disrupter and HME work against other races

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -534,8 +534,12 @@ item_descriptions = {
         Allows Terran mechanical units to regenerate health while not in combat.
         Each level increases life regeneration speed.
     """),
-    item_names.HIVE_MIND_EMULATOR: "Defensive structure. Can permanently Mind Control Zerg units.",
-    item_names.PSI_DISRUPTER: "Defensive structure. Slows the attack and movement speeds of all nearby Zerg units.",
+    item_names.HIVE_MIND_EMULATOR: "Unlocks the Hive Mind Emulator defensive structure, and allows it to permanently Mind Control Zerg units.",
+    item_names.KHALAI_TAKEOVER: "Unlocks the Hive Mind Emulator defensive structure, and allows it to permanently Mind Control Protoss units.",
+    item_names.BRAINWASHING: "Unlocks the Hive Mind Emulator defensive structure, and allows it to permanently Mind Control Terran units.",
+    item_names.PSI_DISRUPTER: "Unlocks the Psi Disrupter defensive structure, and allows it to slow the attack and movement speeds of all nearby Zerg units.",
+    item_names.KHALAI_DISRUPTER: "Unlocks the Psi Disrupter defensive structure, and allows it to slow the attack and movement speeds of all nearby Protoss units.",
+    item_names.SONIC_DISRUPTER: "Unlocks the Psi Disrupter defensive structure, and allows it to slow the attack and movement speeds of all nearby Terran units.",
     item_names.DEVASTATOR_TURRET: "Defensive structure. Deals increased damage to armored targets. Attacks ground units.",
     item_names.STRUCTURE_ARMOR: "Increases armor of all Terran structures by 2.",
     item_names.HI_SEC_AUTO_TRACKING: "Increases attack range of all Terran structures by 1.",

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -56,8 +56,8 @@ MISSILE_TURRET                      = "Missile Turret"
 SENSOR_TOWER                        = "Sensor Tower"
 PLANETARY_FORTRESS                  = "Planetary Fortress"
 PERDITION_TURRET                    = "Perdition Turret"
-HIVE_MIND_EMULATOR                  = "Hive Mind Emulator"
-PSI_DISRUPTER                       = "Psi Disrupter"
+# HIVE_MIND_EMULATOR                  = "Hive Mind Emulator"# moved to Lab / Global upgrades
+# PSI_DISRUPTER                       = "Psi Disrupter"     # moved to Lab / Global upgrades
 DEVASTATOR_TURRET                   = "Devastator Turret"
 
 # Terran Weapon / Armor Upgrades
@@ -119,6 +119,12 @@ MERCENARY_MUNITIONS                   = "Mercenary Munitions (Terran)"
 FAST_DELIVERY                         = "Fast Delivery (Terran/Zerg)"
 RAPID_REINFORCEMENT                   = "Rapid Reinforcement (Terran/Zerg)"
 FUSION_CORE_FUSION_REACTOR            = "Fusion Reactor (Fusion Core)"
+PSI_DISRUPTER                         = "Psi Disrupter"  
+KHALAI_DISRUPTER                      = "Khalai Disrupter"  
+SONIC_DISRUPTER                       = "Sonic Disrupter"  
+HIVE_MIND_EMULATOR                    = "Hive Mind Emulator"
+BRAINWASHING                          = "Brainwashing"
+KHALAI_TAKEOVER                       = "Khalai Takeover"
 
 # Terran Unit Upgrades
 BANSHEE_HYPERFLIGHT_ROTORS                         = "Hyperflight Rotors (Banshee)"

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -967,10 +967,10 @@ item_table = {
         ItemData(617 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive, 4, SC2Race.TERRAN, quantity=3,
                  classification= ItemClassification.progression),
     item_names.HIVE_MIND_EMULATOR:
-        ItemData(618 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Building, 5, SC2Race.TERRAN,
+        ItemData(618 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 21, SC2Race.TERRAN,
                  classification=ItemClassification.progression),
     item_names.PSI_DISRUPTER:
-        ItemData(619 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Building, 6, SC2Race.TERRAN,
+        ItemData(619 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 18, SC2Race.TERRAN,
                  classification=ItemClassification.progression),
     item_names.STRUCTURE_ARMOR:
         ItemData(620 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 9, SC2Race.TERRAN),
@@ -990,6 +990,18 @@ item_table = {
         ItemData(627 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 16, SC2Race.TERRAN),
     item_names.FUSION_CORE_FUSION_REACTOR:
         ItemData(628 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 17, SC2Race.TERRAN),
+    item_names.SONIC_DISRUPTER:
+        ItemData(629 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 19, SC2Race.TERRAN,
+                 classification=ItemClassification.progression),
+    item_names.KHALAI_DISRUPTER:
+        ItemData(630 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 20, SC2Race.TERRAN,
+                 classification=ItemClassification.progression),
+    item_names.KHALAI_TAKEOVER:
+        ItemData(631 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 22, SC2Race.TERRAN,
+                 classification=ItemClassification.progression),
+    item_names.BRAINWASHING:
+        ItemData(632 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 23, SC2Race.TERRAN,
+                 classification=ItemClassification.progression),
 
     # WoL Protoss
     item_names.ZEALOT:


### PR DESCRIPTION
## What is this fixing or adding?

Adds 2 items each to Psi Disrupter and Hive Mind Emulator. Each item allows you to use the building against an additional race.

Khalai Disrupter: Allows the Psi Disrupter to slow Protoss units
Sonic Disrupter: Allows the Psi Disrupter to slow Terran units

Khalai Takeover: Allows the HME to mind control Protoss units
Brainwashing: Allows the HME to mind control Terran units

Finding any of the 3 respective items unlocks the structure. So if you find Sonic Disrupter, you can build a Psi Disrupter that will only slow Terran units. The items are independent, the structure is not a parent item.


## How was this tested?

Local test map for assets and functionality. Generated a local campaign and unlocked the items with commands, spawned different units from different races, tested different combinations  of upgrades.


## If this makes graphical changes, please attach screenshots.

Minor graphical changes. Some icons to indicate, which units currently can be affected. 
![grafik](https://github.com/user-attachments/assets/44ae1422-4c63-43e4-8d0f-f92de3dd2740)
(this currently slows Terran and Protoss units)

[Data PR](https://github.com/Ziktofel/Archipelago-SC2-data/pull/357)