### PR TITLE
sc2: Location inclusion updates

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -34,6 +34,7 @@ from .mission_order import SC2MissionOrder
 
 
 logger = logging.getLogger("Starcraft 2")
+VICTORY_MODULO = 100
 
 
 class Starcraft2WebWorld(WebWorld):
@@ -203,16 +204,12 @@ class SC2World(World):
                 if not location.is_event:
                     assert location.address is not None
                     assert location.item is not None
-                    if lookup_location_id_to_type[location.address] == LocationType.VICTORY:
-                        location_name = location.name
-                        mission_item_classification[location_name] = location.item.classification.as_flag()
-                    elif lookup_location_id_to_type[location.address] == LocationType.VICTORY_CACHE:
+                    if lookup_location_id_to_type[location.address] == LocationType.VICTORY_CACHE:
                         # Ensure that if there are multiple items given for finishing a mission and that at least 
                         # one is progressive, the flag kept is progressive.
-                        # Assuming that the location added are always after the basic one, which is true as long as 
-                        # VICTORY_CACHE_OFFSET is a positive integer.
-                        if mission_item_classification[location_name] != ItemClassification.progression:
-                            mission_item_classification[location_name] = location.item.classification.as_flag() 
+                        location_name = self.location_id_to_name[(location.address // VICTORY_MODULO) * VICTORY_MODULO]
+                        old_classification = mission_item_classification.get(location_name, 0)
+                        mission_item_classification[location_name] = old_classification | location.item.classification.as_flag() 
                     else:
                         mission_item_classification[location.name] = location.item.classification.as_flag()
             slot_data["mission_item_classification"] = mission_item_classification

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -769,7 +769,7 @@ def flag_and_add_resource_locations(world: SC2World, item_list: List[FilterItem]
     plando_locations = get_plando_locations(world)
     filler_location_types = get_location_types(world, LocationInclusion.option_filler)
     filler_location_flags = get_location_flags(world, LocationInclusion.option_filler)
-    location_data = {sc2_location.name: sc2_location for sc2_location in get_locations(world)}
+    location_data = {sc2_location.name: sc2_location for sc2_location in DEFAULT_LOCATION_LIST}
     for location in open_locations:
         # Go through the locations that aren't locked yet (early unit, etc)
         if location.name not in plando_locations:

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -767,16 +767,16 @@ def flag_and_add_resource_locations(world: SC2World, item_list: List[FilterItem]
     """
     open_locations = [location for location in world.location_cache if location.item is None]
     plando_locations = get_plando_locations(world)
-    resource_location_types = get_location_types(world, LocationInclusion.option_resources)
-    resource_location_flags = get_location_flags(world, LocationInclusion.option_resources)
+    filler_location_types = get_location_types(world, LocationInclusion.option_filler)
+    filler_location_flags = get_location_flags(world, LocationInclusion.option_filler)
     location_data = {sc2_location.name: sc2_location for sc2_location in get_locations(world)}
     for location in open_locations:
         # Go through the locations that aren't locked yet (early unit, etc)
         if location.name not in plando_locations:
             # The location is not plando'd
             sc2_location = location_data[location.name]
-            if (sc2_location.type in resource_location_types
-                or (sc2_location.flags & resource_location_flags)
+            if (sc2_location.type in filler_location_types
+                or (sc2_location.flags & filler_location_flags)
             ):
                 item_name = world.get_filler_item_name()
                 item = create_item_with_correct_settings(world.player, item_name)

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -27,7 +27,7 @@ from CommonClient import CommonContext, server_loop, ClientCommandProcessor, gui
 from Utils import init_logging, is_windows, async_start
 from .item import item_names, item_parents
 from .item.item_groups import item_name_groups, unlisted_item_name_groups
-from . import options
+from . import options, VICTORY_MODULO
 from .options import (
     MissionOrder, KerriganPrimalStatus, kerrigan_unit_available, KerriganPresence, EnableMorphling, GameDifficulty,
     GameSpeed, GenericUpgradeItems, GenericUpgradeResearch, ColorChoice, GenericUpgradeMissions, MaxUpgradeLevel,
@@ -76,7 +76,6 @@ pool = concurrent.futures.ThreadPoolExecutor(1)
 loop = asyncio.get_event_loop_policy().new_event_loop()
 nest_asyncio.apply(loop)
 MAX_BONUS: int = 28
-VICTORY_MODULO: int = 100
 
 # GitHub repo where the Map/mod data is hosted for /download_data command
 DATA_REPO_OWNER = "Ziktofel"
@@ -648,6 +647,8 @@ class SC2Context(CommonContext):
         self.trade_lock_start: typing.Optional[float] = None
         self.trade_response: typing.Optional[str] = None
         self.difficulty_damage_modifier: int = DifficultyDamageModifier.default
+        self.mission_order_scouting = MissionOrderScouting.option_none
+        self.mission_item_classification: typing.Optional[typing.Dict[str, int]] = None
 
     async def server_auth(self, password_requested: bool = False) -> None:
         self.game = STARCRAFT2
@@ -838,7 +839,7 @@ class SC2Context(CommonContext):
             self.trade_age_limit = args["slot_data"].get("void_trade_age_limit", VoidTradeAgeLimit.default)
             self.difficulty_damage_modifier = args["slot_data"].get("difficulty_damage_modifier", DifficultyDamageModifier.option_true)
             self.mission_order_scouting = args["slot_data"].get("mission_order_scouting", MissionOrderScouting.option_none)
-            self.mission_item_classification = args["slot_data"].get("mission_item_classification", None)
+            self.mission_item_classification = args["slot_data"].get("mission_item_classification")
 
             if self.required_tactics == RequiredTactics.option_no_logic:
                 # Locking Grant Story Tech/Levels if no logic

--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -471,8 +471,8 @@ class SC2Manager(GameManager):
         title = location_type.name.title().replace("_", " ")
         if self.ctx.location_inclusions[location_type] == LocationInclusion.option_disabled:
             title += " (Nothing)"
-        elif self.ctx.location_inclusions[location_type] == LocationInclusion.option_resources:
-            title += " (Resources)"
+        elif self.ctx.location_inclusions[location_type] == LocationInclusion.option_filler:
+            title += " (Filler)"
         else:
             title += ""
         return title

--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -492,23 +492,25 @@ class SC2Manager(GameManager):
         else:
             return False
 
-
     def handle_scout_display(self, location_name: str) -> str:
+        if self.ctx.mission_item_classification is None:
+            return ""
         # Only one information is provided for the victory locations of a mission
         if " Cache (" in location_name:
             location_name = location_name.split(" Cache")[0]
         item_classification_key = self.ctx.mission_item_classification[location_name]
-        if item_classification_key == ItemClassification.filler:
-            return " [color=00EEEE](Filler)[/color]"
-        if item_classification_key == ItemClassification.progression:
+        if ((ItemClassification.progression & item_classification_key)
+            and (ItemClassification.useful & item_classification_key)
+        ):
+            # Uncommon, but some games do this to show off that an item is super-important
+            # This can also happen on a victory display if the cache holds both progression and useful
+            return " [color=AF99EF](Useful+Progression)[/color]"
+        if ItemClassification.progression & item_classification_key:
             return " [color=AF99EF](Progression)[/color]"
-        elif item_classification_key == ItemClassification.useful:
+        if ItemClassification.useful & item_classification_key:
             return " [color=6D8BE8](Useful)[/color]"
-        elif item_classification_key == ItemClassification.trap:
-            return " [color=FA8072](Trap)[/color]"
-        else:
-            # Should not happen, but better safe than sory
-            return ""
+        return " [color=00EEEE](Filler)[/color]"
+
 
 def start_gui(context: SC2Context):
     context.ui = SC2Manager(context)

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -36,6 +36,8 @@ class LocationType(enum.IntEnum):
 
 class LocationFlag(enum.IntFlag):
     NONE = 0
+    BASEBUST = enum.auto()
+    """Locations about killing challenging bases"""
     SPEEDRUN = enum.auto()
     """Locations that are about doing something fast"""
     PREVENTATIVE = enum.auto()
@@ -98,6 +100,8 @@ def get_location_flags(world: 'SC2World', inclusion_type: int) -> LocationFlag:
     :return: A list of location types that match the inclusion type
     """
     matching_location_flags = LocationFlag.NONE
+    if world.options.basebust_locations.value == inclusion_type:
+        matching_location_flags |= LocationFlag.BASEBUST
     if world.options.speedrun_locations.value == inclusion_type:
         matching_location_flags |= LocationFlag.SPEEDRUN
     if world.options.preventative_locations.value == inclusion_type:
@@ -181,16 +185,20 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and logic.terran_defense_rating(state, True) >= 2)
         ),
         make_location_data(SC2Mission.ZERO_HOUR.mission_name, "First Hatchery", SC2WOL_LOC_ID_OFFSET + 304, LocationType.CHALLENGE,
-            logic.terran_competent_comp
+            logic.terran_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ZERO_HOUR.mission_name, "Second Hatchery", SC2WOL_LOC_ID_OFFSET + 305, LocationType.CHALLENGE,
-            logic.terran_competent_comp
+            logic.terran_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ZERO_HOUR.mission_name, "Third Hatchery", SC2WOL_LOC_ID_OFFSET + 306, LocationType.CHALLENGE,
-            logic.terran_competent_comp
+            logic.terran_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ZERO_HOUR.mission_name, "Fourth Hatchery", SC2WOL_LOC_ID_OFFSET + 307, LocationType.CHALLENGE,
-            logic.terran_competent_comp
+            logic.terran_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ZERO_HOUR.mission_name, "Ride's on its Way", SC2WOL_LOC_ID_OFFSET + 308, LocationType.EXTRA,
             logic.terran_common_unit
@@ -236,13 +244,15 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             lambda state: (
                 logic.terran_common_unit(state)
                 and logic.terran_base_trasher(state)
-                and logic.terran_competent_anti_air(state))
+                and logic.terran_competent_anti_air(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.EVACUATION.mission_name, "Eastern Zerg Base", SC2WOL_LOC_ID_OFFSET + 408, LocationType.MASTERY,
             lambda state: (
                 logic.terran_common_unit(state)
                 and logic.terran_base_trasher(state)
-                and logic.terran_competent_anti_air(state))
+                and logic.terran_competent_anti_air(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.OUTBREAK.mission_name, "Victory", SC2WOL_LOC_ID_OFFSET + 500, LocationType.VICTORY,
             logic.terran_outbreak_requirement
@@ -386,7 +396,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             lambda state: (
                 logic.terran_common_unit(state)
                 and logic.terran_base_trasher(state)
-                and logic.terran_competent_anti_air(state))
+                and logic.terran_competent_anti_air(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.THE_DIG.mission_name, "Victory", SC2WOL_LOC_ID_OFFSET + 900, LocationType.VICTORY,
             lambda state: (
@@ -454,7 +465,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and logic.terran_defense_rating(state, False, False) >= 6
                 and logic.terran_common_unit(state)
                 and (logic.marine_medic_upgrade(state) or adv_tactics)
-                and (logic.terran_base_trasher(state) or state.has(item_names.COMMAND_CENTER_SCANNER_SWEEP, player)))
+                and (logic.terran_base_trasher(state) or state.has(item_names.COMMAND_CENTER_SCANNER_SWEEP, player))),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.THE_DIG.mission_name, "Northeastern Protoss Base", SC2WOL_LOC_ID_OFFSET + 910, LocationType.MASTERY,
             lambda state: (
@@ -463,7 +475,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and logic.terran_defense_rating(state, False, False) >= 6
                 and logic.terran_common_unit(state)
                 and (logic.marine_medic_upgrade(state) or adv_tactics)
-                and (logic.terran_base_trasher(state) or state.has(item_names.COMMAND_CENTER_SCANNER_SWEEP, player)))
+                and (logic.terran_base_trasher(state) or state.has(item_names.COMMAND_CENTER_SCANNER_SWEEP, player))),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.THE_DIG.mission_name, "Eastern Protoss Base", SC2WOL_LOC_ID_OFFSET + 911, LocationType.MASTERY,
             lambda state: (
@@ -472,7 +485,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and logic.terran_defense_rating(state, False, False) >= 6
                 and logic.terran_common_unit(state)
                 and (logic.marine_medic_upgrade(state) or adv_tactics)
-                and (logic.terran_base_trasher(state) or state.has(item_names.COMMAND_CENTER_SCANNER_SWEEP, player)))
+                and (logic.terran_base_trasher(state) or state.has(item_names.COMMAND_CENTER_SCANNER_SWEEP, player))),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.THE_MOEBIUS_FACTOR.mission_name, "Victory", SC2WOL_LOC_ID_OFFSET + 1000, LocationType.VICTORY,
             lambda state: (
@@ -610,7 +624,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             lambda state: (
                 logic.terran_competent_anti_air(state)
                 and (logic.terran_common_unit(state)
-                     or state.has(item_names.REAPER, player)))
+                     or state.has(item_names.REAPER, player))),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.WELCOME_TO_THE_JUNGLE.mission_name, "Victory", SC2WOL_LOC_ID_OFFSET + 1400, LocationType.VICTORY,
             logic.welcome_to_the_jungle_requirement
@@ -629,7 +644,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             lambda state: (
                 logic.welcome_to_the_jungle_requirement(state)
                 and logic.terran_beats_protoss_deathball(state)
-                and logic.terran_base_trasher(state))
+                and logic.terran_base_trasher(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.WELCOME_TO_THE_JUNGLE.mission_name, "No Terrazine Nodes Sealed", SC2WOL_LOC_ID_OFFSET + 1406, LocationType.CHALLENGE,
             lambda state: (
@@ -842,7 +858,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             lambda state: logic.protoss_common_unit(state) and logic.protoss_competent_anti_air(state)
         ),
         make_location_data(SC2Mission.A_SINISTER_TURN.mission_name, "Southwest Base", SC2WOL_LOC_ID_OFFSET + 2305, LocationType.CHALLENGE,
-            lambda state: logic.protoss_common_unit(state) and logic.protoss_competent_anti_air(state)
+            lambda state: logic.protoss_common_unit(state) and logic.protoss_competent_anti_air(state),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.A_SINISTER_TURN.mission_name, "Maar", SC2WOL_LOC_ID_OFFSET + 2306, LocationType.EXTRA,
             logic.protoss_common_unit
@@ -1129,13 +1146,16 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             logic.zerg_common_unit_competent_aa
         ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER.mission_name, "West Launch Bay", SC2HOTS_LOC_ID_OFFSET + 510, LocationType.CHALLENGE,
-            logic.zerg_competent_comp_competent_aa
+            logic.zerg_competent_comp_competent_aa,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER.mission_name, "Center Launch Bay", SC2HOTS_LOC_ID_OFFSET + 511, LocationType.CHALLENGE,
-            logic.zerg_competent_comp_competent_aa
+            logic.zerg_competent_comp_competent_aa,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER.mission_name, "East Launch Bay", SC2HOTS_LOC_ID_OFFSET + 512, LocationType.CHALLENGE,
-            logic.zerg_competent_comp_competent_aa
+            logic.zerg_competent_comp_competent_aa,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ENEMY_WITHIN.mission_name, "Victory", SC2HOTS_LOC_ID_OFFSET + 600, LocationType.VICTORY,
             lambda state: (
@@ -1199,7 +1219,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             logic.zerg_common_unit
         ),
         make_location_data(SC2Mission.DOMINATION.mission_name, "Win Without 100 Eggs", SC2HOTS_LOC_ID_OFFSET + 710, LocationType.CHALLENGE,
-            logic.zerg_competent_comp_competent_aa
+            logic.zerg_competent_comp_competent_aa,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY.mission_name, "Victory", SC2HOTS_LOC_ID_OFFSET + 800, LocationType.VICTORY,
             lambda state: (
@@ -1249,13 +1270,16 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and logic.spread_creep(state))
         ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY.mission_name, "South Orbital Command Center", SC2HOTS_LOC_ID_OFFSET + 810, LocationType.CHALLENGE,
-            logic.zerg_competent_comp
+            logic.zerg_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY.mission_name, "Northwest Orbital Command Center", SC2HOTS_LOC_ID_OFFSET + 811, LocationType.CHALLENGE,
-            logic.zerg_competent_comp
+            logic.zerg_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY.mission_name, "Southeast Orbital Command Center", SC2HOTS_LOC_ID_OFFSET + 812, LocationType.CHALLENGE,
-            logic.zerg_competent_comp
+            logic.zerg_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.OLD_SOLDIERS.mission_name, "Victory", SC2HOTS_LOC_ID_OFFSET + 900, LocationType.VICTORY,
             logic.zerg_competent_comp_basic_aa
@@ -1303,10 +1327,12 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             logic.zerg_competent_comp_competent_aa
         ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT.mission_name, "South Main Primal Hive", SC2HOTS_LOC_ID_OFFSET + 1007, LocationType.CHALLENGE,
-            logic.zerg_competent_comp_competent_aa
+            logic.zerg_competent_comp_competent_aa,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT.mission_name, "East Main Primal Hive", SC2HOTS_LOC_ID_OFFSET + 1008, LocationType.CHALLENGE,
-            logic.zerg_competent_comp_competent_aa
+            logic.zerg_competent_comp_competent_aa,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT.mission_name, "Flawless", SC2HOTS_LOC_ID_OFFSET + 1009, LocationType.CHALLENGE,
             logic.zerg_competent_comp_competent_aa,
@@ -1631,7 +1657,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             logic.protoss_common_unit_basic_aa
         ),
         make_location_data(SC2Mission.DARK_WHISPERS.mission_name, "Zerg Base", SC2LOTV_LOC_ID_OFFSET + 105, LocationType.MASTERY,
-            logic.protoss_competent_comp
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.GHOSTS_IN_THE_FOG.mission_name, "Victory", SC2LOTV_LOC_ID_OFFSET + 200, LocationType.VICTORY,
             logic.protoss_common_unit_anti_armor_air
@@ -1833,9 +1860,11 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION.mission_name, "Terran Main Base", SC2LOTV_LOC_ID_OFFSET + 1207, LocationType.MASTERY,
             logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION.mission_name, "Protoss Main Base", SC2LOTV_LOC_ID_OFFSET + 1208, LocationType.MASTERY,
             logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.THE_INFINITE_CYCLE.mission_name, "Victory", SC2LOTV_LOC_ID_OFFSET + 1300, LocationType.VICTORY,
             logic.the_infinite_cycle_requirement
@@ -2462,7 +2491,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         ),
         make_location_data(SC2Mission.END_GAME.mission_name, "Destroy Orbital Commands", SC2NCO_LOC_ID_OFFSET + 907, LocationType.CHALLENGE,
             logic.end_game_requirement,
-            flags=LocationFlag.PREVENTATIVE
+            flags=LocationFlag.BASEBUST,
         ),
         # Mission Variants
         # 10X/20X - Liberation Day
@@ -2505,16 +2534,20 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             logic.zerg_competent_defense
         ),
         make_location_data(SC2Mission.ZERO_HOUR_Z.mission_name, "First Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 504, LocationType.CHALLENGE,
-            logic.zerg_competent_comp
+            logic.zerg_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ZERO_HOUR_Z.mission_name, "Second Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 505, LocationType.CHALLENGE,
-            logic.zerg_competent_comp
+            logic.zerg_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ZERO_HOUR_Z.mission_name, "Third Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 506, LocationType.CHALLENGE,
-            logic.zerg_competent_comp
+            logic.zerg_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ZERO_HOUR_Z.mission_name, "Fourth Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 507, LocationType.CHALLENGE,
-            logic.zerg_competent_comp
+            logic.zerg_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ZERO_HOUR_Z.mission_name, "Ride's on its Way", SC2_RACESWAP_LOC_ID_OFFSET + 508, LocationType.EXTRA,
             logic.zerg_common_unit
@@ -2539,16 +2572,20 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             logic.protoss_common_unit
         ),
         make_location_data(SC2Mission.ZERO_HOUR_P.mission_name, "First Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 604, LocationType.CHALLENGE,
-            logic.protoss_competent_comp
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ZERO_HOUR_P.mission_name, "Second Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 605, LocationType.CHALLENGE,
-            logic.protoss_competent_comp
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ZERO_HOUR_P.mission_name, "Third Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 606, LocationType.CHALLENGE,
-            logic.protoss_competent_comp
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ZERO_HOUR_P.mission_name, "Fourth Hatchery", SC2_RACESWAP_LOC_ID_OFFSET + 607, LocationType.CHALLENGE,
-            logic.protoss_competent_comp
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ZERO_HOUR_P.mission_name, "Ride's on its Way", SC2_RACESWAP_LOC_ID_OFFSET + 608, LocationType.EXTRA,
             logic.protoss_common_unit
@@ -2590,12 +2627,14 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.EVACUATION_Z.mission_name, "Western Zerg Base", SC2_RACESWAP_LOC_ID_OFFSET + 707, LocationType.MASTERY,
             lambda state: (
                 logic.zerg_common_unit_competent_aa(state)
-                and logic.zerg_base_buster(state))
+                and logic.zerg_base_buster(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.EVACUATION_Z.mission_name, "Eastern Zerg Base", SC2_RACESWAP_LOC_ID_OFFSET + 708, LocationType.MASTERY,
             lambda state: (
                 logic.zerg_common_unit_competent_aa(state)
-                and logic.zerg_base_buster(state))
+                and logic.zerg_base_buster(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.EVACUATION_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 800, LocationType.VICTORY,
             lambda state: (
@@ -2623,10 +2662,12 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             flags=LocationFlag.PREVENTATIVE
         ),
         make_location_data(SC2Mission.EVACUATION_P.mission_name, "Western Zerg Base", SC2_RACESWAP_LOC_ID_OFFSET + 807, LocationType.MASTERY,
-            logic.protoss_competent_comp
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.EVACUATION_P.mission_name, "Eastern Zerg Base", SC2_RACESWAP_LOC_ID_OFFSET + 808, LocationType.MASTERY,
-            logic.protoss_competent_comp
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.OUTBREAK_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 900, LocationType.VICTORY,
             lambda state: (
@@ -2932,7 +2973,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.SMASH_AND_GRAB_Z.mission_name, "Defeat Kerrigan", SC2_RACESWAP_LOC_ID_OFFSET + 1507, LocationType.MASTERY,
             lambda state: (
                 logic.zerg_common_unit_competent_aa(state)
-                and logic.zerg_base_buster(state))
+                and logic.zerg_base_buster(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.SMASH_AND_GRAB_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1600, LocationType.VICTORY,
             lambda state: (
@@ -2972,7 +3014,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 ))
         ),
         make_location_data(SC2Mission.SMASH_AND_GRAB_P.mission_name, "Defeat Kerrigan", SC2_RACESWAP_LOC_ID_OFFSET + 1607, LocationType.MASTERY,
-            logic.protoss_competent_comp
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.THE_DIG_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1700, LocationType.VICTORY,
             lambda state: (
@@ -3029,7 +3072,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and logic.zerg_defense_rating(state, False, True) >= 8
                 and logic.zerg_defense_rating(state, False, False) >= 6
                 and logic.zerg_common_unit(state)
-                and logic.zerg_base_buster(state))
+                and logic.zerg_base_buster(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.THE_DIG_Z.mission_name, "Northeastern Protoss Base", SC2_RACESWAP_LOC_ID_OFFSET + 1710, LocationType.MASTERY,
             lambda state: (
@@ -3037,7 +3081,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and logic.zerg_defense_rating(state, False, True) >= 8
                 and logic.zerg_defense_rating(state, False, False) >= 6
                 and logic.zerg_common_unit(state)
-                and logic.zerg_base_buster(state))
+                and logic.zerg_base_buster(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.THE_DIG_Z.mission_name, "Eastern Protoss Base", SC2_RACESWAP_LOC_ID_OFFSET + 1711, LocationType.MASTERY,
             lambda state: (
@@ -3045,7 +3090,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and logic.zerg_defense_rating(state, False, True) >= 8
                 and logic.zerg_defense_rating(state, False, False) >= 6
                 and logic.zerg_common_unit(state)
-                and logic.zerg_base_buster(state))
+                and logic.zerg_base_buster(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.THE_DIG_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1800, LocationType.VICTORY,
             lambda state: (
@@ -3097,21 +3143,24 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 logic.protoss_basic_anti_air(state)
                 and logic.protoss_defense_rating(state, False) >= 6
                 and logic.protoss_common_unit(state)
-                and (logic.protoss_competent_comp(state) or state.has(item_names.OBSERVER, player)))
+                and (logic.protoss_competent_comp(state) or state.has(item_names.OBSERVER, player))),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.THE_DIG_P.mission_name, "Northeastern Protoss Base", SC2_RACESWAP_LOC_ID_OFFSET + 1810, LocationType.MASTERY,
             lambda state: (
                 logic.protoss_basic_anti_air(state)
                 and logic.protoss_defense_rating(state, False) >= 6
                 and logic.protoss_common_unit(state)
-                and (logic.protoss_competent_comp(state) or state.has(item_names.OBSERVER, player)))
+                and (logic.protoss_competent_comp(state) or state.has(item_names.OBSERVER, player))),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.THE_DIG_P.mission_name, "Eastern Protoss Base", SC2_RACESWAP_LOC_ID_OFFSET + 1811, LocationType.MASTERY,
             lambda state: (
                 logic.protoss_basic_anti_air(state)
                 and logic.protoss_defense_rating(state, False) >= 6
                 and logic.protoss_common_unit(state)
-                and (logic.protoss_competent_comp(state) or state.has(item_names.OBSERVER, player)))
+                and (logic.protoss_competent_comp(state) or state.has(item_names.OBSERVER, player))),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.THE_MOEBIUS_FACTOR_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 1900, LocationType.VICTORY,
             lambda state: (
@@ -3385,7 +3434,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.DEVILS_PLAYGROUND_Z.mission_name, "Zerg Cleared", SC2_RACESWAP_LOC_ID_OFFSET + 2508, LocationType.CHALLENGE,
             lambda state: (
                 logic.zerg_competent_anti_air(state)
-                and logic.zerg_common_unit(state))
+                and logic.zerg_common_unit(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.DEVILS_PLAYGROUND_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 2600, LocationType.VICTORY,
             lambda state: (
@@ -3418,7 +3468,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.DEVILS_PLAYGROUND_P.mission_name, "Zerg Cleared", SC2_RACESWAP_LOC_ID_OFFSET + 2608, LocationType.CHALLENGE,
             lambda state: (
                 logic.protoss_competent_anti_air(state)
-                and (logic.protoss_common_unit(state)))
+                and (logic.protoss_common_unit(state))),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.WELCOME_TO_THE_JUNGLE_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 2700, LocationType.VICTORY,
             logic.welcome_to_the_jungle_z_requirement
@@ -3437,7 +3488,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             lambda state: (
                 logic.welcome_to_the_jungle_z_requirement(state)
                 and logic.zerg_competent_anti_air(state)
-                and logic.zerg_base_buster(state))
+                and logic.zerg_base_buster(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.WELCOME_TO_THE_JUNGLE_Z.mission_name, "No Terrazine Nodes Sealed", SC2_RACESWAP_LOC_ID_OFFSET + 2706, LocationType.CHALLENGE,
             lambda state: (
@@ -3488,7 +3540,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.WELCOME_TO_THE_JUNGLE_P.mission_name, "Main Base", SC2_RACESWAP_LOC_ID_OFFSET + 2805, LocationType.MASTERY,
             lambda state: (
                 logic.welcome_to_the_jungle_p_requirement(state)
-                and logic.protoss_competent_comp(state))
+                and logic.protoss_competent_comp(state)),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.WELCOME_TO_THE_JUNGLE_P.mission_name, "No Terrazine Nodes Sealed", SC2_RACESWAP_LOC_ID_OFFSET + 2806, LocationType.CHALLENGE,
             lambda state: (
@@ -3788,11 +3841,12 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                            lambda state: logic.terran_common_unit(state) and logic.terran_competent_anti_air(state)
                            ),
         make_location_data(SC2Mission.A_SINISTER_TURN_T.mission_name, "Southwest Base", SC2_RACESWAP_LOC_ID_OFFSET + 4505, LocationType.CHALLENGE,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_common_unit(state)
-                                   and logic.terran_competent_anti_air(state))
-                           ),
+            lambda state: (
+                logic.terran_competent_comp(state)
+                and logic.terran_common_unit(state)
+                and logic.terran_competent_anti_air(state)),
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_T.mission_name, "Maar", SC2_RACESWAP_LOC_ID_OFFSET + 4506, LocationType.EXTRA,
                            logic.terran_common_unit
                            ),
@@ -3830,8 +3884,9 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                            lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
                            ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "Southwest Base", SC2_RACESWAP_LOC_ID_OFFSET + 4605, LocationType.CHALLENGE,
-                           lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
-                           ),
+            lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state),
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "Maar", SC2_RACESWAP_LOC_ID_OFFSET + 4606, LocationType.EXTRA,
                            logic.zerg_common_unit
                            ),
@@ -4309,20 +4364,23 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                            lambda state: logic.terran_common_unit(state) and logic.terran_competent_ground_to_air(state)
                            ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER_T.mission_name, "West Launch Bay", SC2_RACESWAP_LOC_ID_OFFSET + 6710, LocationType.CHALLENGE,
-                           lambda state: logic.terran_beats_protoss_deathball(state)
-                                         and logic.terran_competent_ground_to_air(state)
-                                         and logic.terran_common_unit(state)
-                           ),
+            lambda state: logic.terran_beats_protoss_deathball(state)
+                            and logic.terran_competent_ground_to_air(state)
+                            and logic.terran_common_unit(state),
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER_T.mission_name, "Center Launch Bay", SC2_RACESWAP_LOC_ID_OFFSET + 6711, LocationType.CHALLENGE,
-                           lambda state: logic.terran_beats_protoss_deathball(state)
-                                         and logic.terran_competent_ground_to_air(state)
-                                         and logic.terran_common_unit(state)
-                           ),
+            lambda state: logic.terran_beats_protoss_deathball(state)
+                            and logic.terran_competent_ground_to_air(state)
+                            and logic.terran_common_unit(state),
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER_T.mission_name, "East Launch Bay", SC2_RACESWAP_LOC_ID_OFFSET + 6712, LocationType.CHALLENGE,
-                           lambda state: logic.terran_beats_protoss_deathball(state)
-                                         and logic.terran_competent_ground_to_air(state)
-                                         and logic.terran_common_unit(state)
-                           ),
+            lambda state: logic.terran_beats_protoss_deathball(state)
+                            and logic.terran_competent_ground_to_air(state)
+                            and logic.terran_common_unit(state),
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 6800, LocationType.VICTORY,
                            lambda state: (
                                    logic.protoss_common_unit(state)
@@ -4351,309 +4409,323 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                            ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER_P.mission_name, "Southwest Frozen Group", SC2_RACESWAP_LOC_ID_OFFSET + 6806, LocationType.EXTRA),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER_P.mission_name, "Southeast Frozen Group", SC2_RACESWAP_LOC_ID_OFFSET + 6807, LocationType.EXTRA,
-                           lambda state: logic.protoss_common_unit(state) or adv_tactics
-                           ),
+            lambda state: logic.protoss_common_unit(state) or adv_tactics
+        ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER_P.mission_name, "West Frozen Group", SC2_RACESWAP_LOC_ID_OFFSET + 6808, LocationType.EXTRA,
-                           lambda state: (
-                                   logic.protoss_common_unit(state)
-                                   and logic.protoss_anti_armor_anti_air(state))
-                           ),
+            lambda state: (
+                    logic.protoss_common_unit(state)
+                    and logic.protoss_anti_armor_anti_air(state))
+        ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER_P.mission_name, "East Frozen Group", SC2_RACESWAP_LOC_ID_OFFSET + 6809, LocationType.EXTRA,
-                           lambda state: (
-                                   logic.protoss_common_unit(state)
-                                   and logic.protoss_anti_armor_anti_air(state))
-                           ),
+            lambda state: (
+                    logic.protoss_common_unit(state)
+                    and logic.protoss_anti_armor_anti_air(state))
+        ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER_P.mission_name, "West Launch Bay", SC2_RACESWAP_LOC_ID_OFFSET + 6810, LocationType.CHALLENGE,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER_P.mission_name, "Center Launch Bay", SC2_RACESWAP_LOC_ID_OFFSET + 6811, LocationType.CHALLENGE,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.SHOOT_THE_MESSENGER_P.mission_name, "East Launch Bay", SC2_RACESWAP_LOC_ID_OFFSET + 6812, LocationType.CHALLENGE,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.DOMINATION_T.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 7100, LocationType.VICTORY,
-                           lambda state: logic.terran_common_unit(state) and logic.terran_basic_anti_air(state)
-                           ),
+            lambda state: logic.terran_common_unit(state) and logic.terran_basic_anti_air(state)
+        ),
         make_location_data(SC2Mission.DOMINATION_T.mission_name, "Center Infested Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 7101, LocationType.VANILLA,
-                           logic.terran_common_unit
-                           ),
+            logic.terran_common_unit
+        ),
         make_location_data(SC2Mission.DOMINATION_T.mission_name, "North Infested Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 7102, LocationType.VANILLA,
-                           logic.terran_common_unit
-                           ),
+            logic.terran_common_unit
+        ),
         make_location_data(SC2Mission.DOMINATION_T.mission_name, "Repel Zagara", SC2_RACESWAP_LOC_ID_OFFSET + 7103, LocationType.EXTRA),
         make_location_data(SC2Mission.DOMINATION_T.mission_name, "Close Bunker", SC2_RACESWAP_LOC_ID_OFFSET + 7104, LocationType.EXTRA),
         make_location_data(SC2Mission.DOMINATION_T.mission_name, "South Bunker", SC2_RACESWAP_LOC_ID_OFFSET + 7105, LocationType.EXTRA,
-                           lambda state: adv_tactics or logic.terran_common_unit(state)
-                           ),
+            lambda state: adv_tactics or logic.terran_common_unit(state)
+        ),
         make_location_data(SC2Mission.DOMINATION_T.mission_name, "Southwest Bunker", SC2_RACESWAP_LOC_ID_OFFSET + 7106, LocationType.EXTRA,
-                           logic.terran_common_unit
-                           ),
+            logic.terran_common_unit
+        ),
         make_location_data(SC2Mission.DOMINATION_T.mission_name, "Southeast Bunker", SC2_RACESWAP_LOC_ID_OFFSET + 7107, LocationType.EXTRA,
-                           lambda state: logic.terran_common_unit(state) and logic.terran_basic_anti_air(state)
-                           ),
+            lambda state: logic.terran_common_unit(state) and logic.terran_basic_anti_air(state)
+        ),
         make_location_data(SC2Mission.DOMINATION_T.mission_name, "North Bunker", SC2_RACESWAP_LOC_ID_OFFSET + 7108, LocationType.EXTRA,
-                           logic.terran_common_unit
-                           ),
+            logic.terran_common_unit
+        ),
         make_location_data(SC2Mission.DOMINATION_T.mission_name, "Northeast Bunker", SC2_RACESWAP_LOC_ID_OFFSET + 7109, LocationType.EXTRA,
-                           logic.terran_common_unit
-                           ),
+            logic.terran_common_unit
+        ),
         make_location_data(SC2Mission.DOMINATION_T.mission_name, "Win Without 100 Eggs", SC2_RACESWAP_LOC_ID_OFFSET + 7110, LocationType.CHALLENGE,
-                           logic.terran_competent_comp
-                           ),
+            logic.terran_competent_comp,
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.DOMINATION_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 7200, LocationType.VICTORY,
-                           logic.protoss_common_unit_basic_aa
-                           ),
+            logic.protoss_common_unit_basic_aa
+        ),
         make_location_data(SC2Mission.DOMINATION_P.mission_name, "Center Infested Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 7201, LocationType.VANILLA,
-                           logic.protoss_common_unit
-                           ),
+            logic.protoss_common_unit
+        ),
         make_location_data(SC2Mission.DOMINATION_P.mission_name, "North Infested Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 7202, LocationType.VANILLA,
-                           logic.protoss_common_unit
-                           ),
+            logic.protoss_common_unit
+        ),
         make_location_data(SC2Mission.DOMINATION_P.mission_name, "Repel Zagara", SC2_RACESWAP_LOC_ID_OFFSET + 7203, LocationType.EXTRA),
         make_location_data(SC2Mission.DOMINATION_P.mission_name, "Close Supplicants", SC2_RACESWAP_LOC_ID_OFFSET + 7204, LocationType.EXTRA),
         make_location_data(SC2Mission.DOMINATION_P.mission_name, "South Supplicants", SC2_RACESWAP_LOC_ID_OFFSET + 7205, LocationType.EXTRA,
-                           lambda state: adv_tactics or logic.protoss_common_unit(state)
-                           ),
+            lambda state: adv_tactics or logic.protoss_common_unit(state)
+        ),
         make_location_data(SC2Mission.DOMINATION_P.mission_name, "Southwest Supplicants", SC2_RACESWAP_LOC_ID_OFFSET + 7206, LocationType.EXTRA,
-                           logic.protoss_common_unit
-                           ),
+            logic.protoss_common_unit
+        ),
         make_location_data(SC2Mission.DOMINATION_P.mission_name, "Southeast Supplicants", SC2_RACESWAP_LOC_ID_OFFSET + 7207, LocationType.EXTRA,
-                           logic.protoss_common_unit_basic_aa
-                           ),
+            logic.protoss_common_unit_basic_aa
+        ),
         make_location_data(SC2Mission.DOMINATION_P.mission_name, "North Supplicants", SC2_RACESWAP_LOC_ID_OFFSET + 7208, LocationType.EXTRA,
-                           logic.protoss_common_unit
-                           ),
+            logic.protoss_common_unit
+        ),
         make_location_data(SC2Mission.DOMINATION_P.mission_name, "Northeast Supplicants", SC2_RACESWAP_LOC_ID_OFFSET + 7209, LocationType.EXTRA,
-                           logic.protoss_common_unit
-                           ),
+            logic.protoss_common_unit
+        ),
         make_location_data(SC2Mission.DOMINATION_P.mission_name, "Win Without 100 Eggs", SC2_RACESWAP_LOC_ID_OFFSET + 7210, LocationType.CHALLENGE,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 7300, LocationType.VICTORY,
-                           lambda state: (
-                               logic.terran_common_unit(state)
-                               and logic.terran_competent_comp(state))
-                           ),
+            lambda state: (
+                logic.terran_common_unit(state)
+                and logic.terran_competent_comp(state))
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "West Biomass", SC2_RACESWAP_LOC_ID_OFFSET + 7301, LocationType.VANILLA),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "North Biomass", SC2_RACESWAP_LOC_ID_OFFSET + 7302, LocationType.VANILLA,
-                           lambda state: (
-                                   logic.terran_common_unit(state)
-                                   and logic.terran_competent_comp(state))
-                           ),
+            lambda state: (
+                logic.terran_common_unit(state)
+                and logic.terran_competent_comp(state))
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "South Biomass", SC2_RACESWAP_LOC_ID_OFFSET + 7303, LocationType.VANILLA,
-                           lambda state: (
-                                   logic.terran_common_unit(state)
-                                   and logic.terran_competent_comp(state))
-                           ),
+            lambda state: (
+                logic.terran_common_unit(state)
+                and logic.terran_competent_comp(state))
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "Destroy 3 Gorgons", SC2_RACESWAP_LOC_ID_OFFSET + 7304, LocationType.EXTRA,
-                           lambda state: (
-                                   logic.terran_common_unit(state)
-                                   and logic.terran_competent_comp(state))
-                           ),
+            lambda state: (
+                logic.terran_common_unit(state)
+                and logic.terran_competent_comp(state))
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "Close Rescue", SC2_RACESWAP_LOC_ID_OFFSET + 7305, LocationType.EXTRA),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "South Rescue", SC2_RACESWAP_LOC_ID_OFFSET + 7306, LocationType.EXTRA,
-                           logic.terran_common_unit
-                           ),
+            logic.terran_common_unit
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "North Rescue", SC2_RACESWAP_LOC_ID_OFFSET + 7307, LocationType.EXTRA,
-                           lambda state: (
-                                   logic.terran_common_unit(state)
-                                   and logic.terran_competent_comp(state))
-                           ),
+            lambda state: (
+                logic.terran_common_unit(state)
+                and logic.terran_competent_comp(state))
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "West Medic Rescue", SC2_RACESWAP_LOC_ID_OFFSET + 7308, LocationType.EXTRA,
-                           lambda state: (
-                                   logic.terran_common_unit(state)
-                                   and logic.terran_competent_comp(state))
-                           ),
+            lambda state: (
+                logic.terran_common_unit(state)
+                and logic.terran_competent_comp(state))
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "East Medic Rescue", SC2_RACESWAP_LOC_ID_OFFSET + 7309, LocationType.EXTRA,
-                           lambda state: (
-                                   logic.terran_common_unit(state)
-                                   and logic.terran_competent_comp(state))
-                           ),
+            lambda state: (
+                logic.terran_common_unit(state)
+                and logic.terran_competent_comp(state))
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "South Orbital Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 7310, LocationType.CHALLENGE,
-                           lambda state: (
-                                   logic.terran_common_unit(state)
-                                   and logic.terran_competent_comp(state))
-                           ),
+            lambda state: (
+                logic.terran_common_unit(state)
+                and logic.terran_competent_comp(state)),
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "Northwest Orbital Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 7311, LocationType.CHALLENGE,
-                           lambda state: (
-                                   logic.terran_common_unit(state)
-                                   and logic.terran_competent_comp(state))
-                           ),
+            lambda state: (
+                logic.terran_common_unit(state)
+                and logic.terran_competent_comp(state)),
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_T.mission_name, "Southeast Orbital Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 7312, LocationType.CHALLENGE,
-                           lambda state: (
-                                   logic.terran_common_unit(state)
-                                   and logic.terran_competent_comp(state))
-                           ),
+            lambda state: (
+                logic.terran_common_unit(state)
+                and logic.terran_competent_comp(state)),
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 7400, LocationType.VICTORY,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "West Biomass", SC2_RACESWAP_LOC_ID_OFFSET + 7401, LocationType.VANILLA),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "North Biomass", SC2_RACESWAP_LOC_ID_OFFSET + 7402, LocationType.VANILLA,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "South Biomass", SC2_RACESWAP_LOC_ID_OFFSET + 7403, LocationType.VANILLA,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "Destroy 3 Gorgons", SC2_RACESWAP_LOC_ID_OFFSET + 7404, LocationType.EXTRA,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "Close Rescue", SC2_RACESWAP_LOC_ID_OFFSET + 7405, LocationType.EXTRA),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "South Rescue", SC2_RACESWAP_LOC_ID_OFFSET + 7406, LocationType.EXTRA,
-                           logic.protoss_common_unit
-                           ),
+            logic.protoss_common_unit
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "North Rescue", SC2_RACESWAP_LOC_ID_OFFSET + 7407, LocationType.EXTRA,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "Sentry Rescue", SC2_RACESWAP_LOC_ID_OFFSET + 7408, LocationType.EXTRA,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "Havoc Rescue", SC2_RACESWAP_LOC_ID_OFFSET + 7409, LocationType.EXTRA,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "South Orbital Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 7410, LocationType.CHALLENGE,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "Northwest Orbital Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 7411, LocationType.CHALLENGE,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.FIRE_IN_THE_SKY_P.mission_name, "Southeast Orbital Command Center", SC2_RACESWAP_LOC_ID_OFFSET + 7412, LocationType.CHALLENGE,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.OLD_SOLDIERS_T.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 7500, LocationType.VICTORY,
-                           logic.terran_competent_comp
-                           ),
+            logic.terran_competent_comp
+        ),
         make_location_data(SC2Mission.OLD_SOLDIERS_T.mission_name, "East Science Lab", SC2_RACESWAP_LOC_ID_OFFSET + 7501, LocationType.VANILLA,
-                           logic.terran_competent_comp
-                           ),
+            logic.terran_competent_comp
+        ),
         make_location_data(SC2Mission.OLD_SOLDIERS_T.mission_name, "North Science Lab", SC2_RACESWAP_LOC_ID_OFFSET + 7502, LocationType.VANILLA,
-                           logic.terran_competent_comp
-                           ),
+            logic.terran_competent_comp
+        ),
         make_location_data(SC2Mission.OLD_SOLDIERS_T.mission_name, "Get Nuked", SC2_RACESWAP_LOC_ID_OFFSET + 7503, LocationType.EXTRA),
         make_location_data(SC2Mission.OLD_SOLDIERS_T.mission_name, "Entrance Gate", SC2_RACESWAP_LOC_ID_OFFSET + 7504, LocationType.EXTRA),
         make_location_data(SC2Mission.OLD_SOLDIERS_T.mission_name, "Citadel Gate", SC2_RACESWAP_LOC_ID_OFFSET + 7505, LocationType.EXTRA,
-                           logic.terran_competent_comp
-                           ),
+            logic.terran_competent_comp
+        ),
         make_location_data(SC2Mission.OLD_SOLDIERS_T.mission_name, "South Expansion", SC2_RACESWAP_LOC_ID_OFFSET + 7506, LocationType.EXTRA),
         make_location_data(SC2Mission.OLD_SOLDIERS_T.mission_name, "Rich Mineral Expansion", SC2_RACESWAP_LOC_ID_OFFSET + 7507, LocationType.EXTRA,
-                           logic.terran_competent_comp
-                           ),
+            logic.terran_competent_comp
+        ),
         make_location_data(SC2Mission.OLD_SOLDIERS_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 7600, LocationType.VICTORY,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.OLD_SOLDIERS_P.mission_name, "East Science Lab", SC2_RACESWAP_LOC_ID_OFFSET + 7601, LocationType.VANILLA,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.OLD_SOLDIERS_P.mission_name, "North Science Lab", SC2_RACESWAP_LOC_ID_OFFSET + 7602, LocationType.VANILLA,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.OLD_SOLDIERS_P.mission_name, "Get Nuked", SC2_RACESWAP_LOC_ID_OFFSET + 7603, LocationType.EXTRA),
         make_location_data(SC2Mission.OLD_SOLDIERS_P.mission_name, "Entrance Gate", SC2_RACESWAP_LOC_ID_OFFSET + 7604, LocationType.EXTRA),
         make_location_data(SC2Mission.OLD_SOLDIERS_P.mission_name, "Citadel Gate", SC2_RACESWAP_LOC_ID_OFFSET + 7605, LocationType.EXTRA,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.OLD_SOLDIERS_P.mission_name, "South Expansion", SC2_RACESWAP_LOC_ID_OFFSET + 7606, LocationType.EXTRA),
         make_location_data(SC2Mission.OLD_SOLDIERS_P.mission_name, "Rich Mineral Expansion", SC2_RACESWAP_LOC_ID_OFFSET + 7607, LocationType.EXTRA,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_T.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 7700,LocationType.VICTORY,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_common_unit(state)
-                                   and logic.terran_competent_anti_air(state)
-                           )
-                           ),
+            lambda state: (
+                    logic.terran_competent_comp(state)
+                    and logic.terran_common_unit(state)
+                    and logic.terran_competent_anti_air(state)
+            )
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_T.mission_name, "Center Essence Pool", SC2_RACESWAP_LOC_ID_OFFSET + 7701, LocationType.VANILLA),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_T.mission_name, "East Essence Pool", SC2_RACESWAP_LOC_ID_OFFSET + 7702, LocationType.VANILLA,
-                           lambda state: (
-                                   logic.terran_common_unit(state)
-                                   and (adv_tactics
-                                        and logic.terran_basic_anti_air(state)
-                                        or logic.terran_competent_anti_air(state)))
-                           ),
+            lambda state: (
+                    logic.terran_common_unit(state)
+                    and (adv_tactics
+                        and logic.terran_basic_anti_air(state)
+                        or logic.terran_competent_anti_air(state)))
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_T.mission_name, "South Essence Pool", SC2_RACESWAP_LOC_ID_OFFSET + 7703, LocationType.VANILLA,
-                           lambda state: (
-                                   logic.terran_common_unit(state)
-                                   and (adv_tactics
-                                        and logic.terran_basic_anti_air(state)
-                                        or logic.terran_competent_anti_air(state)))
-                           ),
+            lambda state: (
+                    logic.terran_common_unit(state)
+                    and (adv_tactics
+                        and logic.terran_basic_anti_air(state)
+                        or logic.terran_competent_anti_air(state)))
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_T.mission_name, "Finish Feeding", SC2_RACESWAP_LOC_ID_OFFSET + 7704, LocationType.EXTRA,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_common_unit(state)
-                                   and logic.terran_competent_anti_air(state)
-                           )
-                           ),
+            lambda state: (
+                    logic.terran_competent_comp(state)
+                    and logic.terran_common_unit(state)
+                    and logic.terran_competent_anti_air(state)
+            )
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_T.mission_name, "South Proxy Primal Hive", SC2_RACESWAP_LOC_ID_OFFSET + 7705, LocationType.CHALLENGE,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_common_unit(state)
-                                   and logic.terran_competent_anti_air(state)
-                           )
-                           ),
+            lambda state: (
+                    logic.terran_competent_comp(state)
+                    and logic.terran_common_unit(state)
+                    and logic.terran_competent_anti_air(state)
+            )
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_T.mission_name, "East Proxy Primal Hive", SC2_RACESWAP_LOC_ID_OFFSET + 7706, LocationType.CHALLENGE,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_common_unit(state)
-                                   and logic.terran_competent_anti_air(state)
-                           )
-                           ),
+            lambda state: (
+                    logic.terran_competent_comp(state)
+                    and logic.terran_common_unit(state)
+                    and logic.terran_competent_anti_air(state)
+            )
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_T.mission_name, "South Main Primal Hive", SC2_RACESWAP_LOC_ID_OFFSET + 7707, LocationType.CHALLENGE,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_common_unit(state)
-                                   and logic.terran_competent_anti_air(state)
-                           )
-                           ),
+            lambda state: (
+                    logic.terran_competent_comp(state)
+                    and logic.terran_common_unit(state)
+                    and logic.terran_competent_anti_air(state)
+            ),
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_T.mission_name, "East Main Primal Hive", SC2_RACESWAP_LOC_ID_OFFSET + 7708, LocationType.CHALLENGE,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_common_unit(state)
-                                   and logic.terran_competent_anti_air(state)
-                           )
-                           ),
+            lambda state: (
+                    logic.terran_competent_comp(state)
+                    and logic.terran_common_unit(state)
+                    and logic.terran_competent_anti_air(state)
+            ),
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_T.mission_name, "Flawless", SC2_RACESWAP_LOC_ID_OFFSET + 7709, LocationType.CHALLENGE,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_common_unit(state)
-                                   and logic.terran_competent_anti_air(state)
-                           ),
-                           flags=LocationFlag.PREVENTATIVE,
-                           ),
+            lambda state: (
+                    logic.terran_competent_comp(state)
+                    and logic.terran_common_unit(state)
+                    and logic.terran_competent_anti_air(state)
+            ),
+            flags=LocationFlag.PREVENTATIVE,
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_P.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 7800, LocationType.VICTORY,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_P.mission_name, "Center Essence Pool", SC2_RACESWAP_LOC_ID_OFFSET + 7801, LocationType.VANILLA),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_P.mission_name, "East Essence Pool", SC2_RACESWAP_LOC_ID_OFFSET + 7802, LocationType.VANILLA,
-                           lambda state: (
-                                   logic.protoss_common_unit(state)
-                                   and logic.protoss_anti_light_anti_air(state))
-                           ),
+            lambda state: (
+                logic.protoss_common_unit(state)
+                and logic.protoss_anti_light_anti_air(state))
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_P.mission_name, "South Essence Pool", SC2_RACESWAP_LOC_ID_OFFSET + 7803, LocationType.VANILLA,
-                           lambda state: (
-                                   logic.protoss_common_unit(state)
-                                   and logic.protoss_anti_light_anti_air(state))
-                           ),
+            lambda state: (
+                logic.protoss_common_unit(state)
+                and logic.protoss_anti_light_anti_air(state))
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_P.mission_name, "Finish Feeding", SC2_RACESWAP_LOC_ID_OFFSET + 7804, LocationType.EXTRA,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_P.mission_name, "South Proxy Primal Hive", SC2_RACESWAP_LOC_ID_OFFSET + 7805, LocationType.CHALLENGE,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_P.mission_name, "East Proxy Primal Hive", SC2_RACESWAP_LOC_ID_OFFSET + 7806, LocationType.CHALLENGE,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_P.mission_name, "South Main Primal Hive", SC2_RACESWAP_LOC_ID_OFFSET + 7807, LocationType.CHALLENGE,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_P.mission_name, "East Main Primal Hive", SC2_RACESWAP_LOC_ID_OFFSET + 7808, LocationType.CHALLENGE,
-                           logic.protoss_competent_comp
-                           ),
+            logic.protoss_competent_comp
+        ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_P.mission_name, "Flawless", SC2_RACESWAP_LOC_ID_OFFSET + 7809, LocationType.CHALLENGE,
-                           logic.protoss_competent_comp,
-                           flags=LocationFlag.PREVENTATIVE,
-                           ),
+            logic.protoss_competent_comp,
+            flags=LocationFlag.PREVENTATIVE,
+        ),
         make_location_data(SC2Mission.THE_CRUCIBLE_T.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 7900, LocationType.VICTORY,
                            lambda state: (
                                    logic.terran_common_unit(state)
@@ -5075,45 +5147,47 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                            flags=LocationFlag.SPEEDRUN
                            ),
         make_location_data(SC2Mission.DARK_WHISPERS_T.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 9900, LocationType.VICTORY,
-                           logic.terran_competent_comp
-                           ),
+            logic.terran_competent_comp
+        ),
         make_location_data(SC2Mission.DARK_WHISPERS_T.mission_name, "First Prisoner Group", SC2_RACESWAP_LOC_ID_OFFSET + 9901, LocationType.VANILLA,
-                           logic.terran_competent_comp
-                           ),
+            logic.terran_competent_comp
+        ),
         make_location_data(SC2Mission.DARK_WHISPERS_T.mission_name, "Second Prisoner Group", SC2_RACESWAP_LOC_ID_OFFSET + 9902, LocationType.VANILLA,
-                           logic.terran_competent_comp
-                           ),
+            logic.terran_competent_comp
+        ),
         make_location_data(SC2Mission.DARK_WHISPERS_T.mission_name, "First Pylon", SC2_RACESWAP_LOC_ID_OFFSET + 9903, LocationType.VANILLA,
-                           logic.terran_competent_comp
-                           ),
+            logic.terran_competent_comp
+        ),
         make_location_data(SC2Mission.DARK_WHISPERS_T.mission_name, "Second Pylon", SC2_RACESWAP_LOC_ID_OFFSET + 9904, LocationType.VANILLA,
-                           logic.terran_competent_comp
-                           ),
+            logic.terran_competent_comp
+        ),
         make_location_data(SC2Mission.DARK_WHISPERS_T.mission_name, "Zerg Base", SC2_RACESWAP_LOC_ID_OFFSET + 9905, LocationType.MASTERY,
-                           lambda state: (
-                                  logic.terran_competent_comp(state)
-                                  and logic.terran_base_trasher(state))
-                           ),
+            lambda state: (
+                logic.terran_competent_comp(state)
+                and logic.terran_base_trasher(state)),
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.DARK_WHISPERS_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 10000, LocationType.VICTORY,
-                           logic.zerg_competent_comp_basic_aa
-                           ),
+            logic.zerg_competent_comp_basic_aa
+        ),
         make_location_data(SC2Mission.DARK_WHISPERS_Z.mission_name, "First Prisoner Group", SC2_RACESWAP_LOC_ID_OFFSET + 10001, LocationType.VANILLA,
-                           logic.zerg_competent_comp_basic_aa
-                           ),
+            logic.zerg_competent_comp_basic_aa
+        ),
         make_location_data(SC2Mission.DARK_WHISPERS_Z.mission_name, "Second Prisoner Group", SC2_RACESWAP_LOC_ID_OFFSET + 10002, LocationType.VANILLA,
-                           logic.zerg_competent_comp_basic_aa
-                           ),
+            logic.zerg_competent_comp_basic_aa
+        ),
         make_location_data(SC2Mission.DARK_WHISPERS_Z.mission_name, "First Pylon", SC2_RACESWAP_LOC_ID_OFFSET + 10003, LocationType.VANILLA,
-                           logic.zerg_competent_comp_basic_aa
-                           ),
+            logic.zerg_competent_comp_basic_aa
+        ),
         make_location_data(SC2Mission.DARK_WHISPERS_Z.mission_name, "Second Pylon", SC2_RACESWAP_LOC_ID_OFFSET + 10004, LocationType.VANILLA,
-                           logic.zerg_competent_comp_basic_aa
-                           ),
+            logic.zerg_competent_comp_basic_aa
+        ),
         make_location_data(SC2Mission.DARK_WHISPERS_Z.mission_name, "Zerg Base", SC2_RACESWAP_LOC_ID_OFFSET + 10005, LocationType.VANILLA,
-                           lambda state: (
-                               logic.zerg_competent_comp(state)
-                               and logic.zerg_base_buster(state))
-                           ),
+            lambda state: (
+                logic.zerg_competent_comp(state)
+                and logic.zerg_base_buster(state)),
+            flags=LocationFlag.BASEBUST,
+        ),
         make_location_data(SC2Mission.GHOSTS_IN_THE_FOG_T.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 10100, LocationType.VICTORY,
                            lambda state: (
                                logic.terran_beats_protoss_deathball(state)
@@ -5496,97 +5570,101 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                            logic.zerg_last_stand_requirement
                            ),
         make_location_data(SC2Mission.FORBIDDEN_WEAPON_T.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 11900, LocationType.VICTORY,
-                           logic.terran_beats_protoss_deathball
-                           ),
+            logic.terran_beats_protoss_deathball
+        ),
         make_location_data(SC2Mission.FORBIDDEN_WEAPON_T.mission_name, "South Solarite", SC2_RACESWAP_LOC_ID_OFFSET + 11901, LocationType.VANILLA,
-                           logic.terran_beats_protoss_deathball
-                           ),
+            logic.terran_beats_protoss_deathball
+        ),
         make_location_data(SC2Mission.FORBIDDEN_WEAPON_T.mission_name, "North Solarite", SC2_RACESWAP_LOC_ID_OFFSET + 11902, LocationType.VANILLA,
-                           logic.terran_beats_protoss_deathball
-                           ),
+            logic.terran_beats_protoss_deathball
+        ),
         make_location_data(SC2Mission.FORBIDDEN_WEAPON_T.mission_name, "Northwest Solarite", SC2_RACESWAP_LOC_ID_OFFSET + 11903, LocationType.VANILLA,
-                           logic.terran_beats_protoss_deathball
-                           ),
+            logic.terran_beats_protoss_deathball
+        ),
         make_location_data(SC2Mission.FORBIDDEN_WEAPON_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 12000, LocationType.VICTORY,
-                           logic.zerg_competent_comp_competent_aa
-                           ),
+            logic.zerg_competent_comp_competent_aa
+        ),
         make_location_data(SC2Mission.FORBIDDEN_WEAPON_Z.mission_name, "South Solarite", SC2_RACESWAP_LOC_ID_OFFSET + 12001, LocationType.VANILLA,
-                           logic.zerg_competent_comp_competent_aa
-                           ),
+            logic.zerg_competent_comp_competent_aa
+        ),
         make_location_data(SC2Mission.FORBIDDEN_WEAPON_Z.mission_name, "North Solarite", SC2_RACESWAP_LOC_ID_OFFSET + 12002, LocationType.VANILLA,
-                           logic.zerg_competent_comp_competent_aa
-                           ),
+            logic.zerg_competent_comp_competent_aa
+        ),
         make_location_data(SC2Mission.FORBIDDEN_WEAPON_Z.mission_name, "Northwest Solarite", SC2_RACESWAP_LOC_ID_OFFSET + 12003, LocationType.VANILLA,
-                           logic.zerg_competent_comp_competent_aa
-                           ),
+            logic.zerg_competent_comp_competent_aa
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_T.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 12100, LocationType.VICTORY,
-                           logic.terran_beats_protoss_deathball
-                           ),
+            logic.terran_beats_protoss_deathball
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_T.mission_name, "Mid Celestial Lock", SC2_RACESWAP_LOC_ID_OFFSET + 12101, LocationType.EXTRA,
-                           logic.terran_beats_protoss_deathball
-                           ),
+            logic.terran_beats_protoss_deathball
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_T.mission_name, "West Celestial Lock", SC2_RACESWAP_LOC_ID_OFFSET + 12102, LocationType.EXTRA,
-                           logic.terran_beats_protoss_deathball
-                           ),
+            logic.terran_beats_protoss_deathball
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_T.mission_name, "South Celestial Lock", SC2_RACESWAP_LOC_ID_OFFSET + 12103, LocationType.EXTRA,
-                           logic.terran_beats_protoss_deathball
-                           ),
+            logic.terran_beats_protoss_deathball
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_T.mission_name, "East Celestial Lock", SC2_RACESWAP_LOC_ID_OFFSET + 12104, LocationType.EXTRA,
-                           logic.terran_beats_protoss_deathball
-                           ),
+            logic.terran_beats_protoss_deathball
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_T.mission_name, "North Celestial Lock", SC2_RACESWAP_LOC_ID_OFFSET + 12105, LocationType.EXTRA,
-                           logic.terran_beats_protoss_deathball
-                           ),
+            logic.terran_beats_protoss_deathball
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_T.mission_name, "Titanic Warp Prism", SC2_RACESWAP_LOC_ID_OFFSET + 12106, LocationType.VANILLA,
             logic.terran_beats_protoss_deathball,
             hard_rule=logic.terran_any_anti_air,
         ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_T.mission_name, "Terran Main Base", SC2_RACESWAP_LOC_ID_OFFSET + 12107, LocationType.MASTERY,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_base_trasher(state)
