### PR TITLE
Mm/fix absolute imports

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -56,7 +56,7 @@ from worlds._sc2common import bot
 from worlds._sc2common.bot.data import Race
 from worlds._sc2common.bot.main import run_game
 from worlds._sc2common.bot.player import Bot
-from worlds.sc2.item.item_tables import (
+from .item.item_tables import (
     lookup_id_to_name, get_full_item_list, ItemData,
     race_to_item_type, ZergItemType, ProtossItemType, upgrade_bundles,
     WEAPON_ARMOR_UPGRADE_MAX_LEVEL,

--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -15,13 +15,13 @@ from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.scrollview import ScrollView
 from kivy.properties import StringProperty, BooleanProperty
 
-from worlds.sc2.client import SC2Context, calc_unfinished_nodes
-from worlds.sc2.item.item_descriptions import item_descriptions
-from worlds.sc2.mission_tables import lookup_id_to_mission, campaign_race_exceptions, \
+from .client import SC2Context, calc_unfinished_nodes
+from .item.item_descriptions import item_descriptions
+from .mission_tables import lookup_id_to_mission, campaign_race_exceptions, \
     SC2Mission, SC2Race
-from worlds.sc2.locations import LocationType, lookup_location_id_to_type, lookup_location_id_to_flags
-from worlds.sc2.options import LocationInclusion, MissionOrderScouting
-from worlds.sc2 import SC2World
+from .locations import LocationType, lookup_location_id_to_type, lookup_location_id_to_flags
+from .options import LocationInclusion, MissionOrderScouting
+from . import SC2World
 
 
 class HoverableButton(HoverBehavior, Button):

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -3891,94 +3891,96 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             logic.zerg_common_unit
         ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "Northwest Preserver", SC2_RACESWAP_LOC_ID_OFFSET + 4607, LocationType.EXTRA,
-                           lambda state: logic.zerg_competent_comp(state) and logic.zerg_competent_anti_air(state)
-                           ),
+            lambda state: logic.zerg_competent_comp(state) and logic.zerg_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "Southwest Preserver", SC2_RACESWAP_LOC_ID_OFFSET + 4608, LocationType.EXTRA,
-                           lambda state: logic.zerg_competent_comp(state) and logic.zerg_competent_anti_air(state)
-                           ),
+            lambda state: logic.zerg_competent_comp(state) and logic.zerg_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.A_SINISTER_TURN_Z.mission_name, "East Preserver", SC2_RACESWAP_LOC_ID_OFFSET + 4609, LocationType.EXTRA,
-                           lambda state: logic.zerg_competent_comp(state) and logic.zerg_competent_anti_air(state)
-                           ),
+            lambda state: logic.zerg_competent_comp(state) and logic.zerg_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_T.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 4700, LocationType.VICTORY,
-                           lambda state: (
-                                   logic.terran_common_unit(state) and logic.terran_competent_anti_air(state)
-                           )
-                           ),
+            lambda state: logic.terran_common_unit(state) and logic.terran_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_T.mission_name, "Close Obelisk", SC2_RACESWAP_LOC_ID_OFFSET + 4701, LocationType.VANILLA,
-                           lambda state: logic.terran_common_unit(state)),
+            logic.terran_common_unit
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_T.mission_name, "West Obelisk", SC2_RACESWAP_LOC_ID_OFFSET + 4702, LocationType.VANILLA,
-                           lambda state: logic.terran_common_unit(state) and (adv_tactics or logic.terran_basic_anti_air(state))
-                           ),
+            lambda state: logic.terran_common_unit(state) and (adv_tactics or logic.terran_basic_anti_air(state))
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_T.mission_name, "Base", SC2_RACESWAP_LOC_ID_OFFSET + 4703, LocationType.EXTRA),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_T.mission_name, "Southwest Tendril", SC2_RACESWAP_LOC_ID_OFFSET + 4704, LocationType.EXTRA,
-                           lambda state: logic.terran_common_unit(state)),
+            logic.terran_common_unit
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_T.mission_name, "Southeast Tendril", SC2_RACESWAP_LOC_ID_OFFSET + 4705, LocationType.EXTRA,
-                           lambda state: logic.terran_common_unit(state)
-                           ),
+            logic.terran_common_unit
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_T.mission_name, "Northeast Tendril", SC2_RACESWAP_LOC_ID_OFFSET + 4706, LocationType.EXTRA,
-                           lambda state: logic.terran_common_unit(state) and logic.terran_competent_anti_air(state)
-                           ),
+            lambda state: logic.terran_common_unit(state) and logic.terran_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_T.mission_name, "Northwest Tendril", SC2_RACESWAP_LOC_ID_OFFSET + 4707, LocationType.EXTRA,
-                           lambda state: logic.terran_common_unit(state) and logic.terran_competent_anti_air(state)
-                           ),
+            lambda state: logic.terran_common_unit(state) and logic.terran_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 4800, LocationType.VICTORY,
-                           lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
-                           ),
+            lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_Z.mission_name, "Close Obelisk", SC2_RACESWAP_LOC_ID_OFFSET + 4801, LocationType.VANILLA,
-                           lambda state: logic.zerg_common_unit(state)),
+            logic.zerg_common_unit
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_Z.mission_name, "West Obelisk", SC2_RACESWAP_LOC_ID_OFFSET + 4802, LocationType.VANILLA,
-                           lambda state: (
-                                   logic.zerg_common_unit(state)
-                                   and logic.zerg_basic_kerriganless_anti_air(state)
-                                   and (adv_tactics or logic.spread_creep(state))
-                           )
-                           ),
+            lambda state: (
+                    logic.zerg_common_unit(state)
+                    and logic.zerg_basic_kerriganless_anti_air(state)
+                    and (adv_tactics or logic.spread_creep(state))
+            )
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_Z.mission_name, "Base", SC2_RACESWAP_LOC_ID_OFFSET + 4803, LocationType.EXTRA),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_Z.mission_name, "Southwest Tendril", SC2_RACESWAP_LOC_ID_OFFSET + 4804, LocationType.EXTRA,
-                           lambda state: logic.zerg_common_unit(state)),
+            logic.zerg_common_unit
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_Z.mission_name, "Southeast Tendril", SC2_RACESWAP_LOC_ID_OFFSET + 4805, LocationType.EXTRA,
-                           lambda state: logic.zerg_common_unit(state)
-                           ),
+            logic.zerg_common_unit
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_Z.mission_name, "Northeast Tendril", SC2_RACESWAP_LOC_ID_OFFSET + 4806, LocationType.EXTRA,
-                           lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
-                           ),
+            lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.ECHOES_OF_THE_FUTURE_Z.mission_name, "Northwest Tendril", SC2_RACESWAP_LOC_ID_OFFSET + 4807, LocationType.EXTRA,
-                           lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
-                           ),
+            lambda state: logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
+        ),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_T.mission_name, "Defeat", SC2_RACESWAP_LOC_ID_OFFSET + 4900, LocationType.VICTORY),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_T.mission_name, "Protoss Archive", SC2_RACESWAP_LOC_ID_OFFSET + 4901, LocationType.VANILLA,
-                           logic.terran_last_stand_requirement
-                           ),
+            logic.terran_last_stand_requirement
+        ),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_T.mission_name, "Kills", SC2_RACESWAP_LOC_ID_OFFSET + 4902, LocationType.VANILLA,
-                           logic.terran_last_stand_requirement
-                           ),
+            logic.terran_last_stand_requirement
+        ),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_T.mission_name, "Urun", SC2_RACESWAP_LOC_ID_OFFSET + 4903, LocationType.EXTRA),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_T.mission_name, "Mohandar", SC2_RACESWAP_LOC_ID_OFFSET + 4904, LocationType.EXTRA,
-                           logic.terran_last_stand_requirement
-                           ),
+            logic.terran_last_stand_requirement
+        ),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_T.mission_name, "Selendis", SC2_RACESWAP_LOC_ID_OFFSET + 4905, LocationType.EXTRA,
-                           logic.terran_last_stand_requirement
-                           ),
+            logic.terran_last_stand_requirement
+        ),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_T.mission_name, "Artanis", SC2_RACESWAP_LOC_ID_OFFSET + 4906, LocationType.EXTRA,
-                           logic.terran_last_stand_requirement
-                           ),
+            logic.terran_last_stand_requirement
+        ),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_Z.mission_name, "Defeat", SC2_RACESWAP_LOC_ID_OFFSET + 5000, LocationType.VICTORY),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_Z.mission_name, "Protoss Archive", SC2_RACESWAP_LOC_ID_OFFSET + 5001, LocationType.VANILLA,
-                           logic.zerg_last_stand_requirement
-                           ),
+            logic.zerg_last_stand_requirement
+        ),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_Z.mission_name, "Kills", SC2_RACESWAP_LOC_ID_OFFSET + 5002, LocationType.VANILLA,
-                           logic.zerg_last_stand_requirement
-                           ),
+            logic.zerg_last_stand_requirement
+        ),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_Z.mission_name, "Urun", SC2_RACESWAP_LOC_ID_OFFSET + 5003, LocationType.EXTRA),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_Z.mission_name, "Mohandar", SC2_RACESWAP_LOC_ID_OFFSET + 5004, LocationType.EXTRA,
-                           logic.zerg_last_stand_requirement
-                           ),
+            logic.zerg_last_stand_requirement
+        ),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_Z.mission_name, "Selendis", SC2_RACESWAP_LOC_ID_OFFSET + 5005, LocationType.EXTRA,
-                           logic.zerg_last_stand_requirement
-                           ),
+            logic.zerg_last_stand_requirement
+        ),
         make_location_data(SC2Mission.IN_UTTER_DARKNESS_Z.mission_name, "Artanis", SC2_RACESWAP_LOC_ID_OFFSET + 5006, LocationType.EXTRA,
-                           logic.zerg_last_stand_requirement
-                           ),
+            logic.zerg_last_stand_requirement
+        ),
         make_location_data(SC2Mission.GATES_OF_HELL_Z.mission_name, "Victory", SC2_RACESWAP_LOC_ID_OFFSET + 5100, LocationType.VICTORY,
             logic.zerg_gates_of_hell_requirement
         ),

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -464,9 +464,10 @@ class GenericUpgradeResearch(Choice):
     option_auto_in_build = 2
     option_always_auto = 3
 
+
 class GenericUpgradeResearchSpeedup(Toggle):
     """
-    If turned on, the weapon and armor upgrades are researched more quickly, if level 4 or higher is unlocked.
+    If turned on, the weapon and armor upgrades are researched more quickly if level 4 or higher is unlocked.
     The research times of upgrades are cut proportionally, so you're able to hit the maximum available level
     at the same time, as you'd hit level 3 normally.
 

--- a/worlds/sc2/test/test_items.py
+++ b/worlds/sc2/test/test_items.py
@@ -1,7 +1,7 @@
 import unittest
 from typing import List, Set
 
-from worlds.sc2.item import item_tables
+from ..item import item_tables
 
 
 class TestItems(unittest.TestCase):


### PR DESCRIPTION
## What is this fixing or adding?
Found a few absolute imports while checking on a potential bug for someone in main chat. Absolute imports like this generally don't work when running through the installer, so this is just a minor issue to resolve before merging to main / making a frozen apworld.

Also chipped away at a little more formatting fixing in locations.py

## How was this tested?
Ran unit tests. Did a generation+connected through the client. All done from source, just checking no imports were broken.

Ran mypy on locations.py to make sure the reformatting didn't change any types.

## If this makes graphical changes, please attach screenshots.
None