### PR TITLE
SC2: Add Probe items

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -1086,7 +1086,7 @@ item_descriptions = {
         Level 2: No longer consumes or requires charges.
     """),
     item_names.PROBE_WARPIN: "You can warp in additonal Probes from your Nexus to any visible location within a Pylon's power field. Has a 30 second cooldown and can store up to 2 charges.",
-    item_names.ELDER_PROBES: "You can warp in a group of 5 Elder Probes, tougher builders from the Brood War. Can only be used once!",
+    item_names.ELDER_PROBES: "You can warp in a group of 5 Elder Probes, tougher builders from the Brood War. Can only be used once.",
 }
 
 # Key descriptions

--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -1085,6 +1085,8 @@ item_descriptions = {
         Level 1: Protoss structures can be moved anywhere within pylon power after a brief delay. Max 3 charges, shared globally.
         Level 2: No longer consumes or requires charges.
     """),
+    item_names.PROBE_WARPIN: "You can warp in additonal Probes from your Nexus to any visible location within a Pylon's power field. Has a 30 second cooldown and can store up to 2 charges.",
+    item_names.ELDER_PROBES: "You can warp in a group of 5 Elder Probes, tougher builders from the Brood War. Can only be used once!",
 }
 
 # Key descriptions

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -895,6 +895,8 @@ OPTIMIZED_ORDNANCE          = "Optimized Ordnance (Protoss)"
 KHALAI_INGENUITY            = "Khalai Ingenuity (Protoss)"
 AMPLIFIED_ASSIMILATORS      = "Amplified Assimilators (Protoss)"
 PROGRESSIVE_WARP_RELOCATE   = "Progressive Warp Relocate (Protoss)"
+PROBE_WARPIN                = "Probe Warpin (Protoss)"
+ELDER_PROBES                = "Elder Probes (Protoss)"
 
 # Filler items
 STARTING_MINERALS           = "Additional Starting Minerals"

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -2034,6 +2034,10 @@ item_table = {
     item_names.PROGRESSIVE_WARP_RELOCATE:
         ItemData(813 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Progressive, 2, SC2Race.PROTOSS, quantity=2,
                  classification=ItemClassification.progression),
+    item_names.PROBE_WARPIN:
+        ItemData(814 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 13, SC2Race.PROTOSS),
+    item_names.ELDER_PROBES:
+        ItemData(815 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 14, SC2Race.PROTOSS),
 }
 
 # Add keys to item table


### PR DESCRIPTION
## What is this fixing or adding?

This adds 2 economic upgrades centered around Probe production, intended to be the Protoss counterpart to Twin Drones + Infested SCVs or CC Reactor + Mules.

# Probe Warpin
Very straight forward, allows you to warp in a probe at your nexus in addition to the regular build. 30 seconds cooldown, can store up to 2 charges. Just like other warpins you can use it on any visible location with a power field. This makes it useful beyond just the economical aspect to get probes to the front line instantly.
![grafik](https://github.com/user-attachments/assets/ddef9ec0-8057-4dd6-bcff-5027d536946a)

![GIF 19 01 2025 18-30-39](https://github.com/user-attachments/assets/4ca90af2-f1f6-41aa-9502-a60100ebf462)

# Elder Probes
Summons a group of 5 Probes at once. They have stronger stats and don't use supply, but you can only summon them once per map. 60 seconds initial cooldown, 200/100 cost, so discounted on minerals, but added gas.
![grafik](https://github.com/user-attachments/assets/e6613d9d-07f6-482b-9a07-71b42331ba84)
![grafik](https://github.com/user-attachments/assets/145d706e-5b39-429a-a655-1ecfef1b4923)

Includes some custom-made assets. Warp In Icon by Alice Voltaire. Wireframe assets for the Elder Probe by me.
Also included in this PR: Compressed versions for the Scout assets, using Aorta.

## How was this tested?

Local testmap for assets and functionality. Generated local campaign for item functionality and description.

[Data PR](https://github.com/Ziktofel/Archipelago-SC2-data/pull/361)