-                           )
+            lambda state: (
+                    logic.terran_competent_comp(state)
+                    and logic.terran_base_trasher(state)
+            ),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_T.mission_name, "Protoss Main Base", SC2_RACESWAP_LOC_ID_OFFSET + 12108, LocationType.MASTERY,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_base_trasher(state)
-                                   and logic.terran_beats_protoss_deathball(state)
-                           )
+            lambda state: (
+                    logic.terran_competent_comp(state)
+                    and logic.terran_base_trasher(state)
+                    and logic.terran_beats_protoss_deathball(state)
+            ),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 12200, LocationType.VICTORY,
-                           logic.zerg_temple_of_unification_requirement
-                           ),
+            logic.zerg_temple_of_unification_requirement
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_Z.mission_name, "Mid Celestial Lock", SC2_RACESWAP_LOC_ID_OFFSET + 12201, LocationType.EXTRA,
-                           logic.zerg_temple_of_unification_requirement
-                           ),
+            logic.zerg_temple_of_unification_requirement
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_Z.mission_name, "West Celestial Lock", SC2_RACESWAP_LOC_ID_OFFSET + 12202, LocationType.EXTRA,
-                           logic.zerg_temple_of_unification_requirement
-                           ),
+            logic.zerg_temple_of_unification_requirement
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_Z.mission_name, "South Celestial Lock", SC2_RACESWAP_LOC_ID_OFFSET + 12203, LocationType.EXTRA,
-                           logic.zerg_temple_of_unification_requirement
-                           ),
+            logic.zerg_temple_of_unification_requirement
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_Z.mission_name, "East Celestial Lock", SC2_RACESWAP_LOC_ID_OFFSET + 12204, LocationType.EXTRA,
-                           logic.zerg_temple_of_unification_requirement
-                           ),
+            logic.zerg_temple_of_unification_requirement
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_Z.mission_name, "North Celestial Lock", SC2_RACESWAP_LOC_ID_OFFSET + 12205, LocationType.EXTRA,
-                           logic.zerg_temple_of_unification_requirement
-                           ),
+            logic.zerg_temple_of_unification_requirement
+        ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_Z.mission_name, "Titanic Warp Prism", SC2_RACESWAP_LOC_ID_OFFSET + 12206, LocationType.VANILLA,
             logic.zerg_temple_of_unification_requirement,
             hard_rule=logic.zerg_any_anti_air,
         ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_Z.mission_name, "Terran Main Base", SC2_RACESWAP_LOC_ID_OFFSET + 12207, LocationType.MASTERY,
