### PR TITLE
sc2: Adding host settings to override the value of disable_forced_camera and skip_cutscenes

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -697,6 +697,15 @@ class SC2Context(CommonContext):
             self.all_in_choice = args["slot_data"]["all_in_map"]
             self.slot_data_version = args["slot_data"].get("version", 2)
 
+            if str(SC2World.settings.disable_forced_camera).casefold() == 'true':
+                self.disable_forced_camera = DisableForcedCamera.option_true
+            elif str(SC2World.settings.disable_forced_camera).casefold() == 'false':
+                self.disable_forced_camera = DisableForcedCamera.option_false
+            if str(SC2World.settings.skip_cutscenes).casefold() == 'true':
+                self.skip_cutscenes = SkipCutscenes.option_true
+            elif str(SC2World.settings.skip_cutscenes).casefold() == 'false':
+                self.skip_cutscenes = SkipCutscenes.option_false
+
             if self.slot_data_version < 4:
                 # Maintaining backwards compatibility with older slot data
                 slot_req_table: dict = args["slot_data"]["mission_req"]

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -29,7 +29,7 @@ from .item import item_names, item_parents
 from .item.item_groups import item_name_groups, unlisted_item_name_groups
 from . import options
 from .options import (
-    MissionOrder, KerriganPrimalStatus, kerrigan_unit_available, KerriganPresence, EnableMorphling,
+    MissionOrder, KerriganPrimalStatus, kerrigan_unit_available, KerriganPresence, EnableMorphling, GameDifficulty,
     GameSpeed, GenericUpgradeItems, GenericUpgradeResearch, ColorChoice, GenericUpgradeMissions, MaxUpgradeLevel,
     LocationInclusion, ExtraLocations, MasteryLocations, SpeedrunLocations, PreventativeLocations, ChallengeLocations,
     VanillaLocations,
@@ -381,6 +381,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         LOGIC_WARNING = f"  *Note changing this may result in logically unbeatable games*\n"
 
         configurable_options = (
+            ConfigurableOptionInfo('speed', 'game_speed', options.GameSpeed),
             ConfigurableOptionInfo('kerrigan_presence', 'kerrigan_presence', options.KerriganPresence, can_break_logic=True),
             ConfigurableOptionInfo('kerrigan_level_cap', 'kerrigan_total_level_cap', options.KerriganTotalLevelCap, ConfigurableOptionType.INTEGER, can_break_logic=True),
             ConfigurableOptionInfo('kerrigan_mission_level_cap', 'kerrigan_levels_per_mission_completed_cap', options.KerriganLevelsPerMissionCompletedCap, ConfigurableOptionType.INTEGER),
@@ -673,6 +674,38 @@ class SC2Context(CommonContext):
     
     def trade_storage_slot(self) -> str:
         return f"{TRADE_DATASTORAGE_SLOT}{self.slot}"
+    
+    def _apply_host_settings_to_options(self) -> None:
+        if str(SC2World.settings.game_difficulty).casefold() == 'casual':
+            self.difficulty = GameDifficulty.option_casual
+        elif str(SC2World.settings.game_difficulty).casefold() == 'normal':
+            self.difficulty = GameDifficulty.option_normal
+        elif str(SC2World.settings.game_difficulty).casefold() == 'hard':
+            self.difficulty = GameDifficulty.option_hard
+        elif str(SC2World.settings.game_difficulty).casefold() == 'brutal':
+            self.difficulty = GameDifficulty.option_brutal
+
+        if str(SC2World.settings.game_speed).casefold() == 'slower':
+            self.game_speed = GameSpeed.option_slower
+        elif str(SC2World.settings.game_speed).casefold() == 'slow':
+            self.game_speed = GameSpeed.option_slow
+        elif str(SC2World.settings.game_speed).casefold() == 'normal':
+            self.game_speed = GameSpeed.option_normal
+        elif str(SC2World.settings.game_speed).casefold() == 'fast':
+            self.game_speed = GameSpeed.option_fast
+        elif str(SC2World.settings.game_speed).casefold() == 'faster':
+            self.game_speed = GameSpeed.option_faster
+
+        if str(SC2World.settings.disable_forced_camera).casefold() == 'true':
+            self.disable_forced_camera = DisableForcedCamera.option_true
+        elif str(SC2World.settings.disable_forced_camera).casefold() == 'false':
+            self.disable_forced_camera = DisableForcedCamera.option_false
+
+        if str(SC2World.settings.skip_cutscenes).casefold() == 'true':
+            self.skip_cutscenes = SkipCutscenes.option_true
+        elif str(SC2World.settings.skip_cutscenes).casefold() == 'false':
+            self.skip_cutscenes = SkipCutscenes.option_false
+
 
     def on_package(self, cmd: str, args: dict) -> None:
         if cmd == "Connected":
@@ -697,14 +730,7 @@ class SC2Context(CommonContext):
             self.all_in_choice = args["slot_data"]["all_in_map"]
             self.slot_data_version = args["slot_data"].get("version", 2)
 
-            if str(SC2World.settings.disable_forced_camera).casefold() == 'true':
-                self.disable_forced_camera = DisableForcedCamera.option_true
-            elif str(SC2World.settings.disable_forced_camera).casefold() == 'false':
-                self.disable_forced_camera = DisableForcedCamera.option_false
-            if str(SC2World.settings.skip_cutscenes).casefold() == 'true':
-                self.skip_cutscenes = SkipCutscenes.option_true
-            elif str(SC2World.settings.skip_cutscenes).casefold() == 'false':
-                self.skip_cutscenes = SkipCutscenes.option_false
+            self._apply_host_settings_to_options()
 
             if self.slot_data_version < 4:
                 # Maintaining backwards compatibility with older slot data

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -706,7 +706,6 @@ class SC2Context(CommonContext):
         elif str(SC2World.settings.skip_cutscenes).casefold() == 'false':
             self.skip_cutscenes = SkipCutscenes.option_false
 
-
     def on_package(self, cmd: str, args: dict) -> None:
         if cmd == "Connected":
             # Set up the trade storage

--- a/worlds/sc2/settings.py
+++ b/worlds/sc2/settings.py
@@ -15,10 +15,16 @@ class Starcraft2Settings(settings.Group):
         """Defines the colour of zerg mission buttons in the launcher in rgb format (3 elements ranging from 0 to 1)"""
     class ProtossButtonColor(list):
         """Defines the colour of protoss mission buttons in the launcher in rgb format (3 elements ranging from 0 to 1)"""
+    class DisableForcedCamera(str):
+        """Overrides the disable forced-camera slot option. Possible values: `true`, `false`, `default`. Default uses slot value"""
+    class SkipCutscenes(str):
+        """Overrides the skip cutscenes slot option. Possible values: `true`, `false`, `default`. Default uses slot value"""
 
     window_width = WindowWidth(1080)
     window_height = WindowHeight(720)
     game_windowed_mode: Union[GameWindowedMode, bool] = False
+    disable_forced_camera = DisableForcedCamera('default')
+    skip_cutscenes = SkipCutscenes('default')
     terran_button_color = TerranButtonColor([0.0838, 0.2898, 0.2346])
     zerg_button_color = ZergButtonColor([0.345, 0.22425, 0.12765])
     protoss_button_color = ProtossButtonColor([0.18975, 0.2415, 0.345])

--- a/worlds/sc2/settings.py
+++ b/worlds/sc2/settings.py
@@ -19,12 +19,18 @@ class Starcraft2Settings(settings.Group):
         """Overrides the disable forced-camera slot option. Possible values: `true`, `false`, `default`. Default uses slot value"""
     class SkipCutscenes(str):
         """Overrides the skip cutscenes slot option. Possible values: `true`, `false`, `default`. Default uses slot value"""
+    class GameDifficulty(str):
+        """Overrides the slot's difficulty setting. Possible values: `casual`, `normal`, `hard`, `brutal`, `default`. Default uses slot value"""
+    class GameSpeed(str):
+        """Overrides the slot's gamespeed setting. Possible values: `slower`, `slow`, `normal`, `fast`, `faster`, `default`. Default uses slot value"""
 
     window_width = WindowWidth(1080)
     window_height = WindowHeight(720)
     game_windowed_mode: Union[GameWindowedMode, bool] = False
-    disable_forced_camera = DisableForcedCamera('default')
-    skip_cutscenes = SkipCutscenes('default')
+    disable_forced_camera = DisableForcedCamera("default")
+    skip_cutscenes = SkipCutscenes("default")
+    game_difficulty = GameDifficulty("default")
+    game_speed = GameSpeed("default")
     terran_button_color = TerranButtonColor([0.0838, 0.2898, 0.2346])
     zerg_button_color = ZergButtonColor([0.345, 0.22425, 0.12765])
     protoss_button_color = ProtossButtonColor([0.18975, 0.2415, 0.345])


### PR DESCRIPTION
## What is this fixing or adding?
Adding new host settings:
```yaml
sc2_options:
  game_speed: slower | slow | normal | fast | faster | default
  game_difficulty: casual | normal | hard | brutal | default
  skip_cutscenes: true | false | default
  disable_forced_camera: true | false | default
```
`skip_cutscenes` and `disable_forced_camera` host settings have been requested by Figment a few times and I've wanted it myself. It allows the user to force these values to true / false regardless of what the slot's yaml option was. This is particularly useful for the big async or asyncs that allow anyone to drop into a slot.

~~This was easier to implement than expected; we may want similar host options for difficulty and gamespeed.~~

edit: Implemented the additional options as well. Added `/option speed` as there didn't seem to be a way to change / check the value already.

## How was this tested?
* Set boolean options to true or false while connecting to a world with the option set to true. Verified the correct value with `/option`.
* Set boolean options to true, false, or some other string ("world", or "default") while connecting to a slot with the option set to false. Verified the correct value with `/option`.
* Set the difficulty to normal or norma before restarting, verified the first caused the client to go to normal and the latter left it on brutal
* Set the gamespeed to slow, verified it went to slow. Removed it, restarted, verified it went back to faster.

## If this makes graphical changes, please attach screenshots.
None