### PR TITLE
sc2: Guaranteeing a unit on any_unit if the first mission is not a nobuild

### DIFF
--- a/worlds/sc2/mission_order/structs.py
+++ b/worlds/sc2/mission_order/structs.py
@@ -1278,13 +1278,35 @@ def create_region(
         target_victory_cache_locations = slot.option_victory_cache
     victory_cache_locations = 0
 
+    # If the first mission is a build mission,
+    # require a unit everywhere except one location in the easiest category
+    mission_needs_unit = False
+    unit_given = False
+    easiest_category = LocationType.MASTERY
+    if slot is not None and slot.min_depth == 0:
+        mission = lookup_name_to_mission.get(region.name)
+        if mission is not None and MissionFlag.NoBuild not in mission.flags:
+            mission_needs_unit = True
+            for location_data in locations_per_region.get(name, ()):
+                if location_data.type == LocationType.VICTORY:
+                    pass
+                elif location_data.type < easiest_category:
+                    easiest_category = location_data.type
+            if easiest_category >= LocationType.CHALLENGE:
+                easiest_category = LocationType.VICTORY
+
     for location_data in locations_per_region.get(name, ()):
         if location_data.type == LocationType.VICTORY_CACHE:
             if victory_cache_locations >= target_victory_cache_locations:
                 continue
             victory_cache_locations += 1
         if world.options.required_tactics.value == world.options.required_tactics.option_any_units:
-            location = create_minimal_logic_location(world.player, location_data, region, location_cache, min(slot.min_depth, 5))
+            if mission_needs_unit and not unit_given and location_data.type == easiest_category:
+
+                location = create_minimal_logic_location(world.player, location_data, region, location_cache, 0)
+                unit_given = True
+            else:
+                location = create_minimal_logic_location(world.player, location_data, region, location_cache, min(slot.min_depth, 5) + mission_needs_unit)
         else:
             location = create_location(world.player, location_data, region, location_cache)
         region.locations.append(location)


### PR DESCRIPTION
## What is this fixing or adding?
Was walking someone through a beta yaml (advanced player), they wanted something hard... but not so hard that they were expected to get no units on harvest of screams without units. The root cause was that they turned no-builds off entirely, which I didn't account for in the design of any_units.

The adjustment is to require 1 unit on locations in the first mission if it's a build mission. Exactly one location doesn't have this constraint, so the unit can be placed there. The location chosen is the first active location in the easiest enabled category (ie it will try vanilla, then extra, then victory). As victory is always enabled, this means that no amount of disabling locations lead to an un-generateable game, though it can be arbitrarily hard (and a generation failure can theoretically occur if only victory locations are turned on, with no victory cache, and the next mission is a different race. I think victory locations-only may be a little out of scope to account for).

## How was this tested?
Generated golden path with no-builds off and sent some hint commands. Checked:
![image](https://github.com/user-attachments/assets/79a6ce1b-d3b4-4b37-92e4-0c412c9f1621)
* A zerg unit (infested missile turret) appeared in "Gather Minerals"
* A terran unit (hellion) appeared in win in under 10 minutes

Constraints all seem satisfied. Nothing said about the difficulty of such a seed.

## If this makes graphical changes, please attach screenshots.
None.