### PR TITLE
SC2: Add Warhound Deploy Turret

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -299,6 +299,7 @@ item_descriptions = {
     item_names.DIAMONDBACK_ION_THRUSTERS: "Increases Diamondback movement speed.",
     item_names.WARHOUND_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(item_names.WARHOUND),
     item_names.WARHOUND_REINFORCED_PLATING: "Increases Warhound armor by 2.",
+    item_names.WARHOUND_DEPLOY_TURRET: "Each Warhound can deploy a single-use Auto-Turret.",
     item_names.HERC_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(item_names.HERC),
     item_names.HERC_JUGGERNAUT_PLATING: "Increases HERC armor by 2.",
     item_names.HERC_KINETIC_FOAM: "Increases HERC life by 50.",

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -312,6 +312,7 @@ VULTURE_PROGRESSIVE_REPLENISHABLE_MAGAZINE         = "Progressive Replenishable 
 VULTURE_AUTO_REPAIR                                = "Auto-Repair (Vulture)"
 WARHOUND_RESOURCE_EFFICIENCY                       = "Resource Efficiency (Warhound)"
 WARHOUND_REINFORCED_PLATING                        = "Reinforced Plating (Warhound)"
+WARHOUND_DEPLOY_TURRET                             = "Deploy Turret (Warhound)"
 WIDOW_MINE_BLACK_MARKET_LAUNCHERS                  = "Black Market Launchers (Widow Mine)"
 WIDOW_MINE_CONCEALMENT                             = "Concealment (Widow Mine)"
 WIDOW_MINE_DEMOLITION_ARMAMENTS                    = "Demolition Armaments (Widow Mine)"

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1080,6 +1080,9 @@ item_table = {
     item_names.SENSOR_TOWER_ENHANCED_VISION:
         ItemData(765 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 19, SC2Race.TERRAN,
                  parent=item_names.SENSOR_TOWER),
+    item_names.WARHOUND_DEPLOY_TURRET:
+        ItemData(765 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 20, SC2Race.TERRAN,
+                 parent=item_names.WARHOUND),
 
     # Filler items to fill remaining spots
     item_names.STARTING_MINERALS:

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1081,7 +1081,7 @@ item_table = {
         ItemData(765 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 19, SC2Race.TERRAN,
                  parent=item_names.SENSOR_TOWER),
     item_names.WARHOUND_DEPLOY_TURRET:
-        ItemData(765 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 20, SC2Race.TERRAN,
+        ItemData(766 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 20, SC2Race.TERRAN,
                  parent=item_names.WARHOUND),
 
     # Filler items to fill remaining spots


### PR DESCRIPTION
## What is this fixing or adding?
Adding a deployable Auto Turret (directly the Raven's turret, affected by its upgrades) to the Warhound. Related https://github.com/Ziktofel/Archipelago-SC2-data/pull/374

## How was this tested?
Locally tested by generating a game and giving it through the cheat console:
![SC2_x64_J0KzcEV17F](https://github.com/user-attachments/assets/ff1bd650-6fe7-44ac-807e-32c785da1c7f)
![firefox_pFPAV9oSM7](https://github.com/user-attachments/assets/12a2d5e5-36dd-4768-81f2-a22cde669d14)
![SC2_x64_gyWfvz0vge](https://github.com/user-attachments/assets/95530fbd-f3e7-4edd-ab8a-08590cc0a8f6)
938f-06b549bf6e17)