-                            lambda state: (
-                                    logic.zerg_temple_of_unification_requirement(state)
-                                    and logic.zerg_base_buster(state)
-                            )
+            lambda state: (
+                logic.zerg_temple_of_unification_requirement(state)
+                and logic.zerg_base_buster(state)
+            ),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.TEMPLE_OF_UNIFICATION_Z.mission_name, "Protoss Main Base", SC2_RACESWAP_LOC_ID_OFFSET + 12208, LocationType.MASTERY,
-                            lambda state: (
-                                    logic.zerg_temple_of_unification_requirement(state)
-                                    and logic.zerg_base_buster(state)
-                            )
+            lambda state: (
+                logic.zerg_temple_of_unification_requirement(state)
+                and logic.zerg_base_buster(state)
+            ),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.HARBINGER_OF_OBLIVION_T.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 12500, LocationType.VICTORY,
                            logic.terran_harbinger_of_oblivion_requirement

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -3823,23 +3823,23 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         ),
         make_location_data(SC2Mission.MEDIA_BLITZ_P.mission_name, "Surprise Attack Ends", SC2_RACESWAP_LOC_ID_OFFSET + 4009, LocationType.EXTRA),
         make_location_data(SC2Mission.A_SINISTER_TURN_T.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 4500, LocationType.VICTORY,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_common_unit(state)
-                                   and logic.terran_competent_anti_air(state))
-                           ),
+            lambda state: (
+                logic.terran_competent_comp(state)
+                and logic.terran_common_unit(state)
+                and logic.terran_competent_anti_air(state))
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_T.mission_name, "Factory", SC2_RACESWAP_LOC_ID_OFFSET + 4501, LocationType.VANILLA,
-                           lambda state: adv_tactics or logic.terran_common_unit(state)
-                           ),
+            lambda state: adv_tactics or logic.terran_common_unit(state)
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_T.mission_name, "Armory", SC2_RACESWAP_LOC_ID_OFFSET + 4502, LocationType.VANILLA,
-                           lambda state: adv_tactics or logic.terran_common_unit(state)
-                           ),
+            lambda state: adv_tactics or logic.terran_common_unit(state)
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_T.mission_name, "Shadow Ops", SC2_RACESWAP_LOC_ID_OFFSET + 4503, LocationType.VANILLA,
-                           lambda state: logic.terran_common_unit(state) and logic.terran_competent_anti_air(state)
-                           ),
+            lambda state: logic.terran_common_unit(state) and logic.terran_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_T.mission_name, "Northeast Base", SC2_RACESWAP_LOC_ID_OFFSET + 4504, LocationType.EXTRA,
-                           lambda state: logic.terran_common_unit(state) and logic.terran_competent_anti_air(state)
-                           ),
+            lambda state: logic.terran_common_unit(state) and logic.terran_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_T.mission_name, "Southwest Base", SC2_RACESWAP_LOC_ID_OFFSET + 4505, LocationType.CHALLENGE,
             lambda state: (
                 logic.terran_competent_comp(state)
@@ -3848,48 +3848,48 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.A_SINISTER_TURN_T.mission_name, "Maar", SC2_RACESWAP_LOC_ID_OFFSET + 4506, LocationType.EXTRA,
-                           logic.terran_common_unit
-                           ),
+            logic.terran_common_unit
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_T.mission_name, "Northwest Preserver", SC2_RACESWAP_LOC_ID_OFFSET + 4507, LocationType.EXTRA,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_common_unit(state)
-                                   and logic.terran_competent_anti_air(state))
-                           ),
+            lambda state: (
+                logic.terran_competent_comp(state)
+                and logic.terran_common_unit(state)
+                and logic.terran_competent_anti_air(state))
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_T.mission_name, "Southwest Preserver", SC2_RACESWAP_LOC_ID_OFFSET + 4508, LocationType.EXTRA,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_common_unit(state)
-                                   and logic.terran_competent_anti_air(state))
-                           ),
+            lambda state: (
+                logic.terran_competent_comp(state)
+                and logic.terran_common_unit(state)
+                and logic.terran_competent_anti_air(state))
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_T.mission_name, "East Preserver", SC2_RACESWAP_LOC_ID_OFFSET + 4509, LocationType.EXTRA,
-                           lambda state: (
-                                   logic.terran_competent_comp(state)
-                                   and logic.terran_common_unit(state)
-                                   and logic.terran_competent_anti_air(state))
-                           ),
+            lambda state: (
+                logic.terran_competent_comp(state)
+                and logic.terran_common_unit(state)
+                and logic.terran_competent_anti_air(state))
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 4600, LocationType.VICTORY,
-                           lambda state: logic.zerg_competent_comp(state) and logic.zerg_competent_anti_air(state)
-                           ),
+            lambda state: logic.zerg_competent_comp(state) and logic.zerg_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "Ultralisk Cavern", SC2_RACESWAP_LOC_ID_OFFSET + 4601, LocationType.VANILLA,
-                           lambda state: (adv_tactics or logic.zerg_common_unit(state)) and logic.spread_creep(state)
-                           ),
+            lambda state: (adv_tactics or logic.zerg_common_unit(state)) and logic.spread_creep(state)
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "Hydralisk Den", SC2_RACESWAP_LOC_ID_OFFSET + 4602, LocationType.VANILLA,
-                           lambda state: (adv_tactics or logic.zerg_common_unit(state)) and logic.spread_creep(state)
-                           ),
+            lambda state: (adv_tactics or logic.zerg_common_unit(state)) and logic.spread_creep(state)
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "Infestation Pit", SC2_RACESWAP_LOC_ID_OFFSET + 4603, LocationType.VANILLA,
-                           lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state) and logic.spread_creep(state)
-                           ),
+            lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state) and logic.spread_creep(state)
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "Northeast Base", SC2_RACESWAP_LOC_ID_OFFSET + 4604, LocationType.EXTRA,
-                           lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
-                           ),
+            lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "Southwest Base", SC2_RACESWAP_LOC_ID_OFFSET + 4605, LocationType.CHALLENGE,
             lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state),
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "Maar", SC2_RACESWAP_LOC_ID_OFFSET + 4606, LocationType.EXTRA,
-                           logic.zerg_common_unit
-                           ),
+            logic.zerg_common_unit
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "Northwest Preserver", SC2_RACESWAP_LOC_ID_OFFSET + 4607, LocationType.EXTRA,
                            lambda state: logic.zerg_competent_comp(state) and logic.zerg_competent_anti_air(state)
                            ),
