### PR TITLE
sc2: Adding a max_upgrade_level option to cap upgrade levels

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -394,6 +394,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             # but that's edge case enough I don't think we should warn about it.
             ConfigurableOptionInfo('soa_passive_presence', 'spear_of_adun_autonomously_cast_ability_presence', options.SpearOfAdunAutonomouslyCastAbilityPresence),
             ConfigurableOptionInfo('soa_passives_in_nobuilds', 'spear_of_adun_autonomously_cast_present_in_no_build', options.SpearOfAdunAutonomouslyCastPresentInNoBuild),
+            ConfigurableOptionInfo('max_upgrade_level', 'max_upgrade_level', options.MaxUpgradeLevel, ConfigurableOptionType.INTEGER),
             ConfigurableOptionInfo('minerals_per_item', 'minerals_per_item', options.MineralsPerItem, ConfigurableOptionType.INTEGER),
             ConfigurableOptionInfo('gas_per_item', 'vespene_per_item', options.VespenePerItem, ConfigurableOptionType.INTEGER),
             ConfigurableOptionInfo('supply_per_item', 'starting_supply_per_item', options.StartingSupplyPerItem, ConfigurableOptionType.INTEGER),

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -30,7 +30,7 @@ from .item.item_groups import item_name_groups, unlisted_item_name_groups
 from . import options
 from .options import (
     MissionOrder, KerriganPrimalStatus, kerrigan_unit_available, KerriganPresence, EnableMorphling,
-    GameSpeed, GenericUpgradeItems, GenericUpgradeResearch, ColorChoice, GenericUpgradeMissions,
+    GameSpeed, GenericUpgradeItems, GenericUpgradeResearch, ColorChoice, GenericUpgradeMissions, MaxUpgradeLevel,
     LocationInclusion, ExtraLocations, MasteryLocations, SpeedrunLocations, PreventativeLocations, ChallengeLocations,
     VanillaLocations,
     DisableForcedCamera, SkipCutscenes, GrantStoryTech, GrantStoryLevels, TakeOverAIAllies, RequiredTactics,
@@ -608,6 +608,7 @@ class SC2Context(CommonContext):
         self.announcements: queue.Queue = queue.Queue()
         self.sc2_run_task: typing.Optional[asyncio.Task] = None
         self.missions_unlocked: bool = False  # allow launching missions ignoring requirements
+        self.max_upgrade_level: int = MaxUpgradeLevel.default
         self.generic_upgrade_missions = 0
         self.generic_upgrade_research = 0
         self.generic_upgrade_items = 0
@@ -774,6 +775,7 @@ class SC2Context(CommonContext):
                 args["slot_data"].get("player_color_nova", ColorChoice.option_dark_grey)
             )
             self.generic_upgrade_missions = args["slot_data"].get("generic_upgrade_missions", GenericUpgradeMissions.default)
+            self.max_upgrade_level = args["slot_data"].get("max_upgrade_level", MaxUpgradeLevel.default)
             self.generic_upgrade_items = args["slot_data"].get("generic_upgrade_items", GenericUpgradeItems.option_individual_items)
             self.generic_upgrade_research = args["slot_data"].get("generic_upgrade_research", GenericUpgradeResearch.option_vanilla)
             self.kerrigan_presence = args["slot_data"].get("kerrigan_presence", KerriganPresence.option_vanilla)
@@ -1363,7 +1365,8 @@ def calculate_items(ctx: SC2Context) -> typing.Dict[SC2Race, typing.List[int]]:
         total_missions = sum(len(column) for campaign in ctx.custom_mission_order for layout in campaign.layouts for column in layout.missions)
         num_missions = int((ctx.generic_upgrade_missions / 100) * total_missions)
         completed = len([mission_id for mission_id in ctx.mission_id_to_location_ids if ctx.is_mission_completed(mission_id)])
