### PR TITLE
SC2: Add Instigator Reconstruction

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -904,6 +904,7 @@ item_descriptions = {
     item_names.STALKER_INSTIGATOR_SLAYER_DISINTEGRATING_PARTICLES: "Increases weapon damage of Stalkers, Instigators, and Slayers.",
     item_names.STALKER_INSTIGATOR_SLAYER_PARTICLE_REFLECTION: "Attacks fired by Stalkers, Instigators, and Slayers have a chance to bounce to additional targets for reduced damage.",
     item_names.INSTIGATOR_BLINK_OVERDRIVE: "Instigators gain +2 maximum blink charges and +1 blink range.",
+    item_names.INSTIGATOR_RECONSTRUCTION: "Instigators gain the Reconstruction ability, allowing them to be reconstructed on death with a 240 seconds cooldown. Using Blink reduces the cooldown.",
     item_names.DRAGOON_HIGH_IMPACT_PHASE_DISRUPTORS: "Dragoons deal increased damage.",
     item_names.DRAGOON_TRILLIC_COMPRESSION_SYSTEM: "Dragoons gain +20 life and their shield regeneration rate is doubled. Allows Dragoons to regenerate shields in combat.",
     item_names.DRAGOON_SINGULARITY_CHARGE: "Increases Dragoon range by +2.",

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -718,6 +718,7 @@ ADEPT_PHASE_BULWARK                                     = "Phase Bulwark (Adept)
 STALKER_INSTIGATOR_SLAYER_DISINTEGRATING_PARTICLES      = "Disintegrating Particles (Stalker/Instigator/Slayer)"
 STALKER_INSTIGATOR_SLAYER_PARTICLE_REFLECTION           = "Particle Reflection (Stalker/Instigator/Slayer)"
 INSTIGATOR_BLINK_OVERDRIVE                              = "Blink Overdrive (Instigator)"
+INSTIGATOR_RECONSTRUCTION                               = "Reconstruction (Instigator)"
 DRAGOON_HIGH_IMPACT_PHASE_DISRUPTORS                    = "High Impact Phase Disruptor (Dragoon)"
 DRAGOON_TRILLIC_COMPRESSION_SYSTEM                      = "Trillic Compression System (Dragoon)"
 DRAGOON_SINGULARITY_CHARGE                              = "Singularity Charge (Dragoon)"

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1932,6 +1932,7 @@ item_table = {
     item_names.MISTWING_NULL_SHROUD: ItemData(413 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_4, 23, SC2Race.PROTOSS, parent=item_names.MISTWING),
     item_names.MISTWING_PILOT: ItemData(414 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_4, 24, SC2Race.PROTOSS, parent=item_names.MISTWING),
     item_names.INSTIGATOR_BLINK_OVERDRIVE: ItemData(415 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_4, 25, SC2Race.PROTOSS, parent=item_names.INSTIGATOR),
+    item_names.INSTIGATOR_RECONSTRUCTION: ItemData(416 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_4, 26, SC2Race.PROTOSS, parent=item_names.INSTIGATOR),
 
 
     # War Council


### PR DESCRIPTION
## What is this fixing or adding?
Adds a new item to the Instigator (Stalker Purifier): 
### Reconstruction
![grafik](https://github.com/user-attachments/assets/6bb6246c-e863-4b9a-88ad-6af3cceea252)
Works similar to the Sentinel variant. Upon taking fatal damage, you are revived after a couple of seconds, and you cannot be revived anymore for a long cooldown. Instigators can reduce the cooldown by using blink.
![GIF_20 01 2025_12-53-06](https://github.com/user-attachments/assets/e598e757-53cf-47f3-bda7-35adce951377)

Includes a custom icon. Also note that it requires a trigger in the Player mod.

## How was this tested?

Local test map for assets and functionality. Local campaign for item functionality and description. Tested interaction with some other items, notably Guardian Shell.

[Data PR](https://github.com/Ziktofel/Archipelago-SC2-data/pull/363)