@@ -4720,7 +4720,8 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_P.mission_name, "East Main Primal Hive", SC2_RACESWAP_LOC_ID_OFFSET + 7808, LocationType.CHALLENGE,
-            logic.protoss_competent_comp
+            logic.protoss_competent_comp,
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.WAKING_THE_ANCIENT_P.mission_name, "Flawless", SC2_RACESWAP_LOC_ID_OFFSET + 7809, LocationType.CHALLENGE,
             logic.protoss_competent_comp,

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -953,6 +953,7 @@ class VictoryCache(Range):
 
 class LocationInclusion(Choice):
     option_enabled = 0
+    option_half_chance = 3
     option_filler = 1
     option_disabled = 2
 
@@ -964,8 +965,9 @@ class VanillaLocations(LocationInclusion):
     along with some additional objectives to balance the missions.
     Enable these locations for a balanced experience.
 
-    Enabled: All locations fitting into this do their normal rewards
-    Filler: Forces these locations to contain filler items
+    Enabled: All locations fitting into this do their normal rewards.
+    Half Chance: Locations of this type have a 50% chance of being excluded.
+    Filler: Forces these locations to contain filler items.
     Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
@@ -982,8 +984,9 @@ class ExtraLocations(LocationInclusion):
     destroying structures, and overcoming minor challenges.
     Enables these locations to add more checks and items to your world.
 
