### PR TITLE
sc2: Adding uri support and updating launcher components so the starcraft 2 client can be started from the room page

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -195,7 +195,7 @@ components: List[Component] = [
     # ChecksFinder
     Component('ChecksFinder Client', 'ChecksFinderClient'),
     # Starcraft 2
-    Component('Starcraft 2 Client', 'Starcraft2Client'),
+    Component('Starcraft 2 Client', 'Starcraft2Client', game_name='Starcraft 2', supports_uri=True),
     # Wargroove
     Component('Wargroove Client', 'WargrooveClient'),
     # Zillion

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -17,7 +17,7 @@ from .locations import (
 	get_locations, DEFAULT_LOCATION_LIST, get_location_types, get_location_flags, 
     get_plando_locations, LocationType, lookup_location_id_to_type
 )
-from .mission_order.layout_types import LayoutType, Gauntlet
+from .mission_order.layout_types import Gauntlet
 from .options import (
     get_option_value, LocationInclusion, KerriganLevelItemDistribution,
     KerriganPresence, KerriganPrimalStatus, kerrigan_unit_available, StarterUnit, SpearOfAdunPresence,
@@ -28,13 +28,13 @@ from .options import (
 from .rules import get_basic_units
 from . import settings
 from .pool_filter import filter_items
-from .mission_tables import (
-    SC2Campaign, SC2Mission, SC2Race, MissionFlag, lookup_name_to_mission, lookup_id_to_mission
-)
+from .mission_tables import SC2Campaign, SC2Mission, SC2Race, MissionFlag
 from .regions import create_mission_order
 from .mission_order import SC2MissionOrder
 
+
 logger = logging.getLogger("Starcraft 2")
+
 
 class Starcraft2WebWorld(WebWorld):
     setup_en = Tutorial(

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1249,11 +1249,20 @@ class CompatItemHolder(typing.NamedTuple):
     quantity: int = 1
 
 
+def parse_uri(uri: str) -> str:
+    if "://" in uri:
+        uri = uri.split("://", 1)[1]
+    return uri.split('?', 1)[0]
+
+
 async def main():
     multiprocessing.freeze_support()
     parser = get_base_parser()
     parser.add_argument('--name', default=None, help="Slot Name to connect as.")
-    args = parser.parse_args()
+    args, uri = parser.parse_known_args()
+
+    if uri and uri[0].startswith('archipelago://'):
+        args.connect = parse_uri(' '.join(uri))
 
     ctx = SC2Context(args.connect, args.password)
     ctx.auth = args.name


### PR DESCRIPTION
## What is this fixing or adding?
Request from octy in main chat: 
> is it possible to get support for launching the SC2 AP client via URI? seems like it should just need game_name and supports_uri=True added in the right place but maybe there's something else needed I'm not aware of
>
>specifically, if you look at a room such as: https://archipelago.gg/room/fWv91RI5Seilf4yq89PR2g
there are links in the "Name" column that are prefixed with archipelago://, and these can launch Archipelago clients from the browser directly

[--Octy, 2024-01-23](https://discord.com/channels/731205301247803413/980554570075873300/1332204081808277504)

I mostly copied things I saw from Factorio and Messenger, coupled with reading some of the code in Launcher.py and LauncherComponents.py to figure out what was possible. The resulting behaviour is:
* Opening the link with Launcher.py opens a kivy window with two buttons on it: launch text client and launch Starcraft 2 client.
* Opening the link with Starcraft2Client.py opens the starcraft 2 client directly
* both connect to the room and slot immediately

Implementation note: Launcher.py can either launch a subprocess or call a python function directly. Calling a function seems more common, but when I tried it, it didn't play nice with running from source as the working directory was in my firefox install folder and thus kivy would crash for being unable to find Starcraft2.kv. Hence, I went with the subprocess route, which did not have this issue, and had the bonus of not requiring an import to define the `Component`, so I could leave the existing definition in LauncherComponents.py in-place and just add a few arguments.

## How was this tested?
Used Octy's room that he linked, opened the client directly.
![uri_open](https://github.com/user-attachments/assets/df81babe-10df-4142-a7aa-cb7ad2c87b02)
![uri_open_2](https://github.com/user-attachments/assets/f6266d2b-5cd2-404c-a334-b2557f90f866)

Note I did not test with frozen .exes directly. I used the same get_exe function as Launcher.py, so I expect the paths should work out fine.

## If this makes graphical changes, please attach screenshots.
None