### PR TITLE
sc2: trap scouting setting + settings fixes

### DIFF
--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -509,6 +509,8 @@ class SC2Manager(GameManager):
             return " [color=AF99EF](Progression)[/color]"
         if ItemClassification.useful & item_classification_key:
             return " [color=6D8BE8](Useful)[/color]"
+        if SC2World.settings.show_traps and ItemClassification.trap & item_classification_key:
+            return " [color=FA8072](Trap)[/color]"
         return " [color=00EEEE](Filler)[/color]"
 
 

--- a/worlds/sc2/settings.py
+++ b/worlds/sc2/settings.py
@@ -23,14 +23,17 @@ class Starcraft2Settings(settings.Group):
         """Overrides the slot's difficulty setting. Possible values: `casual`, `normal`, `hard`, `brutal`, `default`. Default uses slot value"""
     class GameSpeed(str):
         """Overrides the slot's gamespeed setting. Possible values: `slower`, `slow`, `normal`, `fast`, `faster`, `default`. Default uses slot value"""
+    class ShowTraps(settings.Bool):
+        """If set to true, in-client scouting will show traps as distinct from filler"""
 
-    window_width = WindowWidth(1080)
-    window_height = WindowHeight(720)
+    window_width: WindowWidth = WindowWidth(1080)
+    window_height: WindowHeight = WindowHeight(720)
     game_windowed_mode: Union[GameWindowedMode, bool] = False
-    disable_forced_camera = DisableForcedCamera("default")
-    skip_cutscenes = SkipCutscenes("default")
-    game_difficulty = GameDifficulty("default")
-    game_speed = GameSpeed("default")
-    terran_button_color = TerranButtonColor([0.0838, 0.2898, 0.2346])
-    zerg_button_color = ZergButtonColor([0.345, 0.22425, 0.12765])
-    protoss_button_color = ProtossButtonColor([0.18975, 0.2415, 0.345])
+    show_traps: Union[ShowTraps, bool] = False
+    disable_forced_camera: DisableForcedCamera = DisableForcedCamera("default")
+    skip_cutscenes: SkipCutscenes = SkipCutscenes("default")
+    game_difficulty: GameDifficulty = GameDifficulty("default")
+    game_speed: GameSpeed = GameSpeed("default")
+    terran_button_color: TerranButtonColor = TerranButtonColor([0.0838, 0.2898, 0.2346])
+    zerg_button_color: ZergButtonColor = ZergButtonColor([0.345, 0.22425, 0.12765])
+    protoss_button_color: ProtossButtonColor = ProtossButtonColor([0.18975, 0.2415, 0.345])


### PR DESCRIPTION
## What is this fixing or adding?
* Fixing writing host options erasing all options except windowed_mode
* added a setting to display trap items in scouting, `show_traps`

Note that I didn't special-case everything; if an item or victory cache is marked `progression|trap` or `useful|trap`, it will not display the "trap". I'd call this close enough to desired behaviour. This means a victory location will only display trap if all items in victory/cache are filler or trap.

## How was this tested?
* Gen'd a world with scouting, located a trap item. Checked the display with the setting turned each way
* Changed the value of windowed mode with `/windowed_mode` and checked that all my other settings weren't erased
  * Lists were reformatted in expanded form, which was irritating, but oh well

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/ea9a8023-f2fd-4bea-a668-a9a039ac1f72)
![image](https://github.com/user-attachments/assets/d06ab455-eced-4628-9a85-1ea81fc847d7)
![image](https://github.com/user-attachments/assets/3af63e45-07e5-4c77-83ad-b1ae453df988)
