### PR TITLE
issue 4617: Missions names surrounded by asterisks when a hint points to that mission

### DIFF
--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -224,6 +224,14 @@ class SC2Manager(GameManager):
 
         multi_campaign_layout_height = 0
 
+        # Fetching IDs of all the locations with hints  
+        self.hints_to_highlight = []
+        hints = self.ctx.stored_data.get(f"_read_hints_{self.ctx.team}_{self.ctx.slot}")
+        if hints:
+            for hint in hints:
+                if hint['finding_player'] == self.ctx.slot and not hint['found']:
+                    self.hints_to_highlight.append(hint['location'])
+
         MISSION_BUTTON_HEIGHT = 50
         MISSION_BUTTON_PADDING = 6
         for campaign_idx, campaign in enumerate(self.ctx.custom_mission_order):
@@ -418,6 +426,11 @@ class SC2Manager(GameManager):
                 tooltip += "\n- ".join(plando_locations)
 
         tooltip = f"[b]{text}[/b]\n" + tooltip
+
+        #If the mission has any hints pointing to a check, add asterisks around the mission name
+        if any(tuple(x in self.hints_to_highlight for x in self.ctx.locations_for_mission_id(mission_id))):
+            text = "* " + text + " *"
+
         return text, tooltip
         
 


### PR DESCRIPTION
Implementation of ArchipelagoMW/Archipelago/issues/4617

Surrounds mission name with asterisks when hints are found for that mission.

Tested with a full shuffled campaign.

Only problem I saw was when the hints load after the mission board is generated, in that case no asterisks will appear until the next UI refresh.

![sc2hints](https://github.com/user-attachments/assets/f65a51b6-21de-4a18-a697-a8739b5cbd2c)

