### PR TITLE
sc2: Fixing the flaky item filtering test

### DIFF
--- a/worlds/sc2/test/test_item_filtering.py
+++ b/worlds/sc2/test/test_item_filtering.py
@@ -3,7 +3,8 @@ Unit tests for item filtering like pool_filter.py
 """
 
 from .test_base import Sc2SetupTestBase
-from ..item import item_tables, item_groups, item_names, item_parents
+from ..item import item_groups, item_names
+from .. import options
 from ..mission_tables import SC2Race
 
 class ItemFilterTests(Sc2SetupTestBase):
@@ -41,7 +42,6 @@ class ItemFilterTests(Sc2SetupTestBase):
                 item_names.ZEALOT: 1,
                 # Exclude more items to make space
                 item_names.WRATHWALKER: 1,
-                item_names.SENTRY: 1,
                 item_names.ENERGIZER: 1,
                 item_names.AVENGER: 1,
                 item_names.ARBITER: 1,
@@ -54,6 +54,7 @@ class ItemFilterTests(Sc2SetupTestBase):
             'required_tactics': 'standard',
             'selected_races': 'protoss',
             'mission_order': 'grid',
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
         }
         self.generate_world(world_options)
         self.assertTrue(self.multiworld.itempool)


### PR DESCRIPTION
## What is this fixing or adding?
Per Envy's suggestion, just giving that test case all the race-swapped protoss missions for more locations so it no longer culls the desired items for space.

Looked like this issue was acting up a lot on #396.

## How was this tested?
Made a test case that just ran the flaky test 100 times. Verified it failed without the fix. Verified it passed with the fix. Removed the test case before committing.

## If this makes graphical changes, please attach screenshots.
None