-        upgrade_count = min(completed // num_missions, WEAPON_ARMOR_UPGRADE_MAX_LEVEL) if num_missions > 0 else WEAPON_ARMOR_UPGRADE_MAX_LEVEL
+        upgrade_count = min(completed // num_missions, ctx.max_upgrade_level) if num_missions > 0 else ctx.max_upgrade_level
+        upgrade_count = min(upgrade_count, WEAPON_ARMOR_UPGRADE_MAX_LEVEL)
 
         # Equivalent to "Progressive Weapon/Armor Upgrade" item
         global_upgrades: typing.Set[str] = upgrade_included_names[GenericUpgradeItems.option_bundle_all]

--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -768,6 +768,7 @@ item_name_groups[ItemGroupNames.OVERPOWERED_ITEMS] = [
     item_names.KERRIGAN_APOCALYPSE,
     item_names.KERRIGAN_DROP_PODS,
     item_names.KERRIGAN_SPAWN_LEVIATHAN,
+    item_names.KERRIGAN_IMMOBILIZATION_WAVE,
 
     item_names.REAVER_RESOURCE_EFFICIENCY,
     item_names.SOA_TIME_STOP,

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -422,6 +422,14 @@ class VoidTradeAgeLimit(Choice):
     default = option_30_minutes
 
 
+class MaxUpgradeLevel(Range):
+    """Controls the maximum number of weapon/armor upgrades that can be found or unlocked."""
+    display_name = "Maximum upgrade level"
+    range_start = 3
+    range_end = 5
+    default = 3
+
+
 class GenericUpgradeMissions(Range):
     """
     Determines the percentage of missions in the mission order that must be completed before
@@ -480,6 +488,7 @@ class GenericUpgradeItems(Choice):
 
 class VanillaItemsOnly(Toggle):
     """If turned on, the item pool is limited only to items that appear in the main 3 vanilla campaigns.
+    Weapon/Armour upgrades are unaffected; use max_upgrade_level to control maximum level.
     locked_items may override these exclusions."""
     display_name = "Vanilla Items Only"
 
@@ -1055,8 +1064,8 @@ class MissionOrderScouting(Choice):
     None: Never provide information
     Completed: Only for missions that were completed 
     Available: Only for missions that are available to play
-    Layout: Only for missions that are in a acessible layout (e.g. Char, Mar Sara, etc.)
-    Campaign: Only for missions that are in a acessible campaign (e.g. WoL, HotS, etc.)
+    Layout: Only for missions that are in an accessible layout (e.g. Char, Mar Sara, etc.)
+    Campaign: Only for missions that are in an accessible campaign (e.g. WoL, HotS, etc.)
     All: All missions
     """
     display_name = "Mission Order Scouting"
@@ -1258,6 +1267,7 @@ class Starcraft2Options(PerGameCommonOptions):
     ensure_generic_items: EnsureGenericItems
     min_number_of_upgrades: MinNumberOfUpgrades
     max_number_of_upgrades: MaxNumberOfUpgrades
+    max_upgrade_level: MaxUpgradeLevel
     generic_upgrade_missions: GenericUpgradeMissions
     generic_upgrade_research: GenericUpgradeResearch
     generic_upgrade_items: GenericUpgradeItems

--- a/worlds/sc2/test/test_rules.py
+++ b/worlds/sc2/test/test_rules.py
@@ -5,7 +5,7 @@ import unittest
 from typing import List, Set, Iterable
 
 from BaseClasses import ItemClassification, MultiWorld
-from Options import *  # Mandatory
+import Options as CoreOptions
 from worlds.sc2 import options, locations
 from worlds.sc2.item import item_tables
 
@@ -81,6 +81,8 @@ class TestWorld:
             if isinstance(field_class, str):
                 if field_class in globals():
                     field_class = globals()[field_class]
+                else:
+                    field_class = CoreOptions.__dict__[field.type]
             defaults[option_name] = field_class(options.get_option_value(None, option_name))
         self.options: options.Starcraft2Options = options.Starcraft2Options(**defaults)
 


### PR DESCRIPTION
## What is this fixing or adding?
Adding an option to cap weapon/armour levels. This is to deal with a few things:
* Vanilla items only did not account for level 5 not being vanilla. Added a note to the option to check upgrade level for that.
* There is no way to get vanilla / last release behaviour with generic_upgrade_missions.

## How was this tested?
* Added a unit test for correct handling of item filtering
* Generated a world with `generic_upgrade_missions: 1, max_upgrade_level: 4` and beat a few missions (3/45, ie >5%), verified that the upgrade level capped at 4.

## If this makes graphical changes, please attach screenshots.
None