-    Enabled: All locations fitting into this do their normal rewards
-    Filler: Forces these locations to contain filler items
+    Enabled: All locations fitting into this do their normal rewards.
+    Half Chance: Locations of this type have a 50% chance of being excluded.
+    Filler: Forces these locations to contain filler items.
     Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
@@ -999,8 +1002,9 @@ class ChallengeLocations(LocationInclusion):
     You might be required to visit the same mission later after getting stronger in order to finish these tasks.
     Enable these locations to increase the difficulty of completing the multiworld.
 
-    Enabled: All locations fitting into this do their normal rewards
-    Filler: Forces these locations to contain filler items
+    Enabled: All locations fitting into this do their normal rewards.
+    Half Chance: Locations of this type have a 50% chance of being excluded.
+    Filler: Forces these locations to contain filler items.
     Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
@@ -1015,8 +1019,9 @@ class MasteryLocations(LocationInclusion):
     These challenges are often based on Mastery achievements and Feats of Strength.
     Enable these locations to add the most difficult checks to the world.
 
-    Enabled: All locations fitting into this do their normal rewards
-    Filler: Forces these locations to contain filler items
+    Enabled: All locations fitting into this do their normal rewards.
+    Half Chance: Locations of this type have a 50% chance of being excluded.
+    Filler: Forces these locations to contain filler items.
     Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
