### PR TITLE
SC2: Add checks to endgame missions

### DIFF
--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2411,10 +2411,28 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.END_GAME.mission_name, "Victory", SC2NCO_LOC_ID_OFFSET + 900, LocationType.VICTORY,
             lambda state: logic.end_game_requirement(state) and logic.nova_any_weapon(state)
         ),
-        make_location_data(SC2Mission.END_GAME.mission_name, "Xanthos", SC2NCO_LOC_ID_OFFSET + 901, LocationType.VANILLA,
+        make_location_data(SC2Mission.END_GAME.mission_name, "Destroy the Xanthos", SC2NCO_LOC_ID_OFFSET + 901, LocationType.VANILLA,
             logic.end_game_requirement
         ),
-
+        make_location_data(SC2Mission.END_GAME.mission_name, "Disable Xanthos Railgun", SC2NCO_LOC_ID_OFFSET + 902, LocationType.EXTRA,
+            logic.end_game_requirement
+        ),
+        make_location_data(SC2Mission.END_GAME.mission_name, "Disable Xanthos Flamethrower", SC2NCO_LOC_ID_OFFSET + 903, LocationType.EXTRA,
+            logic.end_game_requirement
+        ),
+        make_location_data(SC2Mission.END_GAME.mission_name, "Disable Xanthos Fighter Bay", SC2NCO_LOC_ID_OFFSET + 904, LocationType.EXTRA,
+            logic.end_game_requirement
+        ),
+        make_location_data(SC2Mission.END_GAME.mission_name, "Disable Xanthos Missile Pods", SC2NCO_LOC_ID_OFFSET + 905, LocationType.EXTRA,
+            logic.end_game_requirement
+        ),
+        make_location_data(SC2Mission.END_GAME.mission_name, "Protect Hyperion", SC2NCO_LOC_ID_OFFSET + 906, LocationType.CHALLENGE,
+            logic.end_game_requirement
+        ),
+        make_location_data(SC2Mission.END_GAME.mission_name, "Destroy Orbital Commands", SC2NCO_LOC_ID_OFFSET + 907, LocationType.CHALLENGE,
+            logic.end_game_requirement,
+            flags=LocationFlag.PREVENTATIVE
+        ),
         # Mission Variants
         # 10X/20X - Liberation Day
         make_location_data(SC2Mission.THE_OUTLAWS_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 300, LocationType.VICTORY,

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2087,11 +2087,44 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Victory", SC2LOTV_LOC_ID_OFFSET + 2400, LocationType.VICTORY,
             logic.essence_of_eternity_requirement
         ),
-        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Void Trashers", SC2LOTV_LOC_ID_OFFSET + 2401, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Destroy 2 Void Thrashers", SC2LOTV_LOC_ID_OFFSET + 2401, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Destroy 4 Void Thrashers", SC2LOTV_LOC_ID_OFFSET + 2402, LocationType.EXTRA,
+            logic.essence_of_eternity_requirement
+        ),
+        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Destroy 6 Void Thrashers", SC2LOTV_LOC_ID_OFFSET + 2403, LocationType.EXTRA,
+            logic.essence_of_eternity_requirement
+        ),
+        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Destroy 8 Void Thrashers", SC2LOTV_LOC_ID_OFFSET + 2404, LocationType.EXTRA,
+            logic.essence_of_eternity_requirement
+        ),
+        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "No more than 15 Kerrigan Kills", SC2LOTV_LOC_ID_OFFSET + 2405, LocationType.MASTERY,
+            logic.essence_of_eternity_requirement,
+            flags=LocationFlag.PREVENTATIVE
+        ),
         make_location_data(SC2Mission.AMON_S_FALL.mission_name, "Victory", SC2LOTV_LOC_ID_OFFSET + 2500, LocationType.VICTORY,
             logic.amons_fall_requirement
         ),
