### PR TITLE
SC2: Fixing Hard Bias on Large Mission Orders

### DIFF
--- a/worlds/sc2/mission_order/mission_pools.py
+++ b/worlds/sc2/mission_order/mission_pools.py
@@ -197,16 +197,16 @@ class SC2MOGenMissionPools:
         final_pool: List[int] = []
         desired_difficulty = slot.option_difficulty
         if prefer_close_difficulty:
-            # Iteratively look down and up around the slot's desired difficulty
+            # Iteratively look up and down around the slot's desired difficulty
             # Either a difficulty with valid missions is found, or an error is raised
             difficulty_offset = 0
             while len(final_pool) == 0:
-                lower_diff = max(desired_difficulty - difficulty_offset, 1)
-                higher_diff = min(desired_difficulty + difficulty_offset + 1, 5)
-                final_pool = difficulty_pools[lower_diff]
+                higher_diff = min(desired_difficulty + difficulty_offset + 1, Difficulty.VERY_HARD)
+                final_pool = difficulty_pools[higher_diff]
                 if len(final_pool) > 0:
                     break
-                final_pool = difficulty_pools[higher_diff]
+                lower_diff = max(desired_difficulty - difficulty_offset, Difficulty.STARTER)
+                final_pool = difficulty_pools[lower_diff]
                 if len(final_pool) > 0:
                     break
                 if lower_diff == Difficulty.STARTER and higher_diff == Difficulty.VERY_HARD:

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -910,8 +910,7 @@ class ExcludedMissions(Sc2MissionSet):
 
 class MissionBias(Choice):
     """
-    When building a campaign, determines whether easy or hard missions are more likely to appear.
-    Only applies to mission orders with fewer missions than those available.
+    Determines whether easy missions can appear late in the campaign.
     """
     display_name = "Mission Bias"
     option_easy = 0


### PR DESCRIPTION
## What is this fixing or adding?

Currently, if the mission pool is the same size as the mission order on a non-custom mission order, Very Hard missions end up in Starter slots.

![image](https://github.com/user-attachments/assets/6ecbab2d-357c-4ad9-b6f7-273d7c6a8a53)

Flipping the priority when selecting Mission Bias: Hard slots and goal slots fixes this issue.  

This also rephrases the description of the option to better describe what it does when a mission order contains all possible missions in the pool.  The original intention of the option was to increase the chance of hard missions appearing in the campaign on mission orders with fewer than the maximum number of missions (thus making the campaign harder), but it has the secondary effect of preventing easy missions from appearing later in the campaign when the mission pool is not substantially larger than the mission order.

## How was this tested?

Generated a maximized grid, a vanilla shuffled campaign, and a 3x3 grid with Mission Bias: Hard enabled.

## If this makes graphical changes, please attach screenshots.

![image](https://github.com/user-attachments/assets/4ec7cab3-f074-467d-acbd-6d1d47ebe3f1)
