### PR TITLE
sc2: updating any_units to give slightly better initial units

### DIFF
--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -74,22 +74,11 @@ The logic is a little more restrictive than a player's creativity, so an advance
 more items than they need in any situation. These levels are entirely safe to use in a multiworld.
 
 The "Any Units" level only guarantees that a minimum number of faction-appropriate units or buildings are reachable
-early on, but not what those units are.
-Before starting a build mission, the generator will guarantee that N units or buildings can be acquired before starting it,
-where N is the number of missions the player needs to beat to access the mission, and the units belong to the faction
-the player will play in the mission. For a linear order of missions, ordered [zerg, protoss, terran], a protoss unit
-is guaranteed to be unlocked in the zerg mission, and 2 terran units are guaranteed to be unlocked
-in the preceding 2 missions. This effect maxes out at 5 units guaranteed for each faction.
-
-It's possible to get stuck on "Any Units" if the units can't attack,
-like getting only medics and medivacs for the first 2 units, only getting units that take too long to build
-for the missions at hand, or simply not having enough damage output.
-Some safeguards exist to make sure terrain traversal, no-builds, and having something that can hit air objectives exists,
-so a stuck world can be recovered by either setting the difficulty to casual with `/difficulty casual` in the client
-or using cheat codes like `terribleterribledamage` in-game.
-This logic option is likely to be beatable without cheats, but not guaranteed to be.
-Thus, it is only safe to use in a multiworld if the player is willing to use cheats to get a world unstuck if
-the situation calls for it, or uses settings like start inventory or mission exclusions to guarantee beatability.
+early on, with minimal restrictions on what those units are.
+Generation will guarantee a number of faction-appropriate units are reachable before starting a mission,
+based on the depth of that mission. For example, if the third mission is a zerg mission, it is guaranteed that 2
+zerg units are somewhere in the preceding 2 missions. This logic level is not guaranteed to be beatable, and may
+require lowering the difficulty level (`/difficulty` in the client) if many no-build missions are excluded.
 
 The "No Logic" level provides no logical safeguards for beatability. It is only safe to use in a multiworld if the player curates
 a start inventory or the organizer is okay with the possibility of the StarCraft 2 world being unbeatable.

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -231,7 +231,7 @@ item_table = {
                  classification=ItemClassification.progression, quantity=0),
     item_names.AEGIS_GUARD:
         ItemData(54 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Unit_2, 2, SC2Race.TERRAN,
-                 quantity=0),
+                 classification=ItemClassification.progression, quantity=0),
     item_names.EMPERORS_SHADOW:
         ItemData(55 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Unit_2, 3, SC2Race.TERRAN,
                  classification=ItemClassification.progression, quantity=0),
