### PR TITLE
SC2: Adding Infested Bullfrog

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -606,6 +606,7 @@ item_descriptions = {
     item_names.INFESTED_MISSILE_TURRET: "Anti-air defensive structure. Detects cloaked units and can uproot.",
     item_names.INFESTED_SIEGE_TANK: "Siege tank. Can uproot itself to provide mobile tank support.",
     item_names.INFESTED_DIAMONDBACK: "Fast, high-damage attacker. Can attack while moving and can bring flying units to the ground.",
+    item_names.INFESTED_BULLFROG: "Grounded transport. Launches itself through the air, dealing damage and unloading cargo on impact.",
     item_names.INFESTED_BANSHEE: "Tactical-strike aircraft. Can cloak and can be upgraded to burrow.",
     item_names.INFESTED_LIBERATOR: "Anti-Air flying attacker. Attacks deal high area-damage.",
     item_names.PROGRESSIVE_ZERG_MELEE_ATTACK: GENERIC_UPGRADE_TEMPLATE.format("damage", ZERG, "melee ground units"),
@@ -754,6 +755,10 @@ item_descriptions = {
         Level 1: Infested Diamondbacks gain the Fungal Snare ability, allowing them to temporarily ground flying units.
         Level 2: Infested Diamondback Fungal Snare ability cooldown reduced by 15 seconds.
     """),
+    item_names.BULLFROG_WILD_MUTATION: "Infested Bullfrogs grant themselves and their cargo temporary health and an attack speed boost on impact.",
+    item_names.BULLFROG_RANGE: "Infested Bullfrog leap gains +3 range, and unload-leap gains +6 range.",
+    item_names.BULLFROG_BROODLINGS: "Infested Bullfrogs spawn two broodlings on impact, in addition to unloading their cargo.",
+    item_names.BULLFROG_HARD_IMPACT: "Infested Bullfrogs deal more damage and stun longer on impact.",
     item_names.INFESTED_BANSHEE_BRACED_EXOSKELETON: "Infested Banshees gain +100 life.",
     item_names.INFESTED_BANSHEE_RAPID_HIBERNATION: "Infested Banshees regenerate 20 life and energy per second while burrowed.",
     item_names.INFESTED_BANSHEE_ADVANCED_TARGETING_OPTICS: "Infested Banshees gain +2 range while cloaked.",

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -381,6 +381,7 @@ DEFILER              = "Defiler"
 INFESTED_MARINE      = "Infested Marine"
 INFESTED_SIEGE_TANK  = "Infested Siege Tank"
 INFESTED_DIAMONDBACK = "Infested Diamondback"
+INFESTED_BULLFROG    = "Infested Bullfrog"
 INFESTED_BANSHEE     = "Infested Banshee"
 INFESTED_LIBERATOR   = "Infested Liberator"
 
@@ -551,6 +552,10 @@ FRIGHTFUL_FLESHWELDER_INFESTED_BANSHEE            = "Frightful Fleshwelder (Infe
 FRIGHTFUL_FLESHWELDER_INFESTED_LIBERATOR          = "Frightful Fleshwelder (Infested Liberator)"
 INFESTED_MISSILE_TURRET_BIOELECTRIC_PAYLOAD       = "Bioelectric Payload (Infested Missile Turret)"
 INFESTED_MISSILE_TURRET_ACID_SPORE_VENTS          = "Acid Spore Vents (Infested Missile Turret)"
+BULLFROG_WILD_MUTATION                            = "Mutagen Vents (Infested Bullfrog)"
+BULLFROG_BROODLINGS                               = "Suffused With Vermin (Infested Bullfrog)"
+BULLFROG_HARD_IMPACT                              = "Lethal Impact (Infested Bullfrog)"
+BULLFROG_RANGE                                    = "Catalytic Boosters (Infested Bullfrog)"
 
 # Zerg Strains
 ZERGLING_RAPTOR_STRAIN     = "Raptor Strain (Zergling)"

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1248,6 +1248,9 @@ item_table = {
     item_names.BILE_LAUNCHER:
         ItemData(26 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 25, SC2Race.ZERG,
                  classification=ItemClassification.progression),
+    item_names.INFESTED_BULLFROG:
+        ItemData(27 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Unit, 26, SC2Race.ZERG,
+                 classification=ItemClassification.progression),
 
     item_names.PROGRESSIVE_ZERG_MELEE_ATTACK: ItemData(100 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 0, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.ZERG_MELEE_ATTACKER),
     item_names.PROGRESSIVE_ZERG_MISSILE_ATTACK: ItemData(101 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Upgrade, 4, SC2Race.ZERG, classification=ItemClassification.progression, quantity=WEAPON_ARMOR_UPGRADE_MAX_LEVEL, parent=parent_names.ZERG_MISSILE_ATTACKER),
@@ -1607,6 +1610,14 @@ item_table = {
         ItemData(385 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 12, SC2Race.ZERG, parent=item_names.BILE_LAUNCHER),
     item_names.BILE_LAUNCHER_RAPID_BOMBARMENT:
         ItemData(386 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 13, SC2Race.ZERG, parent=item_names.BILE_LAUNCHER),
+    item_names.BULLFROG_WILD_MUTATION:
+        ItemData(387 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 14, SC2Race.ZERG, parent=item_names.INFESTED_BULLFROG),
+    item_names.BULLFROG_BROODLINGS:
+        ItemData(388 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 15, SC2Race.ZERG, parent=item_names.INFESTED_BULLFROG),
+    item_names.BULLFROG_HARD_IMPACT:
+        ItemData(389 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 16, SC2Race.ZERG, parent=item_names.INFESTED_BULLFROG),
+    item_names.BULLFROG_RANGE:
+        ItemData(390 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 17, SC2Race.ZERG, parent=item_names.INFESTED_BULLFROG),
 
     item_names.KERRIGAN_KINETIC_BLAST: ItemData(400 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 0, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.KERRIGAN_HEROIC_FORTITUDE: ItemData(401 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 1, SC2Race.ZERG, classification=ItemClassification.progression),


### PR DESCRIPTION
## What is this fixing or adding?
New Zerg unit built at the Infested Factory; has no weapon, but loads smaller zerg units and launches itself to unload them on impact.

Includes items:
- Mutagen Vents: grants minor Wild Mutation effect to unloaded cargo and transport on impact
- Suffused With Vermin: spawns 2 broodlings on impact
- Lethal Impact: greater damage + longer stun to enemies on impact
- Catalytic Boosters: longer range for leap

## How was this tested?
Generated a world, sent myself items, verified it all worked properly