@@ -1031,8 +1036,10 @@ class SpeedrunLocations(LocationInclusion):
     These challenges are often based on speed achievements or community challenges.
     Enable these locations if you want to be rewarded for going fast.
 
-    Enabled: All locations fitting into this do their normal rewards
-    Filler: Forces these locations to contain filler items
+    Enabled: All locations fitting into this do their normal rewards.
+    Half Chance: Locations of this type have a 50% chance of being excluded.
+      *Note setting this for both challenge and speedrun will have a 25% of a challenge-speedrun location spawning.
+    Filler: Forces these locations to contain filler items.
     Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
@@ -1048,8 +1055,10 @@ class PreventativeLocations(LocationInclusion):
     such as beating Evacuation without losing a colonist.
     Enable these locations if you want to be rewarded for achieving a higher standard on some locations.
 
-    Enabled: All locations fitting into this do their normal rewards
-    Filler: Forces these locations to contain filler items
+    Enabled: All locations fitting into this do their normal rewards.
+    Half Chance: Locations of this type have a 50% chance of being excluded.
+      *Note setting this for both challenge and preventative will have a 25% of a challenge-preventative location spawning.
+    Filler: Forces these locations to contain filler items.
     Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -953,7 +953,7 @@ class VictoryCache(Range):
 
 class LocationInclusion(Choice):
     option_enabled = 0