@@ -888,7 +888,8 @@ item_table = {
         ItemData(501 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Mercenary, 1, SC2Race.TERRAN,
                  classification=ItemClassification.filler),
     item_names.HAMMER_SECURITIES:
-        ItemData(502 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Mercenary, 2, SC2Race.TERRAN),
+        ItemData(502 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Mercenary, 2, SC2Race.TERRAN,
+                 classification=ItemClassification.progression),
     item_names.SPARTAN_COMPANY:
         ItemData(503 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Mercenary, 3, SC2Race.TERRAN,
                  classification=ItemClassification.progression),
@@ -905,9 +906,11 @@ item_table = {
         ItemData(507 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Mercenary, 7, SC2Race.TERRAN,
                  classification=ItemClassification.progression),
     item_names.SKIBIS_ANGELS:
-        ItemData(508 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Mercenary, 8, SC2Race.TERRAN),
+        ItemData(508 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Mercenary, 8, SC2Race.TERRAN,
+                 classification=ItemClassification.progression),
     item_names.DEATH_HEADS:
-        ItemData(509 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Mercenary, 9, SC2Race.TERRAN),
+        ItemData(509 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Mercenary, 9, SC2Race.TERRAN,
+                 classification=ItemClassification.progression),
     item_names.WINGED_NIGHTMARES:
         ItemData(510 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Mercenary, 10, SC2Race.TERRAN,
                  classification=ItemClassification.progression),
@@ -958,7 +961,7 @@ item_table = {
                  classification=ItemClassification.progression),
     item_names.PREDATOR:
         ItemData(614 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Unit, 24, SC2Race.TERRAN,
-                 classification=ItemClassification.filler),
+                 classification=ItemClassification.progression),
     item_names.HERCULES:
         ItemData(615 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Unit, 25, SC2Race.TERRAN,
                  classification=ItemClassification.progression),
@@ -1004,34 +1007,7 @@ item_table = {
         ItemData(632 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 23, SC2Race.TERRAN,
                  classification=ItemClassification.progression),
 
-    # WoL Protoss
-    item_names.ZEALOT:
-        ItemData(700 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 0, SC2Race.PROTOSS,
-                 classification=ItemClassification.progression),
-    item_names.STALKER: 
-        ItemData(701 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 1, SC2Race.PROTOSS, 
-                 classification=ItemClassification.progression),
-    item_names.HIGH_TEMPLAR: 
-        ItemData(702 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 2, SC2Race.PROTOSS, 
-                 classification=ItemClassification.progression),
-    item_names.DARK_TEMPLAR: 
-        ItemData(703 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 3, SC2Race.PROTOSS, 
-                 classification=ItemClassification.progression),
-    item_names.IMMORTAL: 
-        ItemData(704 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 4, SC2Race.PROTOSS,
-                 classification=ItemClassification.progression),
-    item_names.COLOSSUS:
-        ItemData(705 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 5, SC2Race.PROTOSS,
-                 classification=ItemClassification.progression),
-    item_names.PHOENIX:
-        ItemData(706 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 6, SC2Race.PROTOSS,
-                 classification=ItemClassification.progression),
-    item_names.VOID_RAY:
-        ItemData(707 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 7, SC2Race.PROTOSS,
-                 classification=ItemClassification.progression),
-    item_names.CARRIER:
-        ItemData(708 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 8, SC2Race.PROTOSS,
-                 classification=ItemClassification.progression),
+    # WoL Protoss takes SC2WOL + 700~708
 
     item_names.SCIENCE_VESSEL_TACTICAL_JUMP:
         ItemData(750 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 4, SC2Race.TERRAN,
@@ -1684,8 +1660,35 @@ item_table = {
     item_names.ROACH_PRIMAL_IGNITER_ASPECT: ItemData(804 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 9, SC2Race.ZERG, classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_ROACH),
     item_names.ULTRALISK_TYRANNOZOR_ASPECT: ItemData(805 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 10, SC2Race.ZERG, classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_ULTRALISK),
 
-
-    # Protoss Units (those that aren't as items in WoL (Prophecy))
+    # Protoss Units
+    # The first several are in SC2WOL offset for historical reasons (show up in prophecy)
+    item_names.ZEALOT:
+        ItemData(700 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 0, SC2Race.PROTOSS,
+                 classification=ItemClassification.progression),
+    item_names.STALKER: 
+        ItemData(701 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 1, SC2Race.PROTOSS, 
+                 classification=ItemClassification.progression),
+    item_names.HIGH_TEMPLAR: 
+        ItemData(702 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 2, SC2Race.PROTOSS, 
+                 classification=ItemClassification.progression),
+    item_names.DARK_TEMPLAR: 
+        ItemData(703 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 3, SC2Race.PROTOSS, 
+                 classification=ItemClassification.progression),
+    item_names.IMMORTAL: 
+        ItemData(704 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 4, SC2Race.PROTOSS,
+                 classification=ItemClassification.progression),
+    item_names.COLOSSUS:
+        ItemData(705 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 5, SC2Race.PROTOSS,
+                 classification=ItemClassification.progression),
+    item_names.PHOENIX:
+        ItemData(706 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 6, SC2Race.PROTOSS,
+                 classification=ItemClassification.progression),
+    item_names.VOID_RAY:
+        ItemData(707 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 7, SC2Race.PROTOSS,
+                 classification=ItemClassification.progression),
+    item_names.CARRIER:
+        ItemData(708 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 8, SC2Race.PROTOSS,
+                 classification=ItemClassification.progression),
     item_names.OBSERVER:
         ItemData(0 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Unit, 9, SC2Race.PROTOSS,
                  classification=ItemClassification.progression),
@@ -1711,7 +1714,8 @@ item_table = {
         ItemData(7 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Unit, 16, SC2Race.PROTOSS,
                  classification=ItemClassification.progression),
     item_names.HAVOC:
-        ItemData(8 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Unit, 17, SC2Race.PROTOSS, important_for_filtering=True),
+        ItemData(8 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Unit, 17, SC2Race.PROTOSS,
+                 classification=ItemClassification.progression),
     item_names.SIGNIFIER:
         ItemData(9 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Unit, 18, SC2Race.PROTOSS,
                  classification=ItemClassification.progression),

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -387,7 +387,7 @@ item_table = {
                  parent=item_names.MARAUDER),
     item_names.REAPER_JET_PACK_OVERDRIVE:
         ItemData(239 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 6, SC2Race.TERRAN,
-                 parent=item_names.REAPER),
+                 classification=ItemClassification.progression_skip_balancing, parent=item_names.REAPER),
     item_names.HELLION_INFERNAL_PLATING:
         ItemData(240 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_2, 7, SC2Race.TERRAN,
                  parent=item_names.HELLION),
@@ -836,7 +836,7 @@ item_table = {
                  parent=item_names.PLANETARY_FORTRESS, quantity=2),
     item_names.PLANETARY_FORTRESS_ADVANCED_TARGETING:
         ItemData(389 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 7, SC2Race.TERRAN,
-                 parent=item_names.PLANETARY_FORTRESS),
+                 classification=ItemClassification.progression, parent=item_names.PLANETARY_FORTRESS),
     item_names.VALKYRIE_LAUNCHING_VECTOR_COMPENSATOR:
         ItemData(390 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_6, 8, SC2Race.TERRAN,
                  classification=ItemClassification.filler, parent=item_names.VALKYRIE),
@@ -876,7 +876,8 @@ item_table = {
         ItemData(401 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Building, 1, SC2Race.TERRAN,
                  classification=ItemClassification.progression),
     item_names.SENSOR_TOWER:
-        ItemData(402 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Building, 2, SC2Race.TERRAN),
+        ItemData(402 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Building, 2, SC2Race.TERRAN,
+                 classification=ItemClassification.progression_skip_balancing),
     item_names.DEVASTATOR_TURRET:
         ItemData(403 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Building, 7, SC2Race.TERRAN,
                  classification=ItemClassification.progression),
@@ -886,7 +887,7 @@ item_table = {
                  classification=ItemClassification.progression),
     item_names.DEVIL_DOGS:
         ItemData(501 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Mercenary, 1, SC2Race.TERRAN,
-                 classification=ItemClassification.filler),
+                 classification=ItemClassification.progression_skip_balancing),
     item_names.HAMMER_SECURITIES:
         ItemData(502 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Mercenary, 2, SC2Race.TERRAN,
                  classification=ItemClassification.progression),
@@ -1049,7 +1050,7 @@ item_table = {
         ItemData(762 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 16, SC2Race.TERRAN),
     item_names.WIDOW_MINE_DEMOLITION_ARMAMENTS:
         ItemData(763 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 17, SC2Race.TERRAN,
-                 parent=item_names.WIDOW_MINE),
+                 classification=ItemClassification.progression, parent=item_names.WIDOW_MINE),
     item_names.SENSOR_TOWER_ASSISTIVE_TARGETING:
         ItemData(764 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 18, SC2Race.TERRAN,
                  parent=item_names.SENSOR_TOWER),
@@ -1576,7 +1577,7 @@ item_table = {
         ItemData(380 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 8, SC2Race.ZERG, parent=item_names.INFESTED_LIBERATOR,
                  classification=ItemClassification.progression),
     item_names.ABERRATION_PROGRESSIVE_BANELING_LAUNCH:
-        ItemData(381 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Progressive, 4, SC2Race.ZERG, parent=item_names.ABERRATION, quantity=2),
+        ItemData(381 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Progressive, 4, SC2Race.ZERG, parent=item_names.ABERRATION, quantity=2, classification=ItemClassification.progression),
     item_names.PYGALISK_STIM:
         ItemData(382 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 9, SC2Race.ZERG, parent=item_names.PYGALISK),
     item_names.PYGALISK_DUCAL_BLADES:
@@ -1629,15 +1630,15 @@ item_table = {
     item_names.KERRIGAN_LEVELS_70: ItemData(512 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Level, 70, SC2Race.ZERG, quantity=0, classification=ItemClassification.progression),
 
     # Zerg Mercs
-    item_names.INFESTED_MEDICS: ItemData(600 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 0, SC2Race.ZERG),
+    item_names.INFESTED_MEDICS: ItemData(600 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 0, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.INFESTED_SIEGE_BREAKERS: ItemData(601 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 1, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.INFESTED_DUSK_WINGS: ItemData(602 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 2, SC2Race.ZERG, classification=ItemClassification.progression),
-    item_names.DEVOURING_ONES: ItemData(603 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 3, SC2Race.ZERG),
-    item_names.HUNTER_KILLERS: ItemData(604 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 4, SC2Race.ZERG),
-    item_names.TORRASQUE_MERC: ItemData(605 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 5, SC2Race.ZERG),
+    item_names.DEVOURING_ONES: ItemData(603 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 3, SC2Race.ZERG, classification=ItemClassification.progression),
+    item_names.HUNTER_KILLERS: ItemData(604 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 4, SC2Race.ZERG, classification=ItemClassification.progression),
+    item_names.TORRASQUE_MERC: ItemData(605 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 5, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.HUNTERLING: ItemData(606 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 6, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.YGGDRASIL: ItemData(607 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 7, SC2Race.ZERG, classification=ItemClassification.progression),
-    item_names.THORNSHELL: ItemData(608 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 8, SC2Race.ZERG),
+    item_names.THORNSHELL: ItemData(608 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mercenary, 8, SC2Race.ZERG, classification=ItemClassification.progression),
 
 
     # Misc Upgrades
@@ -1992,7 +1993,7 @@ item_table = {
     item_names.MOTHERSHIP_INTEGRATED_POWER: ItemData(545 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 15, SC2Race.PROTOSS, parent=item_names.MOTHERSHIP),
     # 546-549 reserved for Mothership
     item_names.OPPRESSOR_VULCAN_BLASTER: ItemData(550 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 20, SC2Race.PROTOSS, parent=item_names.OPPRESSOR),
-    item_names.CALADRIUS_CORONA_BEAM: ItemData(551 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 21, SC2Race.PROTOSS, parent=item_names.CALADRIUS),
+    item_names.CALADRIUS_CORONA_BEAM: ItemData(551 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 21, SC2Race.PROTOSS, classification=ItemClassification.progression, parent=item_names.CALADRIUS),
     item_names.MISTWING_PHANTOM_DASH: ItemData(552 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 22, SC2Race.PROTOSS, parent=item_names.MISTWING),
     
 
@@ -2037,7 +2038,7 @@ item_table = {
     item_names.OPTIMIZED_ORDNANCE:
         ItemData(810 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 10, SC2Race.PROTOSS, parent=parent_names.PROTOSS_ATTACKING_BUILDING),
     item_names.KHALAI_INGENUITY:
-        ItemData(811 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 11, SC2Race.PROTOSS),
+        ItemData(811 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 11, SC2Race.PROTOSS, classification=ItemClassification.progression),
     item_names.AMPLIFIED_ASSIMILATORS:
         ItemData(812 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Solarite_Core, 12, SC2Race.PROTOSS),
     item_names.PROGRESSIVE_WARP_RELOCATE:

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -1146,25 +1146,31 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                         item_names.ROACH,
                         item_names.HYDRALISK,
                         item_names.INFESTOR
-                    }, player)))
+                    }, player))),
+            hard_rule=logic.zerg_pass_vents,
         ),
         make_location_data(SC2Mission.ENEMY_WITHIN.mission_name, "Infest Giant Ursadon", SC2HOTS_LOC_ID_OFFSET + 601, LocationType.VANILLA,
-            logic.zerg_pass_vents
+            logic.zerg_pass_vents,
+            hard_rule=logic.zerg_pass_vents,
         ),
         make_location_data(SC2Mission.ENEMY_WITHIN.mission_name, "First Niadra Evolution", SC2HOTS_LOC_ID_OFFSET + 602, LocationType.VANILLA,
-            logic.zerg_pass_vents
+            logic.zerg_pass_vents,
         ),
         make_location_data(SC2Mission.ENEMY_WITHIN.mission_name, "Second Niadra Evolution", SC2HOTS_LOC_ID_OFFSET + 603, LocationType.VANILLA,
-            logic.zerg_pass_vents
+            logic.zerg_pass_vents,
+            hard_rule=logic.zerg_pass_vents,
         ),
         make_location_data(SC2Mission.ENEMY_WITHIN.mission_name, "Third Niadra Evolution", SC2HOTS_LOC_ID_OFFSET + 604, LocationType.VANILLA,
-            logic.zerg_pass_vents
+            logic.zerg_pass_vents,
+            hard_rule=logic.zerg_pass_vents,
         ),
         make_location_data(SC2Mission.ENEMY_WITHIN.mission_name, "Warp Drive", SC2HOTS_LOC_ID_OFFSET + 605, LocationType.EXTRA,
-            logic.zerg_pass_vents
+            logic.zerg_pass_vents,
+            hard_rule=logic.zerg_pass_vents,
         ),
         make_location_data(SC2Mission.ENEMY_WITHIN.mission_name, "Stasis Quadrant", SC2HOTS_LOC_ID_OFFSET + 606, LocationType.EXTRA,
-            logic.zerg_pass_vents
+            logic.zerg_pass_vents,
+            hard_rule=logic.zerg_pass_vents,
         ),
         make_location_data(SC2Mission.DOMINATION.mission_name, "Victory", SC2HOTS_LOC_ID_OFFSET + 700, LocationType.VICTORY,
             logic.zerg_common_unit_basic_aa

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -4,7 +4,6 @@ from .item import item_names
 from .options import (get_option_value, RequiredTactics,
     LocationInclusion, KerriganPresence,
 )
-from .rules import SC2Logic
 from .mission_tables import SC2Mission
 
 from BaseClasses import Location
@@ -136,7 +135,11 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             or not world.options.enable_hots_missions.value
         )
     adv_tactics = logic_level != RequiredTactics.option_standard
-    logic = SC2Logic(world)
+    if world is not None and world.logic is not None:
+        logic = world.logic
+    else:
+        from .rules import SC2Logic
+        logic = SC2Logic(world)
     player = 1 if world is None else world.player
     location_table: List[LocationData] = [
         # WoL

--- a/worlds/sc2/mission_order/mission_pools.py
+++ b/worlds/sc2/mission_order/mission_pools.py
@@ -176,7 +176,8 @@ class SC2MOGenMissionPools:
     def _add_mission_stats(self, mission: SC2Mission) -> None:
         # Update used flag counts & missions
         # Done weirdly for Python <= 3.10 compatibility
-        for flag in iter(MissionFlag):
+        flag: MissionFlag
+        for flag in iter(MissionFlag):  # type: ignore
             if flag & mission.flags == flag:
                 self._used_flags.setdefault(flag, 0)
                 self._used_flags[flag] += 1

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -1441,7 +1441,8 @@ class SC2Logic:
                 item_names.DARK_TEMPLAR,  # Archon, Dark Archon Meld
                 # Stargate
                 item_names.PHOENIX, item_names.MIRAGE, item_names.CORSAIR,
-                item_names.SCOUT, item_names.ARBITER,
+                item_names.SCOUT, item_names.MISTWING, item_names.CALADRIUS, item_names.OPPRESSOR,
+                item_names.ARBITER,
                 item_names.VOID_RAY, item_names.DESTROYER, item_names.INTERCESSOR,
                 item_names.CARRIER, item_names.SKYLORD, item_names.TEMPEST,
                 item_names.MOTHERSHIP,

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -1,5 +1,5 @@
 from math import floor
-from typing import TYPE_CHECKING, Set, Optional, Callable
+from typing import TYPE_CHECKING, Set, Optional, Callable, Dict, Tuple
 
 from BaseClasses import CollectionState, Location
 from .options import (
@@ -21,6 +21,48 @@ if TYPE_CHECKING:
 
 
 class SC2Logic:
+    def __init__(self, world: Optional['SC2World']):
+        # Note: Don't store a reference to the world so we can cache this object on the world object
+        self.player = -1 if world is None else world.player
+        self.logic_level: int = world.options.required_tactics.value if world else RequiredTactics.default
+        self.advanced_tactics = self.logic_level != RequiredTactics.option_standard
+        self.take_over_ai_allies = bool(world and world.options.take_over_ai_allies)
+        self.kerrigan_unit_available = (
+            get_option_value(world, 'kerrigan_presence') in kerrigan_unit_available
+            and SC2Campaign.HOTS in get_enabled_campaigns(world)
+            and SC2Race.ZERG in get_enabled_races(world)
+        )
+        self.kerrigan_levels_per_mission_completed = get_option_value(world, "kerrigan_levels_per_mission_completed")
+        self.kerrigan_levels_per_mission_completed_cap = get_option_value(world, "kerrigan_levels_per_mission_completed_cap")
+        self.kerrigan_total_level_cap = get_option_value(world, "kerrigan_total_level_cap")
+        self.morphling_enabled = get_option_value(world, "enable_morphling") == EnableMorphling.option_true
+        self.story_tech_granted = get_option_value(world, "grant_story_tech") == GrantStoryTech.option_true
+        self.story_levels_granted = get_option_value(world, "grant_story_levels") != GrantStoryLevels.option_disabled
+        self.basic_terran_units = get_basic_units(self.logic_level, SC2Race.TERRAN)
+        self.basic_zerg_units = get_basic_units(self.logic_level, SC2Race.ZERG)
+        self.basic_protoss_units = get_basic_units(self.logic_level, SC2Race.PROTOSS)
+        self.spear_of_adun_presence = SpearOfAdunPresence.default if world is None else world.options.spear_of_adun_presence.value
+        self.spear_of_adun_autonomously_cast_presence = get_option_value(world, "spear_of_adun_autonomously_cast_ability_presence")
+        self.enabled_campaigns = get_enabled_campaigns(world)
+        self.mission_order = get_option_value(world, "mission_order")
+        self.generic_upgrade_missions = get_option_value(world, "generic_upgrade_missions")
+        self.all_in_map = get_option_value(world, "all_in_map")
+
+        # Must be set externally for accurate logic checking of upgrade level when generic_upgrade_missions is checked
+        self.total_mission_count = 1
+
+        # Conditionally set to False by the world after culling items
+        self.has_barracks_unit: bool = True
+        self.has_factory_unit: bool = True
+        self.has_starport_unit: bool = True
+        self.has_zerg_melee_unit: bool = True
+        self.has_zerg_ranged_unit: bool = True
+        self.has_zerg_air_unit: bool = True
+        self.has_protoss_ground_unit: bool = True
+        self.has_protoss_air_unit: bool = True
+
+        self.unit_count_functions: Dict[Tuple[SC2Race, int], Callable[[CollectionState], bool]] = {}
+        """Cache of logic functions used by any_units logic level"""
 
     def is_item_placement(self, state: CollectionState):
         """
@@ -29,39 +71,6 @@ class SC2Logic:
         """
         # has_group with count = 0 is always true for item placement and always false for SC2 item filtering
         return state.has_group("Missions", self.player, 0)
-
-    # Needs to react on how many missions actually got generated
-    def total_mission_count(self):
-        return (
-            1 if (self.world is None or not hasattr(self.world, 'custom_mission_order'))
-            else self.world.custom_mission_order.get_mission_count()
-        )
-
-    # Unit classes in world, these are set properly into the world after the item culling is done
-    # Therefore need to get from the world
-    def world_has_barracks_unit(self):
-        return self.world is not None and self.world.has_barracks_unit
-
-    def world_has_factory_unit(self):
-        return self.world is not None and self.world.has_factory_unit
-
-    def world_has_starport_unit(self):
-        return self.world is not None and self.world.has_starport_unit
-
-    def world_has_zerg_melee_unit(self):
-        return self.world is not None and self.world.has_zerg_melee_unit
-
-    def world_has_zerg_ranged_unit(self):
-        return self.world is not None and self.world.has_zerg_ranged_unit
-
-    def world_has_zerg_air_unit(self):
-        return self.world is not None and self.world.has_zerg_air_unit
-
-    def world_has_protoss_ground_unit(self):
-        return self.world is not None and self.world.has_protoss_ground_unit
-
-    def world_has_protoss_air_unit(self):
-        return self.world is not None and self.world.has_protoss_air_unit
 
     def get_very_hard_required_upgrade_level(self):
         return 2 if self.advanced_tactics else 3
@@ -77,7 +86,7 @@ class SC2Logic:
             else:
                 count += floor(
                     (100 / self.generic_upgrade_missions)
-                    * (state.count_group("Missions", self.player) / self.total_mission_count())
+                    * (state.count_group("Missions", self.player) / self.total_mission_count)
                 )
         count += state.count(upgrade_item, self.player)
         count += state.count_from_list(upgrade_bundle_inverted_lookup[upgrade_item], self.player)
@@ -98,19 +107,19 @@ class SC2Logic:
         Minimum W/A upgrade level for unit classes present in the world
         """
         count: int = WEAPON_ARMOR_UPGRADE_MAX_LEVEL
-        if self.world_has_barracks_unit():
+        if self.has_barracks_unit:
             count = min(
                 count,
                 self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON, state),
                 self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR, state)
             )
-        if self.world_has_factory_unit():
+        if self.has_factory_unit:
             count = min(
                 count,
                 self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON, state),
                 self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_TERRAN_VEHICLE_ARMOR, state)
             )
-        if self.world_has_starport_unit():
+        if self.has_starport_unit:
             count = min(
                 count,
                 self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_TERRAN_SHIP_WEAPON, state),
@@ -468,7 +477,7 @@ class SC2Logic:
             or state.has(item_names.ABERRATION, self.player)
             or (self.advanced_tactics
                 and (
-                    state.has_all({item_names.ZERGLING_BANELING_ASPECT, item_names.BANELING_CORROSIVE_ACID}, self.player)
+                    (self.morph_baneling(state) and state.has(item_names.BANELING_CORROSIVE_ACID, self.player))
                     or state.has_all({item_names.ROACH, item_names.ROACH_GLIAL_RECONSTITUTION}, self.player)
                 )
             )
@@ -736,7 +745,7 @@ class SC2Logic:
             or state.has_all({item_names.REAPER, item_names.REAPER_RESOURCE_EFFICIENCY}, self.player)
             or self.advanced_tactics
         )
-        if get_option_value(self.world, 'all_in_map') == AllInMap.option_ground:
+        if self.all_in_map == AllInMap.option_ground:
             # Ground
             defense_rating = self.terran_defense_rating(state, True, False)
             if state.has_any({item_names.BATTLECRUISER, item_names.BANSHEE}, self.player):
@@ -763,7 +772,7 @@ class SC2Logic:
                 or self.morph_brood_lord(state)
                 or self.advanced_tactics
         )
-        if get_option_value(self.world, 'all_in_map') == AllInMap.option_ground:
+        if self.all_in_map == AllInMap.option_ground:
             # Ground
             defense_rating = self.zerg_defense_rating(state, True, False)
             if state.has_any({item_names.MUTALISK, item_names.INFESTED_BANSHEE, item_names.INFESTED_DUSK_WINGS}, self.player) or self.morph_brood_lord(state):
@@ -793,7 +802,7 @@ class SC2Logic:
                 or (self.protoss_can_merge_dark_archon(state) and state.has(item_names.DARK_ARCHON_FEEDBACK, self.player))
                 or self.advanced_tactics
         )
-        if get_option_value(self.world, 'all_in_map') == AllInMap.option_ground:
+        if self.all_in_map == AllInMap.option_ground:
             # Ground
             defense_rating = self.protoss_defense_rating(state, True)
             if state.has_any({item_names.SKIRMISHER, item_names.DARK_TEMPLAR, item_names.TEMPEST, item_names.TRIREME}, self.player):
@@ -878,11 +887,11 @@ class SC2Logic:
 
     def zerg_army_weapon_armor_upgrade_min_level(self, state: CollectionState) -> int:
         count: int = WEAPON_ARMOR_UPGRADE_MAX_LEVEL
-        if self.world_has_zerg_melee_unit():
+        if self.has_zerg_melee_unit:
             count = min(count, self.zerg_melee_weapon_armor_upgrade_min_level(state))
-        if self.world_has_zerg_ranged_unit():
+        if self.has_zerg_ranged_unit:
             count = min(count, self.zerg_ranged_weapon_armor_upgrade_min_level(state))
-        if self.world_has_zerg_air_unit():
+        if self.has_zerg_air_unit:
             count = min(count, self.zerg_flyer_weapon_armor_upgrade_min_level(state))
         return count
     
@@ -986,6 +995,12 @@ class SC2Logic:
                         or state.has(item_names.INFESTED_BUNKER, self.player)
                         or state.count(item_names.INFESTED_SIEGE_TANK_PROGRESSIVE_AUTOMATED_MITOSIS, self.player) >= (1 if self.advanced_tactics else 2)
                 )
+        )
+
+    def morph_baneling(self, state: CollectionState) -> bool:
+        return (
+            (state.has(item_names.ZERGLING, self.player) or self.morphling_enabled)
+            and state.has(item_names.ZERGLING_BANELING_ASPECT, self.player)
         )
 
     def morph_ravager(self, state: CollectionState) -> bool:
@@ -1352,19 +1367,19 @@ class SC2Logic:
     # LotV
     def protoss_army_weapon_armor_upgrade_min_level(self, state: CollectionState) -> int:
         count: int = WEAPON_ARMOR_UPGRADE_MAX_LEVEL + 1 # +1 for Quatro
-        if self.world_has_protoss_ground_unit():
+        if self.has_protoss_ground_unit:
             count = min(
                 count,
                 self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_PROTOSS_GROUND_WEAPON, state),
                 self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_PROTOSS_GROUND_ARMOR, state)
             )
-        if self.world_has_protoss_air_unit():
+        if self.has_protoss_air_unit:
             count = min(
                 count,
                 self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_PROTOSS_AIR_WEAPON, state),
                 self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_PROTOSS_AIR_ARMOR, state)
             )
-        if self.world_has_protoss_ground_unit() or self.world_has_protoss_air_unit():
+        if self.has_protoss_ground_unit or self.has_protoss_air_unit:
             count = min(
                 count,
                 self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_PROTOSS_SHIELDS, state),
@@ -2518,76 +2533,131 @@ class SC2Logic:
             and self.terran_very_hard_mission_weapon_armor_level(state)
         )
 
-    def __init__(self, world: Optional['SC2World']):
-        self.world = world
-        self.player = -1 if world is None else world.player
-        self.logic_level: int = world.options.required_tactics.value if world else RequiredTactics.default
-        self.advanced_tactics = self.logic_level != RequiredTactics.option_standard
-        self.take_over_ai_allies = bool(world and world.options.take_over_ai_allies)
-        self.kerrigan_unit_available = (
-            get_option_value(world, 'kerrigan_presence') in kerrigan_unit_available
-            and SC2Campaign.HOTS in get_enabled_campaigns(world)
-            and SC2Race.ZERG in get_enabled_races(world)
-        )
-        self.kerrigan_levels_per_mission_completed = get_option_value(world, "kerrigan_levels_per_mission_completed")
-        self.kerrigan_levels_per_mission_completed_cap = get_option_value(world, "kerrigan_levels_per_mission_completed_cap")
-        self.kerrigan_total_level_cap = get_option_value(world, "kerrigan_total_level_cap")
-        self.morphling_enabled = get_option_value(world, "enable_morphling") == EnableMorphling.option_true
-        self.story_tech_granted = get_option_value(world, "grant_story_tech") == GrantStoryTech.option_true
-        self.story_levels_granted = get_option_value(world, "grant_story_levels") != GrantStoryLevels.option_disabled
-        self.basic_terran_units = get_basic_units(self.logic_level, SC2Race.TERRAN)
-        self.basic_zerg_units = get_basic_units(self.logic_level, SC2Race.ZERG)
-        self.basic_protoss_units = get_basic_units(self.logic_level, SC2Race.PROTOSS)
-        self.spear_of_adun_presence = SpearOfAdunPresence.default if world is None else world.options.spear_of_adun_presence.value
-        self.spear_of_adun_autonomously_cast_presence = get_option_value(world, "spear_of_adun_autonomously_cast_ability_presence")
-        self.enabled_campaigns = get_enabled_campaigns(world)
-        self.mission_order = get_option_value(world, "mission_order")
-        self.generic_upgrade_missions = get_option_value(world, "generic_upgrade_missions")
+    def has_terran_units(self, target: int) -> Callable[['CollectionState'], bool]:
+        def _has_terran_units(state: CollectionState) -> bool:
+            return (
+                state.count_from_list_unique(item_groups.terran_units + item_groups.terran_buildings, self.player) >= target
+            ) and (
+                # Anything that can hit buildings
+                state.has_any((
+                    # Infantry
+                    item_names.MARINE, item_names.FIREBAT, item_names.MARAUDER,
+                    item_names.REAPER, item_names.HERC, item_names.DOMINION_TROOPER,
+                    item_names.GHOST, item_names.SPECTRE,
+                    # Vehicles
+                    item_names.HELLION, item_names.VULTURE, item_names.SIEGE_TANK,
+                    item_names.WARHOUND, item_names.GOLIATH, item_names.DIAMONDBACK,
+                    item_names.THOR, item_names.PREDATOR, item_names.CYCLONE,
+                    # Ships
+                    item_names.WRAITH, item_names.VIKING, item_names.BANSHEE,
+                    item_names.RAVEN, item_names.BATTLECRUISER,
+                    # RG
+                    item_names.SON_OF_KORHAL, item_names.AEGIS_GUARD, item_names.EMPERORS_SHADOW,
+                    item_names.BULWARK_COMPANY, item_names.SHOCK_DIVISION, item_names.BLACKHAMMER,
+                    item_names.SKY_FURY, item_names.NIGHT_WOLF, item_names.NIGHT_HAWK,
+                    item_names.PRIDE_OF_AUGUSTRGRAD,
+                    # Mercs with shortest initial cooldown (300s)
+                    item_names.WAR_PIGS, item_names.DEATH_HEADS,
+                    item_names.HELS_ANGELS, item_names.WINGED_NIGHTMARES,
+                ), self.player)
+                or state.has_all((item_names.LIBERATOR, item_names.LIBERATOR_RAID_ARTILLERY), self.player)
+                or state.has_all((item_names.EMPERORS_GUARDIAN, item_names.LIBERATOR_RAID_ARTILLERY), self.player)
+                or state.has_all((item_names.VALKYRIE, item_names.VALKYRIE_FLECHETTE_MISSILES), self.player)
+                or state.has_all((item_names.WIDOW_MINE, item_names.WIDOW_MINE_DEMOLITION_ARMAMENTS), self.player)
+            )
+        return _has_terran_units
+
+    def has_zerg_units(self, target: int) -> Callable[['CollectionState'], bool]:
+        def _has_zerg_units(state: CollectionState) -> bool:
+            return (
+                state.count_from_list_unique(item_groups.zerg_units + item_groups.zerg_buildings, self.player) >= target
+            ) and (
+                # Anything that can hit buildings
+                state.has_any((
+                    item_names.ZERGLING, item_names.SWARM_QUEEN,
+                    item_names.ROACH, item_names.HYDRALISK,
+                    item_names.ABERRATION, item_names.SWARM_HOST,
+                    item_names.MUTALISK, item_names.ULTRALISK,
+                    item_names.PYGALISK,
+                    item_names.INFESTED_MARINE, item_names.INFESTED_BUNKER,
+                    item_names.INFESTED_DIAMONDBACK, item_names.INFESTED_SIEGE_TANK,
+                    item_names.INFESTED_BANSHEE,
+                    # Mercs with <= 300s first drop time
+                    item_names.DEVOURING_ONES, item_names.HUNTER_KILLERS,
+                    item_names.THORNSHELL, item_names.HUNTERLING,
+                ), self.player)
+                or state.has_all((item_names.INFESTOR, item_names.INFESTOR_INFESTED_TERRAN), self.player)
+                or self.morph_baneling(state)
+                or self.morph_lurker(state)
+                or self.morph_impaler(state)
+                or self.morph_brood_lord(state)
+                or self.morph_guardian(state)
+                or self.morph_ravager(state)
+                or self.morph_igniter(state)
+                or self.morph_tyrannozor(state)
+                or self.morph_devourer(state) and state.has(item_names.DEVOURER_PRESCIENT_SPORES, self.player)
+            )
+        return _has_zerg_units
+
+    def has_protoss_units(self, target: int) -> Callable[['CollectionState'], bool]:
+        def _has_protoss_units(state: CollectionState) -> bool:
+            return (
+                state.count_from_list_unique(
+                    item_groups.protoss_units
+                    + item_groups.protoss_buildings
+                    + [item_names.NEXUS_OVERCHARGE],
+                    self.player
+                ) >= target
+            ) and (
+                # Anything that can hit buildings
+                state.has_any((
+                    # Gateway
+                    item_names.ZEALOT, item_names.CENTURION, item_names.SENTINEL, item_names.SUPPLICANT,
+                    item_names.STALKER, item_names.INSTIGATOR, item_names.SLAYER,
+                    item_names.DRAGOON, item_names.ADEPT,
+                    item_names.SENTRY, item_names.ENERGIZER,
+                    item_names.AVENGER, item_names.DARK_TEMPLAR, item_names.BLOOD_HUNTER,
+                    item_names.HIGH_TEMPLAR, item_names.SIGNIFIER, item_names.ASCENDANT,
+                    item_names.DARK_ARCHON,
+                    # Robo
+                    item_names.IMMORTAL, item_names.ANNIHILATOR, item_names.VANGUARD, item_names.STALWART,
+                    item_names.COLOSSUS, item_names.WRATHWALKER,
+                    item_names.REAVER, item_names.DISRUPTOR,
+                    # Stargate
+                    item_names.SKIRMISHER,
+                    item_names.SCOUT, item_names.MISTWING, item_names.OPPRESSOR,
+                    item_names.INTERCESSOR, item_names.VOID_RAY, item_names.DESTROYER, item_names.DAWNBRINGER,
+                    item_names.ARBITER, item_names.ORACLE,
+                    item_names.CARRIER, item_names.TRIREME, item_names.SKYLORD,
+                    item_names.TEMPEST, item_names.MOTHERSHIP,
+                ), self.player)
+                or state.has_all((item_names.WARP_PRISM, item_names.WARP_PRISM_PHASE_BLASTER), self.player)
+                or state.has_all((item_names.CALADRIUS, item_names.CALADRIUS_CORONA_BEAM), self.player)
+                or state.has_all((item_names.PHOTON_CANNON, item_names.KHALAI_INGENUITY), self.player)
+            )
+        return _has_protoss_units
+
+    def has_race_units(self, target: int, race: SC2Race) -> Callable[['CollectionState'], bool]:
+        if target == 0 or race == SC2Race.ANY:
+            return Location.access_rule
+        result = self.unit_count_functions.get((race, target))
+        if result is not None:
+            return result
+        if race == SC2Race.TERRAN:
+            result = self.has_terran_units(target)
+        if race == SC2Race.ZERG:
+            result = self.has_zerg_units(target)
+        if race == SC2Race.PROTOSS:
+            result = self.has_protoss_units(target)
+        assert result
+        self.unit_count_functions[(race, target)] = result
+        return result
 
 
 def get_basic_units(logic_level: int, race: SC2Race) -> Set[str]:
-    if logic_level == RequiredTactics.option_no_logic:
+    if logic_level > RequiredTactics.option_advanced:
         return no_logic_basic_units[race]
     elif logic_level == RequiredTactics.option_advanced:
         return advanced_basic_units[race]
     else:
         return basic_units[race]
-
-
-def has_terran_units(player: int, target: int) -> Callable[['CollectionState'], bool]:
-    def _has_terran_units(state: CollectionState) -> bool:
-        return (
-            state.count_from_list_unique(item_groups.terran_units + item_groups.terran_buildings, player) >= target
-        )
-    return _has_terran_units
-
-
-def has_zerg_units(player: int, target: int) -> Callable[['CollectionState'], bool]:
-    def _has_zerg_units(state: CollectionState) -> bool:
-        return (
-            state.count_from_list_unique(item_groups.zerg_units + item_groups.zerg_buildings, player) >= target
-        )
-    return _has_zerg_units
-
-
-def has_protoss_units(player: int, target: int) -> Callable[['CollectionState'], bool]:
-    def _has_protoss_units(state: CollectionState) -> bool:
-        return (
-            state.count_from_list_unique(
-                item_groups.protoss_units
-                + item_groups.protoss_buildings
-                + [item_names.NEXUS_OVERCHARGE],
-                player
-            ) >= target
-        )
-    return _has_protoss_units
-
-
-def has_race_units(player: int, target: int, race: SC2Race) -> Callable[['CollectionState'], bool]:
-    if race == SC2Race.TERRAN:
-        return has_terran_units(player, target)
-    if race == SC2Race.ZERG:
-        return has_zerg_units(player, target)
-    if race == SC2Race.PROTOSS:
-        return has_protoss_units(player, target)
-    return Location.access_rule

--- a/worlds/sc2/test/test_rules.py
+++ b/worlds/sc2/test/test_rules.py
@@ -9,14 +9,14 @@ import Options as CoreOptions
 from .. import options, locations
 from ..item import item_tables
 from ..rules import SC2Logic
-from .. import mission_tables
+from ..mission_tables import SC2Race, MissionFlag, lookup_name_to_mission
 
 
 class TestInventory:
     """
     Runs checks against inventory with validation if all target items are progression and returns a random result
     """
-    def __init__(self):
+    def __init__(self) -> None:
         self.random: Random = Random()
         self.progression_types: Set[ItemClassification] = {ItemClassification.progression, ItemClassification.progression_skip_balancing}
 
@@ -66,7 +66,7 @@ class TestWorld:
     """
     Mock world to simulate different player options for logic rules
     """
-    def __init__(self):
+    def __init__(self) -> None:
         defaults = dict()
         for field in fields(options.Starcraft2Options):
             field_class = field.type
@@ -86,7 +86,7 @@ class TestWorld:
 
 
 class TestRules(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.required_tactics_values: List[int] = [
             options.RequiredTactics.option_standard, options.RequiredTactics.option_advanced
         ]
@@ -116,7 +116,7 @@ class TestRules(unittest.TestCase):
         test_world.options.take_over_ai_allies.value = take_over_ai_allies
         test_world.options.kerrigan_presence.value = kerrigan_presence
         test_world.options.spear_of_adun_autonomously_cast_ability_presence.value = spear_of_adun_passive_presence
-        test_world.logic = SC2Logic(test_world)
+        test_world.logic = SC2Logic(test_world)  # type: ignore
         return test_world
 
     def test_items_in_rules_are_progression(self):
@@ -128,7 +128,7 @@ class TestRules(unittest.TestCase):
                 for _ in range(self.NUM_TEST_RUNS):
                     location.rule(test_inventory)
     
-    def test_items_in_all_in_are_progression(self) -> None:
+    def test_items_in_all_in_are_progression(self):
         test_inventory = TestInventory()
         for test_options in itertools.product(self.required_tactics_values, self.all_in_map_values):
             test_world = self._get_world(required_tactics=test_options[0], all_in_map=test_options[1])
@@ -138,29 +138,29 @@ class TestRules(unittest.TestCase):
                 for _ in range(self.NUM_TEST_RUNS):
                     location.rule(test_inventory)
 
-    def test_items_in_kerriganless_missions_are_progression(self) -> None:
+    def test_items_in_kerriganless_missions_are_progression(self):
         test_inventory = TestInventory()
         for test_options in itertools.product(self.required_tactics_values, self.kerrigan_presence_values):
             test_world = self._get_world(required_tactics=test_options[0], kerrigan_presence=test_options[1])
             for location in locations.get_locations(test_world):
-                mission = mission_tables.lookup_name_to_mission[location.region]
-                if mission_tables.MissionFlag.Kerrigan not in mission.flags:
+                mission = lookup_name_to_mission[location.region]
+                if MissionFlag.Kerrigan not in mission.flags:
                     continue
                 for _ in range(self.NUM_TEST_RUNS):
                     location.rule(test_inventory)
 
-    def test_items_in_ai_takeover_missions_are_progression(self) -> None:
+    def test_items_in_ai_takeover_missions_are_progression(self):
         test_inventory = TestInventory()
         for test_options in itertools.product(self.required_tactics_values, self.take_over_ai_allies_values):
             test_world = self._get_world(required_tactics=test_options[0], take_over_ai_allies=test_options[1])
             for location in locations.get_locations(test_world):
-                mission = mission_tables.lookup_name_to_mission[location.region]
-                if mission_tables.MissionFlag.AiAlly not in mission.flags:
+                mission = lookup_name_to_mission[location.region]
+                if MissionFlag.AiAlly not in mission.flags:
                     continue
                 for _ in range(self.NUM_TEST_RUNS):
                     location.rule(test_inventory)
     
-    def test_items_in_hard_rules_are_progression(self) -> None:
+    def test_items_in_hard_rules_are_progression(self):
         test_inventory = TestInventory()
         test_world = TestWorld()
         test_world.options.required_tactics.value = options.RequiredTactics.option_any_units
@@ -171,13 +171,13 @@ class TestRules(unittest.TestCase):
                 for _ in range(10):
                     location.hard_rule(test_inventory)
 
-    def test_items_in_any_units_rules_are_progression(self) -> None:
+    def test_items_in_any_units_rules_are_progression(self):
         test_inventory = TestInventory()
         test_world = TestWorld()
         test_world.options.required_tactics.value = options.RequiredTactics.option_any_units
         logic = SC2Logic(test_world)
         test_world.logic = logic
-        for race in (mission_tables.SC2Race.TERRAN, mission_tables.SC2Race.PROTOSS, mission_tables.SC2Race.ZERG):
+        for race in (SC2Race.TERRAN, SC2Race.PROTOSS, SC2Race.ZERG):
             for target in range(1, 5):
                 rule = logic.has_race_units(target, race)
                 for _ in range(10):

--- a/worlds/sc2/test/test_rules.py
+++ b/worlds/sc2/test/test_rules.py
@@ -62,16 +62,6 @@ class TestInventory:
         return sum(self.count(item_name, player) for item_name in items)
 
 
-class AnyUnitsTestInventory(TestInventory):
-    def has(self, item: str, player: int, count: int = 1) -> bool:
-        return False
-    
-    def count(self, item: str, player: int) -> int:
-        super().count(item, player)
-        # Always return enough to pass the 'and' portion of the check
-        return 2
-
-
 class TestWorld:
     """
     Mock world to simulate different player options for logic rules

--- a/worlds/sc2/test/test_rules.py
+++ b/worlds/sc2/test/test_rules.py
@@ -21,7 +21,7 @@ class TestInventory:
         self.progression_types: Set[ItemClassification] = {ItemClassification.progression, ItemClassification.progression_skip_balancing}
 
     def is_item_progression(self, item: str) -> bool:
-        return item_tables.get_full_item_list()[item].classification in self.progression_types
+        return item_tables.item_table[item].classification in self.progression_types
 
     def random_boolean(self):
         return self.random.choice([True, False])
@@ -138,9 +138,9 @@ class TestRules(unittest.TestCase):
         test_inventory = TestInventory()
         for test_world in self.test_worlds:
             location_data = locations.get_locations(test_world)
-            for _ in range(100):
-                for location in location_data:
-                    if location.rule is not None:
+            for location in location_data:
+                if location.rule is not None:
+                    for _ in range(100):
                         location.rule(test_inventory)
     
     def test_items_in_hard_rules_are_progression(self) -> None:
@@ -149,9 +149,9 @@ class TestRules(unittest.TestCase):
         test_world.options.required_tactics.value = options.RequiredTactics.option_any_units
         test_world.logic = SC2Logic(test_world)
         location_data = locations.get_locations(test_world)
-        for _ in range(10):
-            for location in location_data:
-                if location.hard_rule is not None:
+        for location in location_data:
+            if location.hard_rule is not None:
+                for _ in range(10):
                     location.hard_rule(test_inventory)
 
     def test_items_in_any_units_rules_are_progression(self) -> None:

--- a/worlds/sc2/test/test_rules.py
+++ b/worlds/sc2/test/test_rules.py
@@ -6,8 +6,9 @@ from typing import List, Set, Iterable
 
 from BaseClasses import ItemClassification, MultiWorld
 import Options as CoreOptions
-from worlds.sc2 import options, locations
-from worlds.sc2.item import item_tables
+from .. import options, locations
+from ..item import item_tables
+from ..rules import SC2Logic
 
 
 class TestInventory:
@@ -64,15 +65,6 @@ class TestWorld:
     """
     Mock world to simulate different player options for logic rules
     """
-    has_barracks_unit: bool = True
-    has_factory_unit: bool = True
-    has_starport_unit: bool = True
-    has_zerg_melee_unit: bool = True
-    has_zerg_ranged_unit: bool = True
-    has_zerg_air_unit: bool = True
-    has_protoss_ground_unit: bool = True
-    has_protoss_air_unit: bool = True
-
     def __init__(self):
         defaults = dict()
         for field in fields(options.Starcraft2Options):
@@ -96,19 +88,22 @@ class TestRules(unittest.TestCase):
     def __init__(self, methodName='runTest'):
         unittest.TestCase.__init__(self, methodName)
 
-        required_tactics: List[options.RequiredTactics] = \
-            [options.RequiredTactics.option_standard, options.RequiredTactics.option_advanced]
-        all_in_map: List[options.AllInMap] = \
-            [options.AllInMap.option_ground, options.AllInMap.option_air]
-        take_over_ai_allies: List[options.TakeOverAIAllies] = \
-            [options.TakeOverAIAllies.option_true, options.TakeOverAIAllies.option_false]
-        kerrigan_presence: List[options.KerriganPresence] = \
-            [options.KerriganPresence.option_vanilla, options.KerriganPresence.option_not_present]
-        spear_of_adun_autonomously_cast_presence: List[options.SpearOfAdunAutonomouslyCastAbilityPresence] = \
-            [
-                options.SpearOfAdunAutonomouslyCastAbilityPresence.option_everywhere,
-                options.SpearOfAdunAutonomouslyCastAbilityPresence.option_not_present
-            ]
+        required_tactics: List[options.RequiredTactics] = [
+            options.RequiredTactics.option_standard, options.RequiredTactics.option_advanced
+        ]
+        all_in_map: List[options.AllInMap] = [
+            options.AllInMap.option_ground, options.AllInMap.option_air
+        ]
+        take_over_ai_allies: List[options.TakeOverAIAllies] = [
+            options.TakeOverAIAllies.option_true, options.TakeOverAIAllies.option_false
+        ]
+        kerrigan_presence: List[options.KerriganPresence] = [
+            options.KerriganPresence.option_vanilla, options.KerriganPresence.option_not_present
+        ]
+        spear_of_adun_autonomously_cast_presence: List[options.SpearOfAdunAutonomouslyCastAbilityPresence] = [
+            options.SpearOfAdunAutonomouslyCastAbilityPresence.option_everywhere,
+            options.SpearOfAdunAutonomouslyCastAbilityPresence.option_not_present
+        ]
 
         self.test_worlds: List[TestWorld] = []
         for option_tuple in itertools.product(
@@ -124,6 +119,7 @@ class TestRules(unittest.TestCase):
             test_world.options.take_over_ai_allies.value = option_tuple[2]
             test_world.options.kerrigan_presence.value = option_tuple[3]
             test_world.options.spear_of_adun_autonomously_cast_ability_presence.value = option_tuple[4]
+            test_world.logic = SC2Logic(test_world)
 
             self.test_worlds.append(test_world)
 


### PR DESCRIPTION
Also refactoring logic slightly to allow reusing lambdas more easily

## What is this fixing or adding?
Following some feedback from any_units enjoyers, I'm trying to restrict the options of what the first unit given is. The benchmark I'm following is that the unit:
* Must be able to attack buildings
* If it is a merc, its initial cooldown must be less than or equal to 300s (5min)

This should rule out stupid or unbeatable situations like medic+medivac or defiler first or somesuch. I think it would be reasonable to go sillier, say by allowing more merc types in combination with cooldown-reduction items or allowing more terran buildings in combination with multibuild. I'll leave things at this stage for now to await feedback.

### Refactor
I fixed some old annoyances with the logic object:
* Moved the constructor to the top of the file
* It no longer holds a reference to the world object
* The world object now holds a reference to the logic after it's created
  * This means that we can store the logic object and reuse it down the line, such as for creating any_units logic rules
* Integrated any_units logic rules with the SC2Logic object
  * Cached the any_units logic rule lambdas to slightly reduce the number of duplicate objects being created in memory

Other changes:
* Many units are now progression. Aegis Guard not being progression was criminal
* Moved protoss units down in the item_tables.py file to be with the other protoss units
  * Left a comment at the original location to notify about in-use IDs elsewhere

## How was this tested?
Generated several worlds and checked the spoiler. Verified that initial units were always attacking units.

## If this makes graphical changes, please attach screenshots.
None