### PR TITLE
sc2: Fixing offset window position when using window size settings

### DIFF
--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -141,7 +141,10 @@ class SC2Manager(GameManager):
         from . import gui_config
         warnings, window_width, window_height = gui_config.get_window_defaults()
         from kivy.core.window import Window
+        original_size_x, original_size_y = Window.size
         Window.size = window_width, window_height
+        Window.left -= max((window_width - original_size_x) // 2, 0)
+        Window.top -= max((window_height - original_size_y) // 2, 0)
         # Add the logging handler manually here instead of using `logging_pairs` to avoid adding 2 unnecessary tabs
         logging.getLogger("Starcraft2").addHandler(LogtoUI(self.log_panels["All"].on_log))
         for startup_warning in warnings:


### PR DESCRIPTION
## What is this fixing or adding?
When using the `window_width` and `window_height` sc2 host.yaml settings, the window was being resized but not re-centered. This means that when setting the numbers high, the window would tend to spill off the screen and would have to be repositioned. This is especially irritating because the GUI can be unresponsive for a couple settings on startup if connecting with command-line args.

This fixes that by adjusting the window position by half the change in width and height.

## How was this tested?
Started the client, verified the window was centered. Set the `window_width` to 2400 and restarted the client, verified the window was still centered.

## If this makes graphical changes, please attach screenshots
![window_centered](https://github.com/user-attachments/assets/8c648fa7-4c36-4e5f-b666-cc473ff1b035)

