### PR TITLE
SC2: Rework Infested Liberator defender mode

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -760,7 +760,7 @@ item_descriptions = {
     item_names.INFESTED_BANSHEE_ADVANCED_TARGETING_OPTICS: "Infested Banshees gain +2 range while cloaked.",
     item_names.INFESTED_LIBERATOR_CLOUD_DISPERSAL: "Infested Liberators instantly transform into a cloud of microscopic organisms while attacking, reducing the damage they take by 85%.",
     item_names.INFESTED_LIBERATOR_VIRAL_CONTAMINATION: "Increases the damage Infested Liberators deal to their primary target by 100%.",
-    item_names.INFESTED_LIBERATOR_DEFENDER_MODE: "Allows Infested Liberators to deploy into Defender Mode to attack ground units.",
+    item_names.INFESTED_LIBERATOR_DEFENDER_MODE: "Allows Infested Liberators to deploy into Defender Mode to attack ground units. Weapon knocks back the attack target and damages units behind it.",
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_SIEGE_TANK: _get_resource_efficiency_desc(item_names.INFESTED_SIEGE_TANK),
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_DIAMONDBACK: _get_resource_efficiency_desc(item_names.INFESTED_DIAMONDBACK),
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_BANSHEE: _get_resource_efficiency_desc(item_names.INFESTED_BANSHEE),


### PR DESCRIPTION
## What is this fixing or adding?

This is a rework for the Defender Mode of the Infested Liberator, to distinguish it from the Terran counterpart and add some Zerg flavor.

Area selection is no longer a circle, but a line/rectancle shape. Effective range is similar to Terran Liberators, but the total affected area is smaller.
Comparison Terran Liberator vs Infested Liberator:
![grafik](https://github.com/user-attachments/assets/61cfa7f8-cc2b-44ba-9dcf-e21956a24d58)

Area indicator fades out after setup to be less visually distracting. Inspired by melee Liberator changes:
![GIF 10 02 2025 11-44-26](https://github.com/user-attachments/assets/7985cc47-bc3d-4c32-b1b2-17ac3337ce67)


Weapon changed to a tentacle weapon. Weaker damage, but a small knockback, bonus damage to armored targets and splash damage in a small area behind the attack target.
![GIF 10 02 2025 11-46-31](https://github.com/user-attachments/assets/ffa64ad8-c1e2-4869-892e-2ab869025cb7)


## How was this tested?

Tested in local testmap for assets and functionality. Since the only client change is the description, it was not tested in a campaign so far.
[
Data PR
](https://github.com/Ziktofel/Archipelago-SC2-data/pull/381)