### PR TITLE
SC2: Add option groups for webhost

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -23,7 +23,7 @@ from .options import (
     KerriganPresence, KerriganPrimalStatus, kerrigan_unit_available, StarterUnit, SpearOfAdunPresence,
     get_enabled_campaigns, SpearOfAdunAutonomouslyCastAbilityPresence, Starcraft2Options,
     GrantStoryTech, GenericUpgradeResearch, RequiredTactics,
-    upgrade_included_names, EnableVoidTrade, FillerRatio, MissionOrderScouting,
+    upgrade_included_names, EnableVoidTrade, FillerRatio, MissionOrderScouting, option_groups,
 )
 from .rules import get_basic_units
 from . import settings
@@ -65,6 +65,7 @@ class Starcraft2WebWorld(WebWorld):
     )
 
     tutorials = [setup_en, setup_fr, custom_mission_orders_en]
+    option_groups = option_groups
 
 
 class SC2World(World):

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from Options import (
     Choice, Toggle, DefaultOnToggle, OptionSet, Range,
     PerGameCommonOptions, Option, VerifyKeys, StartInventory,
-    is_iterable_except_str,
+    is_iterable_except_str, OptionGroup
 )
 from Utils import get_fuzzy_results
 from BaseClasses import PlandoOptions
@@ -1313,6 +1313,108 @@ class Starcraft2Options(PerGameCommonOptions):
     mission_order_scouting: MissionOrderScouting
 
     custom_mission_order: CustomMissionOrder
+
+option_groups = [
+    OptionGroup("Difficulty Settings", [
+        GameDifficulty,
+        GameSpeed,
+        # VanillaItemsOnly,
+        StarterUnit,
+        RequiredTactics,
+        NerfUnitBaselines,
+        MissionBias,
+    ]),
+    OptionGroup("Primary Campaign Settings", [
+        MissionOrder,
+        MaximumCampaignSize,
+        EnableWolMissions,
+        EnableProphecyMissions,
+        EnableHotsMissions,
+        EnableLotVPrologueMissions,
+        EnableLotVMissions,
+        EnableEpilogueMissions,
+        EnableNCOMissions,
+        EnableRaceSwapVariants,
+        ShuffleNoBuild,
+    ]),
+    OptionGroup("Optional Campaign Settings", [
+        ShuffleCampaigns,
+        AllInMap,
+        GridTwoStartPositions,
+        SelectRaces,
+        ExcludeVeryHardMissions,
+        EnableMissionRaceBalancing,
+    ]),
+    OptionGroup("Unit Upgrades", [
+        EnsureGenericItems,
+        MinNumberOfUpgrades,
+        MaxNumberOfUpgrades,
+        MaxUpgradeLevel,
+        GenericUpgradeMissions,
+        GenericUpgradeResearch,
+        GenericUpgradeItems,
+    ]),
+    OptionGroup("Kerrigan", [
+        KerriganPresence,
+        GrantStoryLevels,
+        KerriganLevelsPerMissionCompleted,
+        KerriganLevelsPerMissionCompletedCap,
+        KerriganLevelItemSum,
+        KerriganLevelItemDistribution,
+        KerriganTotalLevelCap,
+        StartPrimaryAbilities,
+        KerriganPrimalStatus,
+    ]),
+    OptionGroup("Spear of Adun", [
+        SpearOfAdunPresence,
+        SpearOfAdunPresentInNoBuild,
+        SpearOfAdunAutonomouslyCastAbilityPresence,
+        SpearOfAdunAutonomouslyCastPresentInNoBuild,
+    ]),
+    OptionGroup("Race Specific Options", [
+        EnableMorphling,
+    ]),
+    OptionGroup("Check Locations", [
+        VictoryCache,
+        VanillaLocations,
+        ExtraLocations,
+        ChallengeLocations,
+        MasteryLocations,
+        SpeedrunLocations,
+        PreventativeLocations,
+    ]),
+    OptionGroup("Filler Options", [
+        FillerPercentage,
+        MineralsPerItem,
+        VespenePerItem,
+        StartingSupplyPerItem,
+        MaximumSupplyPerItem,
+        MaximumSupplyReductionPerItem,
+        LowestMaximumSupply,
+        FillerRatio,
+    ]),
+    OptionGroup("Inclusions & Exclusions", [
+        LockedItems,
+        ExcludedItems,
+        UnexcludedItems,
+        ExcludedMissions,
+    ]),
+    OptionGroup("Advanced Gameplay", [
+        DifficultyDamageModifier,
+        KeyMode,
+        TakeOverAIAllies,
+        EnableVoidTrade,
+        VoidTradeAgeLimit,
+        GrantStoryTech,
+    ]),
+    OptionGroup("Cosmetics", [
+        PlayerColorTerranRaynor,
+        PlayerColorProtoss,
+        PlayerColorZerg,
+        PlayerColorZergPrimal,
+        PlayerColorNova,
+    ])
+]
 
 def get_option_value(world: Union['SC2World', None], name: str) -> int:
     """

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -1338,6 +1338,7 @@ option_groups = [
         ShuffleNoBuild,
     ]),
     OptionGroup("Optional Campaign Settings", [
+        KeyMode,
         ShuffleCampaigns,
         AllInMap,
         GridTwoStartPositions,
@@ -1401,7 +1402,6 @@ option_groups = [
     ]),
     OptionGroup("Advanced Gameplay", [
         DifficultyDamageModifier,
-        KeyMode,
         TakeOverAIAllies,
         EnableVoidTrade,
         VoidTradeAgeLimit,


### PR DESCRIPTION
## What is this fixing or adding?
This PR adds option groups for the SC2 player options page to make it easier to use.

## How was this tested?
Checked in a locally hosted webhost

## If this makes graphical changes, please attach screenshots.
![Screenshot 2025-01-26 at 21-55-29 Starcraft 2 Options](https://github.com/user-attachments/assets/2a62180c-1fa6-426a-b0ce-e2caaf70cec7)