-
+        make_location_data(SC2Mission.AMON_S_FALL.mission_name, "Destroy 1 Crystal", SC2LOTV_LOC_ID_OFFSET + 2501, LocationType.EXTRA,
+            logic.amons_fall_requirement
+        ),
+        make_location_data(SC2Mission.AMON_S_FALL.mission_name, "Destroy 2 Crystals", SC2LOTV_LOC_ID_OFFSET + 2502, LocationType.EXTRA,
+            logic.amons_fall_requirement
+        ),
+        make_location_data(SC2Mission.AMON_S_FALL.mission_name, "Destroy 3 Crystals", SC2LOTV_LOC_ID_OFFSET + 2503, LocationType.EXTRA,
+            logic.amons_fall_requirement
+        ),
+        make_location_data(SC2Mission.AMON_S_FALL.mission_name, "Destroy 4 Crystals", SC2LOTV_LOC_ID_OFFSET + 2504, LocationType.EXTRA,
+            logic.amons_fall_requirement
+        ),
+        make_location_data(SC2Mission.AMON_S_FALL.mission_name, "Destroy 5 Crystals", SC2LOTV_LOC_ID_OFFSET + 2505, LocationType.EXTRA,
+            logic.amons_fall_requirement
+        ),
+        make_location_data(SC2Mission.AMON_S_FALL.mission_name, "Destroy 6 Crystals", SC2LOTV_LOC_ID_OFFSET + 2506, LocationType.EXTRA,
+            logic.amons_fall_requirement
+        ),
+        make_location_data(SC2Mission.AMON_S_FALL.mission_name, "Clear Void Chasms", SC2LOTV_LOC_ID_OFFSET + 2507, LocationType.MASTERY,
+            logic.amons_fall_requirement
+        ),
         # Nova Covert Ops
         make_location_data(SC2Mission.THE_ESCAPE.mission_name, "Victory", SC2NCO_LOC_ID_OFFSET + 100, LocationType.VICTORY,
             logic.the_escape_requirement,

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2087,17 +2087,20 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Victory", SC2LOTV_LOC_ID_OFFSET + 2400, LocationType.VICTORY,
             logic.essence_of_eternity_requirement
         ),
-        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Destroy 2 Void Thrashers", SC2LOTV_LOC_ID_OFFSET + 2401, LocationType.EXTRA),
-        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Destroy 4 Void Thrashers", SC2LOTV_LOC_ID_OFFSET + 2402, LocationType.EXTRA,
+        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Initial Void Thrashers", SC2LOTV_LOC_ID_OFFSET + 2401, LocationType.EXTRA),
+        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Void Thrasher Wave 1", SC2LOTV_LOC_ID_OFFSET + 2402, LocationType.EXTRA,
             logic.essence_of_eternity_requirement
         ),
-        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Destroy 6 Void Thrashers", SC2LOTV_LOC_ID_OFFSET + 2403, LocationType.EXTRA,
+        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Void Thrasher Wave 2", SC2LOTV_LOC_ID_OFFSET + 2403, LocationType.EXTRA,
             logic.essence_of_eternity_requirement
         ),
-        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Destroy 8 Void Thrashers", SC2LOTV_LOC_ID_OFFSET + 2404, LocationType.EXTRA,
+        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Void Thrasher Wave 3", SC2LOTV_LOC_ID_OFFSET + 2404, LocationType.EXTRA,
             logic.essence_of_eternity_requirement
         ),
-        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "No more than 15 Kerrigan Kills", SC2LOTV_LOC_ID_OFFSET + 2405, LocationType.MASTERY,
+        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "Void Thrasher Wave 4", SC2LOTV_LOC_ID_OFFSET + 2405, LocationType.EXTRA,
+            logic.essence_of_eternity_requirement
+        ),
+        make_location_data(SC2Mission.THE_ESSENCE_OF_ETERNITY.mission_name, "No more than 15 Kerrigan Kills", SC2LOTV_LOC_ID_OFFSET + 2406, LocationType.MASTERY,
             logic.essence_of_eternity_requirement,
             flags=LocationFlag.PREVENTATIVE
         ),


### PR DESCRIPTION
## What is this fixing or adding?
Adds additional checks to some very hard endgame missions

Essence of Eternity:
- Destroy Void Thrashers. 8 Thrashers total, 1 check per 2 Thrashers. Category: Extra
  (replaces the check for the initial 2 Thrashers)
- No more than 15 Kerrigan Kills. Category: Preventive

Total checks for this mission: 1 Victory + 4 Thrashers + 1 Kerrigan kills = 6 checks for 20 minutes

Amon's Fall:
- Destroy Crystals. 7 Crystals total, 1 check per Crystal for the first 6. 7th Crystal equals Victory, so it doesn't get an additional check. Category: Extra
- Destroy all Void Chasms, after all Void Chasms have become active. All 7 Chasms have to have been active at least once, which takes about 12 minutes. Category: Mastery

Total checks: 1 Victory + 6 Crystals + 1 Chasms = 8 checks for... probably an hour. The chasm check is not easy.

Endgame:
- Disable Xanthos Subsystems. 4 different Weapons, 1 check for disabling each weapon for the first time. Category: Extra
- Destroy all Orbital Commands. 4 Orbital Commands on the map, 1 check for destroying all of them. Doesn't count re-build Orbitals. Category: Challenge
- Protect the Hyperion. When the Hyperion attacks, keep it alive for the entire duration of the attack, so it times out by it's own timer. 1 check for doing it once.  Category: Preventative

Total checks: 1 Victory + 1 Xanthos + 4 Subsystems + 1 Orbitals + 1 Hyperion = 8 checks for about 40 minutes

## How was this tested?

Local campaign, fulfilled the checks and deliberately failed them

[Data PR](https://github.com/Ziktofel/Archipelago-SC2-data/pull/379)
