### PR TITLE
sc2: Making Devil's Playground east reinforcements no longer challenge

### DIFF
--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -596,7 +596,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 or logic.terran_basic_anti_air(state)
                     and (logic.terran_common_unit(state) or state.has(item_names.REAPER, player)))
         ),
-        make_location_data(SC2Mission.DEVILS_PLAYGROUND.mission_name, "East Reapers", SC2WOL_LOC_ID_OFFSET + 1307, LocationType.CHALLENGE,
+        make_location_data(SC2Mission.DEVILS_PLAYGROUND.mission_name, "East Reapers", SC2WOL_LOC_ID_OFFSET + 1307, LocationType.EXTRA,
             lambda state: (
                 logic.terran_basic_anti_air(state)
                 and (adv_tactics
@@ -3284,7 +3284,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 or logic.zerg_basic_kerriganless_anti_air(state)
                     and (logic.zerg_common_unit(state) or state.has(item_names.HUNTERLING, player)))
         ),
-        make_location_data(SC2Mission.DEVILS_PLAYGROUND_Z.mission_name, "East Reinforcements", SC2_RACESWAP_LOC_ID_OFFSET + 2507, LocationType.CHALLENGE,
+        make_location_data(SC2Mission.DEVILS_PLAYGROUND_Z.mission_name, "East Reinforcements", SC2_RACESWAP_LOC_ID_OFFSET + 2507, LocationType.EXTRA,
             lambda state: (
                 logic.zerg_basic_kerriganless_anti_air(state)
                 and (adv_tactics
@@ -3318,7 +3318,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 or logic.protoss_basic_anti_air(state)
                     and logic.protoss_common_unit(state))
         ),
-        make_location_data(SC2Mission.DEVILS_PLAYGROUND_P.mission_name, "East Reinforcements", SC2_RACESWAP_LOC_ID_OFFSET + 2607, LocationType.CHALLENGE,
+        make_location_data(SC2Mission.DEVILS_PLAYGROUND_P.mission_name, "East Reinforcements", SC2_RACESWAP_LOC_ID_OFFSET + 2607, LocationType.EXTRA,
             lambda state: (
                 logic.protoss_basic_anti_air(state)
                 and (adv_tactics


### PR DESCRIPTION
## What is this fixing or adding?
This has been discussed a few times, but bumped into it again in the UI today and decided to fix it. With the addition of the zerg cleared objective, I don't think the east reapers really count as a challenge, so returning it to extra to match the other reaper locations. Gemster has also brought this up several times.

## How was this tested?
Ran unit tests. Did a couple of test gens.

## If this makes graphical changes, please attach screenshots.
Gen with extra locations disabled:
![image](https://github.com/user-attachments/assets/af822f9b-e11c-4eda-8e95-e94f711f18f9)
gen with extra locations enabled:
![image](https://github.com/user-attachments/assets/17f17a9b-280e-4970-bdd2-dedb2365f7c4)