-    option_resources = 1
+    option_filler = 1
     option_disabled = 2
 
 
@@ -965,7 +965,7 @@ class VanillaLocations(LocationInclusion):
     Enable these locations for a balanced experience.
 
     Enabled: All locations fitting into this do their normal rewards
-    Resources: Forces these locations to contain Starting Resources
+    Filler: Forces these locations to contain filler items
     Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
@@ -983,7 +983,7 @@ class ExtraLocations(LocationInclusion):
     Enables these locations to add more checks and items to your world.
 
     Enabled: All locations fitting into this do their normal rewards
-    Resources: Forces these locations to contain Starting Resources
+    Filler: Forces these locations to contain filler items
     Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
@@ -1000,7 +1000,7 @@ class ChallengeLocations(LocationInclusion):
     Enable these locations to increase the difficulty of completing the multiworld.
 
     Enabled: All locations fitting into this do their normal rewards
-    Resources: Forces these locations to contain Starting Resources
+    Filler: Forces these locations to contain filler items
     Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
@@ -1016,7 +1016,7 @@ class MasteryLocations(LocationInclusion):
     Enable these locations to add the most difficult checks to the world.
 
     Enabled: All locations fitting into this do their normal rewards
-    Resources: Forces these locations to contain Starting Resources
+    Filler: Forces these locations to contain filler items
     Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
