### PR TITLE
Non-vanilla raceswap options + raceswap support for campaign mission orders

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1177,7 +1177,7 @@ class SC2Context(CommonContext):
 
         # Build response data
         unit_counts: typing.Dict[str, int] = {}
-        slots_to_update: typing.Dict[str, typing.Dict[str, int]] = {}
+        slots_to_update: typing.Dict[str, typing.Dict[int, typing.Dict[str, int]]] = {}
         for (unit, slot, send_time) in units:
             unit_counts[unit] = unit_counts.get(unit, 0) + 1
             if slot not in slots_to_update:

--- a/worlds/sc2/docs/custom_mission_orders_en.md
+++ b/worlds/sc2/docs/custom_mission_orders_en.md
@@ -23,6 +23,7 @@
     - [Static Presets](#static-presets)
       - [Preset Options](#preset-options)
         - [Missions](#missions)
+        - [Shuffle Raceswaps](#shuffle-raceswaps)
         - [Keys](#keys)
     - [Golden Path](#golden-path)
   - [Layout Options](#layout-options)
@@ -644,6 +645,7 @@ With all presets, you can override their layout options by defining the layouts 
     My Campaign:
       preset: wol + prophecy
       missions: random # Optional
+      shuffle_raceswaps: false # Optional
       keys: none # Optional
       Prophecy:
         mission_pool:
@@ -690,6 +692,9 @@ The `missions` option accepts these possible values:
 - `random` (default), which removes pre-defined `mission_pool` options from layouts and missions, meaning all missions will follow the pool defined in your campaign's `global` layout. This is the default if you don't define the `missions` option.
 - `vanilla_shuffled`, which will leave `mission_pool`s on layouts to shuffle vanilla missions within their respective campaigns.
 - `vanilla`, which will leave all missions as they are in the vanilla campaigns.
+
+##### Shuffle Raceswaps
+The `shuffle_raceswaps` option accepts `true` and `false` (default). If enabled, the missions pools in the preset will contain raceswapped missions. This means `missions: vanilla_shuffled` will shuffle raceswaps alongside their regular variants, and `missions: vanilla` will allow a random variant of the mission in each slot. This option does nothing if `missions` is set to `random`.
 
 ##### Keys
 The `keys` option accepts these possible values:

--- a/worlds/sc2/mission_order/presets_static.py
+++ b/worlds/sc2/mission_order/presets_static.py
@@ -785,7 +785,7 @@ def _build_static_preset(preset: Dict[str, Any], options: Dict[str, Any]) -> Dic
     elif not isinstance(raceswaps, bool):
         # The presets are set up for no raceswaps, so this covers the case that the option is not a bool
         raise ValueError(
-            f"Preset option \"shuffle_raceswaps\" received unknown value \"{missions}\".\n"
+            f"Preset option \"shuffle_raceswaps\" received unknown value \"{raceswaps}\".\n"
             "Valid values are: true, false"
         )
 

--- a/worlds/sc2/mission_order/presets_static.py
+++ b/worlds/sc2/mission_order/presets_static.py
@@ -763,7 +763,12 @@ preset_nco = {
 def _build_static_preset(preset: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, Any]:
     # Raceswap shuffling
     raceswaps = options.pop("shuffle_raceswaps", False)
-    if raceswaps == True:
+    if not isinstance(raceswaps, bool):
+        raise ValueError(
+            f"Preset option \"shuffle_raceswaps\" received unknown value \"{raceswaps}\".\n"
+            "Valid values are: true, false"
+        )
+    elif raceswaps == True:
         # Remove "~ Raceswap Missions" operation from mission pool options
         # Also add raceswap variants to plando'd vanilla missions
         for layout in preset.values():
@@ -782,12 +787,7 @@ def _build_static_preset(preset: Dict[str, Any], options: Dict[str, Any]) -> Dic
                             mission_name = slot_mission_pool[:slot_mission_pool.rfind("(")]
                             new_mission_pool = [f"{mission_name}({race})" for race in ["Terran", "Zerg", "Protoss"]]
                             slot["mission_pool"] = new_mission_pool
-    elif not isinstance(raceswaps, bool):
-        # The presets are set up for no raceswaps, so this covers the case that the option is not a bool
-        raise ValueError(
-            f"Preset option \"shuffle_raceswaps\" received unknown value \"{raceswaps}\".\n"
-            "Valid values are: true, false"
-        )
+    # The presets are set up for no raceswaps, so raceswaps == False doesn't need to be covered
 
     # Mission pool selection
     missions = options.pop("missions", "random")

--- a/worlds/sc2/mission_order/presets_static.py
+++ b/worlds/sc2/mission_order/presets_static.py
@@ -761,6 +761,34 @@ preset_nco = {
 }
 
 def _build_static_preset(preset: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, Any]:
+    # Raceswap shuffling
+    raceswaps = options.pop("shuffle_raceswaps", False)
+    if raceswaps == True:
+        # Remove "~ Raceswap Missions" operation from mission pool options
+        # Also add raceswap variants to plando'd vanilla missions
+        for layout in preset.values():
+            if type(layout) == dict:
+                # Currently mission pools in layouts are always ["X campaign missions", "~ raceswap missions"]
+                layout_mission_pool: List[str] = layout.get("mission_pool", None)
+                if layout_mission_pool is not None:
+                    layout_mission_pool.pop()
+                    layout["mission_pool"] = layout_mission_pool
+                if "missions" in layout:
+                    for slot in layout["missions"]:
+                        # Currently mission pools in slots are always strings
+                        slot_mission_pool: str = slot.get("mission_pool", None)
+                        # Identify raceswappable missions by their race in brackets
+                        if slot_mission_pool is not None and slot_mission_pool[-1] == ")":
+                            mission_name = slot_mission_pool[:slot_mission_pool.rfind("(")]
+                            new_mission_pool = [f"{mission_name}({race})" for race in ["Terran", "Zerg", "Protoss"]]
+                            slot["mission_pool"] = new_mission_pool
+    elif not isinstance(raceswaps, bool):
+        # The presets are set up for no raceswaps, so this covers the case that the option is not a bool
+        raise ValueError(
+            f"Preset option \"shuffle_raceswaps\" received unknown value \"{missions}\".\n"
+            "Valid values are: true, false"
+        )
+
     # Mission pool selection
     missions = options.pop("missions", "random")
     if missions == "vanilla":

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -1381,11 +1381,11 @@ def get_disabled_campaigns(world: 'SC2World') -> Set[SC2Campaign]:
 
 
 def get_disabled_flags(world: 'SC2World') -> MissionFlag:
-    excluded = (MissionFlag.Terran|MissionFlag.Zerg|MissionFlag.Protoss) ^ MissionFlag(get_option_value(world, "selected_races"))
+    excluded = (MissionFlag.Terran|MissionFlag.Zerg|MissionFlag.Protoss) ^ MissionFlag(world.options.selected_races.value)
     # filter out no-build missions
-    if not get_option_value(world, "shuffle_no_build"):
+    if not world.options.shuffle_no_build.value:
         excluded |= MissionFlag.NoBuild
-    raceswap_option = get_option_value(world, "enable_race_swap")
+    raceswap_option = world.options.enable_race_swap.value
     if raceswap_option == EnableRaceSwapVariants.option_disabled:
         excluded |= MissionFlag.RaceSwap
     elif raceswap_option in [EnableRaceSwapVariants.option_pick_one_non_vanilla, EnableRaceSwapVariants.option_shuffle_all_non_vanilla]:
@@ -1420,7 +1420,7 @@ def get_excluded_missions(world: 'SC2World') -> Set[SC2Mission]:
     for campaign in disabled_campaigns:
         excluded_missions = excluded_missions.union(campaign_mission_table[campaign])
     # Omitting unwanted mission variants
-    if get_option_value(world, "enable_race_swap") in [EnableRaceSwapVariants.option_pick_one, EnableRaceSwapVariants.option_pick_one_non_vanilla]:
+    if world.options.enable_race_swap.value in [EnableRaceSwapVariants.option_pick_one, EnableRaceSwapVariants.option_pick_one_non_vanilla]:
         swaps = [
             mission for mission in SC2Mission
             if mission not in excluded_missions

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -73,7 +73,6 @@ class SelectRaces(Choice):
     option_terran_and_zerg = (MissionFlag.Terran|MissionFlag.Zerg).value
     option_terran_and_protoss = (MissionFlag.Terran|MissionFlag.Protoss).value
     option_zerg_and_protoss = (MissionFlag.Zerg|MissionFlag.Protoss).value
-    option_plando = 0
     default = option_all
 
 

--- a/worlds/sc2/regions.py
+++ b/worlds/sc2/regions.py
@@ -6,7 +6,7 @@ from .mission_tables import (
     campaign_final_mission_locations, campaign_alt_final_mission_locations
 )
 from .options import (
-    get_option_value, ShuffleNoBuild, RequiredTactics, ExtraLocations, ShuffleCampaigns,
+    ShuffleNoBuild, RequiredTactics, ExtraLocations, ShuffleCampaigns,
     kerrigan_unit_available, TakeOverAIAllies, MissionOrder, get_excluded_missions, get_enabled_campaigns, static_mission_orders,
     GridTwoStartPositions, KeyMode, EnableMissionRaceBalancing, EnableRaceSwapVariants
 )
@@ -68,13 +68,13 @@ def create_mission_order(
 
 def adjust_mission_pools(world: 'SC2World', pools: SC2MOGenMissionPools):
     # Mission pool changes
-    mission_order_type = get_option_value(world, "mission_order")
+    mission_order_type = world.options.mission_order.value
     enabled_campaigns = get_enabled_campaigns(world)
-    adv_tactics = get_option_value(world, "required_tactics") != RequiredTactics.option_standard
-    shuffle_no_build = get_option_value(world, "shuffle_no_build")
-    extra_locations = get_option_value(world, "extra_locations")
-    grant_story_tech = get_option_value(world, "grant_story_tech")
-    grant_story_levels = get_option_value(world, "grant_story_levels")
+    adv_tactics = world.options.required_tactics.value != RequiredTactics.option_standard
+    shuffle_no_build = world.options.shuffle_no_build.value
+    extra_locations = world.options.extra_locations.value
+    grant_story_tech = world.options.grant_story_tech.value
+    grant_story_levels = world.options.grant_story_levels.value
 
     # WoL
     if shuffle_no_build == ShuffleNoBuild.option_false or adv_tactics:
@@ -112,10 +112,10 @@ def adjust_mission_pools(world: 'SC2World', pools: SC2MOGenMissionPools):
     # Prologue's only valid starter is the goal mission
     if enabled_campaigns == {SC2Campaign.PROLOGUE} \
             or mission_order_type in static_mission_orders \
-            and get_option_value(world, "shuffle_campaigns") == ShuffleCampaigns.option_false:
+            and world.options.shuffle_campaigns.value == ShuffleCampaigns.option_false:
         pools.move_mission(SC2Mission.DARK_WHISPERS, Difficulty.EASY, Difficulty.STARTER)
     # HotS
-    kerriganless = get_option_value(world, "kerrigan_presence") not in kerrigan_unit_available \
+    kerriganless = world.options.kerrigan_presence.value not in kerrigan_unit_available \
         or SC2Campaign.HOTS not in enabled_campaigns
     if adv_tactics:
         # Medium -> Easy
@@ -136,7 +136,7 @@ def adjust_mission_pools(world: 'SC2World', pools: SC2MOGenMissionPools):
         # The player has, all the stuff he needs, provided under these settings
         pools.move_mission(SC2Mission.SUPREME, Difficulty.MEDIUM, Difficulty.STARTER)
         pools.move_mission(SC2Mission.THE_INFINITE_CYCLE, Difficulty.HARD, Difficulty.STARTER)
-    if get_option_value(world, "take_over_ai_allies") == TakeOverAIAllies.option_true:
+    if world.options.take_over_ai_allies.value == TakeOverAIAllies.option_true:
         pools.move_mission(SC2Mission.HARBINGER_OF_OBLIVION, Difficulty.MEDIUM, Difficulty.STARTER)
     if pools.get_pool_size(Difficulty.STARTER) < 2 and not kerriganless or adv_tactics:
         # Conditionally moving Easy missions to Starter
@@ -149,7 +149,7 @@ def adjust_mission_pools(world: 'SC2World', pools: SC2MOGenMissionPools):
         pools.move_mission(SC2Mission.FLASHPOINT, Difficulty.HARD, Difficulty.EASY)
 
 def setup_mission_pool_balancing(world: 'SC2World', pools: SC2MOGenMissionPools):
-    race_mission_balance = get_option_value(world, "mission_race_balancing")
+    race_mission_balance = world.options.mission_race_balancing.value
     flag_ratios: Dict[MissionFlag, int] = {}
     flag_weights: Dict[MissionFlag, int] = {}
     if race_mission_balance == EnableMissionRaceBalancing.option_semi_balanced:
@@ -172,18 +172,18 @@ def create_static_mission_order(world: 'SC2World', mission_order_type: int, miss
     enabled_campaigns = get_enabled_campaigns(world)
     if mission_order_type == MissionOrder.option_vanilla:
         missions = "vanilla"
-    elif get_option_value(world, "shuffle_campaigns") == ShuffleCampaigns.option_true:
+    elif world.options.shuffle_campaigns.value == ShuffleCampaigns.option_true:
         missions = "random"
     else:
         missions = "vanilla_shuffled"
     
-    if get_option_value(world, "enable_race_swap") == EnableRaceSwapVariants.option_disabled:
+    if world.options.enable_race_swap.value == EnableRaceSwapVariants.option_disabled:
         shuffle_raceswaps = False
     else:
         # Picking specific raceswap variants is handled by mission exclusion
         shuffle_raceswaps = True
 
-    key_mode_option = get_option_value(world, "key_mode")
+    key_mode_option = world.options.key_mode.value
     if key_mode_option == KeyMode.option_missions:
         keys = "missions"
     elif key_mode_option == KeyMode.option_questlines:
@@ -420,13 +420,13 @@ def make_grid(world: 'SC2World', size: int) -> Dict[str, Dict[str, Any]]:
             "display_name": "",
             "type": "grid",
             "size": size,
-            "two_start_positions": get_option_value(world, "grid_two_start_positions") == GridTwoStartPositions.option_true
+            "two_start_positions": world.options.grid_two_start_positions.value == GridTwoStartPositions.option_true
         }
     }
     return mission_order
 
 def make_golden_path(world: 'SC2World', size: int) -> Dict[str, Dict[str, Any]]:
-    key_mode = get_option_value(world, "key_mode")
+    key_mode = world.options.key_mode.value
     if key_mode == KeyMode.option_missions:
         keys = "missions"
     elif key_mode == KeyMode.option_questlines:
@@ -476,7 +476,7 @@ def make_hopscotch(world: 'SC2World', size: int) -> Dict[str, Dict[str, Any]]:
             "display_name": "",
             "type": "hopscotch",
             "size": size,
-            "two_start_positions": get_option_value(world, "grid_two_start_positions") == GridTwoStartPositions.option_true
+            "two_start_positions": world.options.grid_two_start_positions.value == GridTwoStartPositions.option_true
         }
     }
     return mission_order
@@ -501,7 +501,7 @@ def create_dynamic_mission_order(world: 'SC2World', mission_order_type: int, mis
     # Optionally add key requirements
     # This only works for layout types that don't define their own entry rules (which is currently all of them)
     # Golden Path handles Key Mode on its own
-    key_mode = get_option_value(world, "key_mode")
+    key_mode = world.options.key_mode.value
     if key_mode == KeyMode.option_missions:
         mission_order[list(mission_order.keys())[0]]["missions"] = [
             { "index": "all", "entry_rules": [{ "items": { "Key": 1 }}] },

--- a/worlds/sc2/regions.py
+++ b/worlds/sc2/regions.py
@@ -203,13 +203,14 @@ def create_static_mission_order(world: 'SC2World', mission_order_type: int, miss
             "keys": keys
         }
 
+    prophecy_enabled = SC2Campaign.PROPHECY in enabled_campaigns
     if SC2Campaign.WOL in enabled_campaigns:
-        mission_order[SC2Campaign.WOL.campaign_name] = mission_order_preset("wol")
-        
-    if SC2Campaign.PROPHECY in enabled_campaigns:
+        if prophecy_enabled:
+            mission_order[SC2Campaign.WOL.campaign_name] = mission_order_preset("wol + prophecy")
+        else:
+            mission_order[SC2Campaign.WOL.campaign_name] = mission_order_preset("wol")   
+    elif prophecy_enabled:
         mission_order[SC2Campaign.PROPHECY.campaign_name] = mission_order_preset("prophecy")
-        if SC2Campaign.WOL in enabled_campaigns:
-            mission_order[SC2Campaign.PROPHECY.campaign_name]["entry_rules"] = [{ "scope": SC2Campaign.WOL.campaign_name + "/Artifact/1" }]
 
     if SC2Campaign.HOTS in enabled_campaigns:
         mission_order[SC2Campaign.HOTS.campaign_name] = mission_order_preset("hots")


### PR DESCRIPTION
## What is this fixing or adding?
This PR aims to fulfill two recent feature requests:
- `enable_race_swap: pick_one_non_vanilla, shuffle_all_non_vanilla` are new options mirroring the existing ones that specifically avoid picking the vanilla mission
- `mission_order: vanilla, vanilla_shuffled, mini_campaign` now support raceswapping
I thought these two features might interact on some level, but in the end they use separate existing mechanisms, so this is a multi-purpose PR.

I also included some smaller changes:
- Fixed a type hint I forgot to update in the previous trade rework PR
- Removed the `selected_races: plando` option since it does nothing and its originally intended use with custom mission orders is obsolete (CMOs respect the option as it is, and plandoing is done via `mission_pool` directly in CMOs)
- Fixed WoL + Prophecy not having interconnected entry rules. I forgot about this in the CMO PR and as far as I know nobody has reported this as an issue, but WoL was not counting Prophecy for its mission count requirements and Prophecy didn't require the second mission of Artifact to unlock.

## How was this tested?
I generated a variety of combinations of `mission_order`, `enable_race_swap`, `selected_races`, `shuffle_campaigns`, and enabled campaigns, then checked the result in the client. I specifically checked that WoL + Prophecy has the correct mission requirements now.

## If this makes graphical changes, please attach screenshots.
Some examples of the new options:

- WoL
- `mission_order: vanilla`
- `enable_race_swap: shuffle_all`

![python_SElbkww756](https://github.com/user-attachments/assets/0045e492-7e0f-4129-9b3d-9d4eb188bd27)

- HotS + LotV
- `mission_order: mini_campaign`
- `enable_race_swap: pick_one_non_vanilla`

![python_ksZURfKKav](https://github.com/user-attachments/assets/45312e76-c71f-4df2-ac51-9f5a19af2813)

- HotS + LotV
- `mission_order: vanilla_shuffled`
- `enable_race_swap: shuffle_all_non_vanilla`
- `shuffle_campaigns: false`

![python_fhOOruHu2A](https://github.com/user-attachments/assets/da327727-ebc6-46dd-a3c4-701f3d36c0b3)

- WoL
- `mission_order: vanilla_shuffled`
- `enable_race_swap: shuffle_all`
- `enabled_races: protoss`

![python_FUb8mqkyLe](https://github.com/user-attachments/assets/693f00fc-598a-4791-a52c-b9b2b975ccc7)
