### PR TITLE
sc2: standardizing royal guard descriptions; clarifying they don't get w/a upgrades

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -109,6 +109,10 @@ def _ability_desc(unit_name_plural: str, ability_name: str, ability_description:
     return f"{unit_name_plural} gain the {ability_name} ability{suffix}."
 
 
+def _royal_guard_desc(base_unit_name: str) -> str:
+    return f"Royal Guard {base_unit_name}. Royal Guard units do not benefit from weapon and armour upgrades."
+
+
 item_descriptions = {
     item_names.MARINE: "General-purpose infantry.",
     item_names.MEDIC: "Support trooper. Heals nearby biological units.",
@@ -153,24 +157,18 @@ item_descriptions = {
     item_names.WARHOUND: "Anti-vehicle mech. Haywire missiles do bonus damage to mechanical units.",
     item_names.DOMINION_TROOPER:
         "General-purpose infantry. Can be outfitted with weapons for different combat situations.",
-    item_names.PRIDE_OF_AUGUSTRGRAD: "Powerful Royal Guard warship.",
-    item_names.SKY_FURY: inspect.cleandoc("""
-        Durable Royal Guard support flyer. Loaded with strong anti-capital air missiles. 
-        Can switch into Assault Mode to attack ground units.
-    """),
-    item_names.SHOCK_DIVISION: "Royal Guard heavy tank. Long-range artillery in Siege Mode.",
-    item_names.BLACKHAMMER: "Royal Guard heavy assault mech.",
-    item_names.AEGIS_GUARD: "Royal Guard heavy assault infantry.",
-    item_names.EMPERORS_SHADOW: "Royal Guard specialist. Can use Pyrokinetic Immolation and EMP Blast abilities. Can call down Tactical missiles.",
-    item_names.SON_OF_KORHAL: "Royal Guard general-purpose indantry.",
-    item_names.BULWARK_COMPANY: "Royal Guard heavy-fire support unit.",
-    item_names.FIELD_RESPONSE_THETA: "Royal Guard support trooper. Heals nearby biological units.",
-    item_names.EMPERORS_GUARDIAN: inspect.cleandoc("""
-        Royal Guard artillery fighter. Loaded with missiles that deal area damage to enemy air targets. 
-        Can switch into Defender Mode to provide siege support.
-    """),
-    item_names.NIGHT_HAWK: "Royal Guard highly mobile flying unit. Excellent at surgical strikes.",
-    item_names.NIGHT_WOLF: "Royal Guard tactical-strike aircraft.",
+    item_names.SON_OF_KORHAL: _royal_guard_desc("Marine"),
+    item_names.FIELD_RESPONSE_THETA: _royal_guard_desc("Medic"),
+    item_names.AEGIS_GUARD: _royal_guard_desc("Marauder"),
+    item_names.EMPERORS_SHADOW: _royal_guard_desc("Ghost"),
+    item_names.BULWARK_COMPANY: _royal_guard_desc("Goliath"),
+    item_names.SHOCK_DIVISION: _royal_guard_desc("Siege Tank"),
+    item_names.BLACKHAMMER: _royal_guard_desc("Thor"),
+    item_names.NIGHT_HAWK: _royal_guard_desc("Wraith"),
+    item_names.EMPERORS_GUARDIAN: _royal_guard_desc("Liberator"),
+    item_names.SKY_FURY: _royal_guard_desc("Viking"),
+    item_names.NIGHT_WOLF: _royal_guard_desc("Banshee"),
+    item_names.PRIDE_OF_AUGUSTRGRAD: _royal_guard_desc("Battlecruiser"),
     item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON: GENERIC_UPGRADE_TEMPLATE.format("damage", TERRAN, "infantry"),
     item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR: GENERIC_UPGRADE_TEMPLATE.format("armor", TERRAN, "infantry"),
     item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON: GENERIC_UPGRADE_TEMPLATE.format("damage", TERRAN, "vehicles"),

--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -110,7 +110,7 @@ def _ability_desc(unit_name_plural: str, ability_name: str, ability_description:
 
 
 def _royal_guard_desc(base_unit_name: str) -> str:
-    return f"Royal Guard {base_unit_name}. Royal Guard units do not benefit from weapon and armour upgrades."
+    return f"Royal Guard {base_unit_name}. Royal Guard units do not benefit from weapon and armor upgrades."
 
 
 item_descriptions = {
@@ -568,7 +568,7 @@ item_descriptions = {
         Level 2: Nova is permanently cloaked.
     """),
     item_names.NOVA_ENERGY_SUIT_MODULE: "Increases Nova's maximum energy and energy regeneration rate.",
-    item_names.NOVA_ARMORED_SUIT_MODULE: "Increases Nova's health by 100 and armour by 1. Nova also regenerates life quickly out of combat.",
+    item_names.NOVA_ARMORED_SUIT_MODULE: "Increases Nova's health by 100 and armor by 1. Nova also regenerates life quickly out of combat.",
     item_names.NOVA_JUMP_SUIT_MODULE: "Increases Nova's movement speed and allows her to jump up and down cliffs.",
     item_names.NOVA_C20A_CANISTER_RIFLE: "Allows Nova to equip the C20A Canister Rifle, which has a ranged attack and allows Nova to cast Snipe.",
     item_names.NOVA_HELLFIRE_SHOTGUN: "Allows Nova to equip the Hellfire Shotgun, which has a short-range area attack in a cone and allows Nova to cast Penetrating Blast.",
@@ -620,7 +620,7 @@ item_descriptions = {
     item_names.ZERGLING_ADRENAL_OVERLOAD: "Increases Zergling attack speed.",
     item_names.ZERGLING_METABOLIC_BOOST: "Increases Zergling movement speed.",
     item_names.ROACH_HYDRIODIC_BILE: "Roaches deal +8 damage to light targets.",
-    item_names.ROACH_ADAPTIVE_PLATING: "Roaches gain +3 armour when their life is below 50%.",
+    item_names.ROACH_ADAPTIVE_PLATING: "Roaches gain +3 armor when their life is below 50%.",
     item_names.ROACH_TUNNELING_CLAWS: "Allows Roaches to move while burrowed.",
     item_names.HYDRALISK_FRENZY: "Allows Hydralisks to use the Frenzy ability, which increases their attack speed by 50%.",
     item_names.HYDRALISK_ANCILLARY_CARAPACE: "Hydralisks gain +20 health.",
@@ -645,7 +645,7 @@ item_descriptions = {
     item_names.SCOURGE_VIRULENT_SPORES: "Scourge will deal splash damage.",
     item_names.SCOURGE_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(item_names.SCOURGE),
     item_names.SCOURGE_SWARM_SCOURGE: "An extra Scourge will be built from each egg at no additional cost.",
-    item_names.ZERGLING_SHREDDING_CLAWS: "Zergling attacks will temporarily reduce their target's armour to 0.",
+    item_names.ZERGLING_SHREDDING_CLAWS: "Zergling attacks will temporarily reduce their target's armor to 0.",
     item_names.ROACH_GLIAL_RECONSTITUTION: "Increases Roach movement speed.",
     item_names.ROACH_ORGANIC_CARAPACE: "Increases Roach health by +25.",
     item_names.HYDRALISK_MUSCULAR_AUGMENTS: "Increases Hydralisk movement speed.",
@@ -869,7 +869,7 @@ item_descriptions = {
     item_names.DESTROYER: "Area assault craft. Can use the Destruction Beam ability to attack multiple units at once.",
     item_names.INTERCESSOR: "Support craft. Applies a stacking slow, and targets with maximum slow stacks take increased damage from all sources.",
     item_names.DAWNBRINGER: "Flying Anti-Surface Assault Ship. Attacks in an area around the target. Attack count increases as it continues firing.",
-    item_names.SCOUT: "Versatile high-speed fighter. Has a powerful anti-armoured air attack and a weaker anti-ground attack.",
+    item_names.SCOUT: "Versatile high-speed fighter. Has a powerful anti-armored air attack and a weaker anti-ground attack.",
     item_names.OPPRESSOR: "Tal'Darim Scout variant. Has a weaker air attack, but a stronger ground attack. Can use the Vulcan Blaster ability.",
     item_names.CALADRIUS: "Purifier Scout variant. Has no ground attack, but a stronger air attack, which can be upgraded to hit multiple targets. Can use the Corona Beam ability.",
     item_names.MISTWING: "Nerazim Scout variant. Specialized stealth fighter. Can use the Cloak, Phantom Dash and Pilot (Transport) abilities.",
@@ -939,7 +939,7 @@ item_descriptions = {
     item_names.ARBITER_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(item_names.ARBITER),
     item_names.ARBITER_ENHANCED_CLOAK_FIELD: "Increases Arbiter Cloaking Field range.",
     item_names.CARRIER_TRIREME_GRAVITON_CATAPULT: "Carriers and Triremes can launch Interceptors and Bombers more quickly.",
-    item_names.CARRIER_SKYLORD_TRIREME_HULL_OF_PAST_GLORIES: "Carrier-class ships gain +2 armour.",
+    item_names.CARRIER_SKYLORD_TRIREME_HULL_OF_PAST_GLORIES: "Carrier-class ships gain +2 armor.",
     item_names.VOID_RAY_DESTROYER_INTERCESSOR_DAWNBRINGER_FLUX_VANES: "Increases movement speed of Void Ray variants.",
     item_names.DAWNBRINGER_ANTI_SURFACE_COUNTERMEASURES: "Dawnbringers take reduced damage from non-spell ground sources.",
     item_names.DAWNBRINGER_ENHANCED_SHIELD_GENERATOR: "Increases Dawnbringer maximum shields by +50.",
@@ -1068,7 +1068,7 @@ item_descriptions = {
     item_names.SOA_TIME_STOP: "The Spear of Adun freezes all enemy units and structures in time for 20 seconds.",
     item_names.SOA_SOLAR_BOMBARDMENT: "The Spear of Adun fires 200 laser blasts randomly over a wide area.",
     item_names.MATRIX_OVERLOAD: "All friendly units gain 25% movement speed and 15% attack speed within a Pylon's power field and for 15 seconds after leaving it.",
-    item_names.QUATRO: "All friendly Protoss units gain the equivalent of their +1 armour, attack, and shield upgrades.",
+    item_names.QUATRO: "All friendly Protoss units gain the equivalent of their +1 armor, attack, and shield upgrades.",
     item_names.NEXUS_OVERCHARGE: "The Protoss Nexus gains a long-range auto-attack.",
     item_names.ORBITAL_ASSIMILATORS: "Assimilators automatically harvest Vespene Gas without the need for Probes.",
     item_names.WARP_HARMONIZATION: "Stargates and Robotics Facilities can transform to utilize Warp In technology. Warp In cooldowns are 20% faster than original build times.",

--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -108,7 +108,7 @@ class ItemGroupNames:
     TERRAN_ORIGINAL_PROGRESSIVE_UPGRADES = "Terran Original Progressive Upgrades"
     """Progressive items where level 1 appeared in WoL"""
     MENGSK_UNITS = "Mengsk Units"
-    TERRAN_VETERANCY_UNITS = "Terran Veterancy Units"
+    TERRAN_ROYAL_GUARD_UNITS = "Terran Royal Guard Units"
     ORBITAL_COMMAND_ABILITIES = "Orbital Command Abilities"
 
     ZERG_ITEMS = "Zerg Items"
@@ -267,10 +267,14 @@ item_name_groups[ItemGroupNames.MENGSK_UNITS] = [
     item_names.PRIDE_OF_AUGUSTRGRAD, item_names.SKY_FURY,
     item_names.DOMINION_TROOPER,
 ]
-item_name_groups[ItemGroupNames.TERRAN_VETERANCY_UNITS] = [
-    item_names.AEGIS_GUARD, item_names.EMPERORS_SHADOW, item_names.SHOCK_DIVISION, item_names.BLACKHAMMER,
-    item_names.PRIDE_OF_AUGUSTRGRAD, item_names.SKY_FURY, item_names.SON_OF_KORHAL, item_names.FIELD_RESPONSE_THETA,
-    item_names.BULWARK_COMPANY, item_names.NIGHT_HAWK, item_names.EMPERORS_GUARDIAN, item_names.NIGHT_WOLF,
+item_name_groups[ItemGroupNames.TERRAN_ROYAL_GUARD_UNITS] = [
+    item_names.SON_OF_KORHAL, item_names.FIELD_RESPONSE_THETA,
+    item_names.AEGIS_GUARD, item_names.EMPERORS_SHADOW,
+    item_names.BULWARK_COMPANY, item_names.SHOCK_DIVISION,
+    item_names.BLACKHAMMER,
+    item_names.EMPERORS_GUARDIAN, item_names.SKY_FURY,
+    item_names.NIGHT_HAWK, item_names.NIGHT_WOLF,
+    item_names.PRIDE_OF_AUGUSTRGRAD,
 ]
 item_name_groups[ItemGroupNames.ORBITAL_COMMAND_ABILITIES] = orbital_command_abilities = [
     item_names.COMMAND_CENTER_SCANNER_SWEEP,

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1052,7 +1052,7 @@ item_table = {
         ItemData(755 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 9, SC2Race.TERRAN,
                  parent=item_names.MEDIVAC),
     item_names.EMPERORS_SHADOW_SOVEREIGN_TACTICAL_MISSILES:
-        ItemData(756 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 10, SC2Race.TERRAN,
+        ItemData(756 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 10, SC2Race.TERRAN, quantity=0,
                  parent=item_names.EMPERORS_SHADOW),
     item_names.DOMINION_TROOPER_B2_HIGH_CAL_LMG:
         ItemData(757 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 11, SC2Race.TERRAN,

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -76,7 +76,7 @@ class TestItemFiltering(Sc2SetupTestBase):
                 item_names.GHOST: 0,
                 item_names.SPECTRE: 0,
                 item_groups.ItemGroupNames.MENGSK_UNITS: 0,
-                item_groups.ItemGroupNames.TERRAN_VETERANCY_UNITS: 0,
+                item_groups.ItemGroupNames.TERRAN_ROYAL_GUARD_UNITS: 0,
             },
             'unexcluded_items': {
                 item_names.NOVA_PLASMA_RIFLE: 1,      # Necessary to pass logic
@@ -815,7 +815,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             },
             # Exclude many items to get filler to generate
             'excluded_items': {
-                item_groups.ItemGroupNames.TERRAN_VETERANCY_UNITS: 0,
+                item_groups.ItemGroupNames.TERRAN_ROYAL_GUARD_UNITS: 0,
             },
             'max_number_of_upgrades': 2,
             'mission_order': options.MissionOrder.option_grid,
@@ -848,7 +848,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             },
             # Exclude many items to get filler to generate
             'excluded_items': {
-                item_groups.ItemGroupNames.TERRAN_VETERANCY_UNITS: 0,
+                item_groups.ItemGroupNames.TERRAN_ROYAL_GUARD_UNITS: 0,
                 item_groups.ItemGroupNames.ZERG_MORPHS: 0,
             },
             'max_number_of_upgrades': 2,


### PR DESCRIPTION
## What is this fixing or adding?
Client-side description changes for RG balance changes. WIP
Pairs with [data PR #369](https://github.com/Ziktofel/Archipelago-SC2-data/pull/369)

May also split some unit upgrades into base unit / RG versions. tbd

## How was this tested?
Ran unit tests. See data PR.

## If this makes graphical changes, please attach screenshots.
None.