@@ -1032,7 +1032,7 @@ class SpeedrunLocations(LocationInclusion):
     Enable these locations if you want to be rewarded for going fast.
 
     Enabled: All locations fitting into this do their normal rewards
-    Resources: Forces these locations to contain Starting Resources
+    Filler: Forces these locations to contain filler items
     Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
@@ -1049,7 +1049,7 @@ class PreventativeLocations(LocationInclusion):
     Enable these locations if you want to be rewarded for achieving a higher standard on some locations.
 
     Enabled: All locations fitting into this do their normal rewards
-    Resources: Forces these locations to contain Starting Resources
+    Filler: Forces these locations to contain filler items
     Disabled: Removes item rewards from these locations.
 
     Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -960,12 +960,12 @@ class LocationInclusion(Choice):
 
 class VanillaLocations(LocationInclusion):
     """
-    Enables or disables item rewards for completing vanilla objectives.
+    Enables or disables checks for completing vanilla objectives.
     Vanilla objectives are bonus objectives from the vanilla game,
     along with some additional objectives to balance the missions.
     Enable these locations for a balanced experience.
 
-    Enabled: All locations fitting into this do their normal rewards.
+    Enabled: Locations of this type give normal rewards.
     Half Chance: Locations of this type have a 50% chance of being excluded.
     Filler: Forces these locations to contain filler items.
     Disabled: Removes item rewards from these locations.
@@ -978,13 +978,13 @@ class VanillaLocations(LocationInclusion):
 
 class ExtraLocations(LocationInclusion):
     """
-    Enables or disables item rewards for mission progress and minor objectives.
+    Enables or disables checks for mission progress and minor objectives.
     This includes mandatory mission objectives,
     collecting reinforcements and resource pickups,
     destroying structures, and overcoming minor challenges.
     Enables these locations to add more checks and items to your world.
 
-    Enabled: All locations fitting into this do their normal rewards.
+    Enabled: Locations of this type give normal rewards.
     Half Chance: Locations of this type have a 50% chance of being excluded.
     Filler: Forces these locations to contain filler items.
     Disabled: Removes item rewards from these locations.
@@ -997,12 +997,12 @@ class ExtraLocations(LocationInclusion):
 
 class ChallengeLocations(LocationInclusion):
     """
-    Enables or disables item rewards for completing challenge tasks.
+    Enables or disables checks for completing challenge tasks.
     Challenges are tasks that are more difficult than completing the mission, and are often based on achievements.
     You might be required to visit the same mission later after getting stronger in order to finish these tasks.
     Enable these locations to increase the difficulty of completing the multiworld.
 
-    Enabled: All locations fitting into this do their normal rewards.
+    Enabled: Locations of this type give normal rewards.
     Half Chance: Locations of this type have a 50% chance of being excluded.
     Filler: Forces these locations to contain filler items.
     Disabled: Removes item rewards from these locations.
@@ -1015,11 +1015,11 @@ class ChallengeLocations(LocationInclusion):
 
 class MasteryLocations(LocationInclusion):
     """
-    Enables or disables item rewards for overcoming especially difficult challenges.
+    Enables or disables checks for overcoming especially difficult challenges.
     These challenges are often based on Mastery achievements and Feats of Strength.
     Enable these locations to add the most difficult checks to the world.
 
-    Enabled: All locations fitting into this do their normal rewards.
+    Enabled: Locations of this type give normal rewards.
     Half Chance: Locations of this type have a 50% chance of being excluded.
     Filler: Forces these locations to contain filler items.
     Disabled: Removes item rewards from these locations.
@@ -1030,13 +1030,31 @@ class MasteryLocations(LocationInclusion):
     display_name = "Mastery Locations"
 
 
+class BasebustLocations(LocationInclusion):
+    """
+    Enables or disables checks for killing non-objective bases.
+    These challenges are about destroying enemy bases that you normally don't have to fight to win a mission.
+    Enable these locations if you like sieges or being rewarded for achieving alternate win conditions.
+
+    Enabled: Locations of this type give normal rewards.
+    Half Chance: Locations of this type have a 50% chance of being excluded.
+      *Note setting this for both challenge and basebust will have a 25% of a challenge-basebust location spawning.
+    Filler: Forces these locations to contain filler items.
+    Disabled: Removes item rewards from these locations.
+
+    Note: Individual locations subject to plando are always enabled, so the plando can be placed properly.
+    See also: Excluded Locations, Item Plando (https://archipelago.gg/tutorial/Archipelago/plando/en#item-plando)
+    """
+    display_name = "Base-Bust Locations"
+
+
 class SpeedrunLocations(LocationInclusion):
     """
-    Enables or disables item rewards for overcoming speedrun challenges.
+    Enables or disables checks for overcoming speedrun challenges.
     These challenges are often based on speed achievements or community challenges.
     Enable these locations if you want to be rewarded for going fast.
 
-    Enabled: All locations fitting into this do their normal rewards.
+    Enabled: Locations of this type give normal rewards.
     Half Chance: Locations of this type have a 50% chance of being excluded.
       *Note setting this for both challenge and speedrun will have a 25% of a challenge-speedrun location spawning.
     Filler: Forces these locations to contain filler items.
@@ -1050,12 +1068,12 @@ class SpeedrunLocations(LocationInclusion):
 
 class PreventativeLocations(LocationInclusion):
     """
-    Enables or disables item rewards for overcoming preventative challenges.
+    Enables or disables checks for overcoming preventative challenges.
     These challenges are about winning or achieving something while preventing something else from happening,
     such as beating Evacuation without losing a colonist.
     Enable these locations if you want to be rewarded for achieving a higher standard on some locations.
 
-    Enabled: All locations fitting into this do their normal rewards.
+    Enabled: Locations of this type give normal rewards.
     Half Chance: Locations of this type have a 50% chance of being excluded.
       *Note setting this for both challenge and preventative will have a 25% of a challenge-preventative location spawning.
     Filler: Forces these locations to contain filler items.
@@ -1312,6 +1330,7 @@ class Starcraft2Options(PerGameCommonOptions):
     extra_locations: ExtraLocations
     challenge_locations: ChallengeLocations
     mastery_locations: MasteryLocations
+    basebust_locations: BasebustLocations
     speedrun_locations: SpeedrunLocations
     preventative_locations: PreventativeLocations
     filler_percentage: FillerPercentage
@@ -1393,6 +1412,7 @@ option_groups = [
         ExtraLocations,
         ChallengeLocations,
         MasteryLocations,
+        BasebustLocations,
         SpeedrunLocations,
         PreventativeLocations,
     ]),

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -496,7 +496,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             'enable_hots_missions': True,
             'mission_order': options.MissionOrder.option_grid,
             'speedrun_locations': options.SpeedrunLocations.option_disabled,
-            'preventative_locations': options.PreventativeLocations.option_resources,
+            'preventative_locations': options.PreventativeLocations.option_filler,
         }
 
         self.generate_world(world_options)


### PR DESCRIPTION
## What is this fixing or adding?
* (polish) renaming location inclusion "resources" option to "filler" (as not all filler are resources)
* (polish) Rewording location inclusion option descriptions a little
* Adding a half_chance option to location inclusion, which gives each location a 50% chance of being included in the world
* Adding a `basebust_locations` option and accompanying location flag

### Basebust locations
I ran this by the #sc2-dev channel to get some live feedback on edge cases. The rule-of-thumb is that it's for attacking bases that are not required for victory and are on challenge or mastery locations (no extra). This excluded Raynor's landing sites on Sky Shield and such. Sinister Turn has one basebust for SW base, as that's challenge but East base is extra (and much easier/more common to take). Primal Hives on Waking the Ancient were only marked as basebust in the bottom-left corner "main" location, as that felt closest to a base; proxies were not flagged as they felt like outposts.

The final list:
* Zero Hour hatches
* Evacuation
* Smash and Grab
* Dig
* Devil's Playground
* Jungle
* Sinister Turn SW base
* Shoot the Messenger launch bays
* Domination without 100 eggs
* Fire in the Sky orbitals
* Waking the Ancient SE corner hives
* Dark Whispers
* Temple of Unification
* End Game orbitals

This comes out to 76 basebust locations. 1 NCO, 25 other base campaigns, 50 in raceswaps.

### Styling
The indentation on raceswap locations is different from non-raceswap. I generally fixed the indentation on missions I touched and left the rest for later. The inconsistency hurts but a more colossal diff hurts more.

## How was this tested?
Ran unit tests. Gen'd a few worlds using the half_chance option on some flags and verified that only some locations rolled.

## If this makes graphical changes, please attach screenshots.
Note how only one Dig base spawned in this world:
![image](https://github.com/user-attachments/assets/d30e35cb-4d91-4525-b4b4-52015f1d10f6)
