### PR TITLE
SC2: Add Supplicant war council item

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -899,6 +899,7 @@ item_descriptions = {
     item_names.SUPPLICANT_SOUL_AUGMENTATION: "Increases Supplicant max shields by +25.",
     item_names.SUPPLICANT_SHIELD_REGENERATION: "Increases Supplicant shield regeneration rate.",
     item_names.SUPPLICANT_ZENITH_PITCH: "Allows Supplicants to attack air units.",
+    item_names.SUPPLICANT_SACRIFICE: "Allows Supplicants to sacrifice themselves to save nearby units from death.",
     item_names.ADEPT_SHOCKWAVE: "When Adepts deal a finishing blow, their projectiles can jump onto 2 additional targets.",
     item_names.ADEPT_RESONATING_GLAIVES: "Increases Adept attack speed.",
     item_names.ADEPT_PHASE_BULWARK: "Increases Adept shield maximum by +50.",

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -713,6 +713,7 @@ SUPPLICANT_BLOOD_SHIELD                                 = "Blood Shield (Supplic
 SUPPLICANT_SOUL_AUGMENTATION                            = "Soul Augmentation (Supplicant)"
 SUPPLICANT_SHIELD_REGENERATION                          = "Shield Regeneration (Supplicant)"
 SUPPLICANT_ZENITH_PITCH                                 = "Zenith Pitch (Supplicant)"
+SUPPLICANT_SACRIFICE                                    = "Sacrifice (Supplicant)"
 ADEPT_SHOCKWAVE                                         = "Shockwave (Adept)"
 ADEPT_RESONATING_GLAIVES                                = "Resonating Glaives (Adept)"
 ADEPT_PHASE_BULWARK                                     = "Phase Bulwark (Adept)"

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1990,7 +1990,8 @@ item_table = {
     item_names.OPPRESSOR_VULCAN_BLASTER: ItemData(550 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 20, SC2Race.PROTOSS, parent=item_names.OPPRESSOR),
     item_names.CALADRIUS_CORONA_BEAM: ItemData(551 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 21, SC2Race.PROTOSS, parent=item_names.CALADRIUS),
     item_names.MISTWING_PHANTOM_DASH: ItemData(552 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 22, SC2Race.PROTOSS, parent=item_names.MISTWING),
-    
+    item_names.SUPPLICANT_SACRIFICE: ItemData(553 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.War_Council_2, 23, SC2Race.PROTOSS, parent=item_names.SUPPLICANT),
+
 
 
     # SoA Calldown powers


### PR DESCRIPTION
## What is this fixing or adding?

Adds the War Council item for Supplicants: **Sacrifice**
- Adds a toggleable ability to the Supplicant
- If toggled on, the Supplicant will sacrifice itself to prevent nearby player units from dying
- If a player unit within 8 range of an active Supplicant receives fatal damage, the nearest active Supplicant will instantly die instead, and the unit will survive
- Current HP and Shield of the supplicant will be transferred to the protected unit. Any surplus will be lost
- HP restores HP and shields restore shields at a 1 to 1 ratio, they do not convert into each other
- Will not protect other supplicants, workers, or units with max hp and max shields both lower than 40. Notably no zerglings

## How was this tested?

Local testmap for assets and functionality. Local campaign for item functionality and interactions with other items. Notably Guardian Shell and other death preventing abilities. Did some performance tests as well.

## If this makes graphical changes, please attach screenshots.

Sacrifice visuals:
![GIF 06 02 2025 16-20-53](https://github.com/user-attachments/assets/048e7807-e563-41e6-a4e5-719759dd9178)


Sacrifice buff. Right inactive, left active:
![GIF_05 02 2025_11-46-00](https://github.com/user-attachments/assets/cc49873b-7b94-4702-9589-8255fbb5bce4)


Icons: 
![GIF 06 02 2025 16-22-31](https://github.com/user-attachments/assets/6aaeac87-c21f-4fed-afcc-792e9e2e1771)


## Notes:
- Icons are ingame assets, slightly modified with Gimp.
- Uses a Player Response, so potential impact on performance. Not more than Guardian Shell though, my local tests didn't indicate any performance loss.
- Potentially fairly strong, might need some balance testing.

[Data PR](https://github.com/Ziktofel/Archipelago-SC2-data/pull/378)
