### PR TITLE
Options: Renaming "Mission Bias" to "Difficulty Curve", harder placement becomes the default, All-In randomized

### DIFF
--- a/worlds/sc2/mission_order/generation.py
+++ b/worlds/sc2/mission_order/generation.py
@@ -293,7 +293,7 @@ def fill_missions(
     locations_per_region = get_locations_per_region(locations)
     regions: List[Region] = [create_region(world, locations_per_region, location_cache, "Menu")]
     locked_ids = [lookup_name_to_mission[mission].id for mission in locked_missions]
-    prefer_easy_missions = world.options.mission_bias.value == world.options.mission_bias.option_easy
+    prefer_easy_missions = world.options.difficulty_curve.value == world.options.difficulty_curve.option_uneven
 
     def set_mission_in_slot(slot: SC2MOGenMission, mission: SC2Mission):
         slot.mission = mission

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -922,13 +922,15 @@ class ExcludedMissions(Sc2MissionSet):
     valid_keys = {mission.mission_name for mission in SC2Mission}
 
 
-class MissionBias(Choice):
+class DifficultyCurve(Choice):
     """
-    Determines whether easy missions can appear late in the campaign.
+    Determines whether campaign missions will be placed with a smooth difficulty curve.
+    Standard: The campaign will start with easy missions and end with challenging missions.  Short campaigns will be more difficult.
+    Uneven: The campaign will start with easy missions, but easy missions can still appear later in the campaign.  Short campaigns will be easier.
     """
     display_name = "Mission Bias"
-    option_easy = 0
-    option_hard = 1
+    option_standard = 0
+    option_uneven = 1
 
 
 class ExcludeVeryHardMissions(Choice):
@@ -1336,7 +1338,7 @@ class Starcraft2Options(PerGameCommonOptions):
     excluded_items: ExcludedItems
     unexcluded_items: UnexcludedItems
     excluded_missions: ExcludedMissions
-    mission_bias: MissionBias
+    difficulty_curve: DifficultyCurve
     exclude_very_hard_missions: ExcludeVeryHardMissions
     vanilla_items_only: VanillaItemsOnly
     victory_cache: VictoryCache
@@ -1367,7 +1369,7 @@ option_groups = [
         StarterUnit,
         RequiredTactics,
         NerfUnitBaselines,
-        MissionBias,
+        DifficultyCurve,
     ]),
     OptionGroup("Primary Campaign Settings", [
         MissionOrder,

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -929,7 +929,7 @@ class DifficultyCurve(Choice):
     Standard: The campaign will start with easy missions and end with challenging missions.  Short campaigns will be more difficult.
     Uneven: The campaign will start with easy missions, but easy missions can still appear later in the campaign.  Short campaigns will be easier.
     """
-    display_name = "Mission Bias"
+    display_name = "Difficulty Curve"
     option_standard = 0
     option_uneven = 1
 

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -130,6 +130,7 @@ class AllInMap(Choice):
     display_name = "All In Map"
     option_ground = 0
     option_air = 1
+    default = 'random'
 
 
 class MissionOrder(Choice):


### PR DESCRIPTION
## What is this fixing or adding?

Mission Bias is getting renamed to Difficulty Curve, with its former `easy` and `hard` options becoming `uneven` and `standard`.

The hard mission bias / standard difficulty curve is now the default, as chat consensus prefers the smooth difficulty curve of the new method over the greater randomness of the original method.

Unrelated: this also changes All In Map to default to Random, rather than Ground.  I did not believe this one line change needed its own PR, and making it default to random is intuitive for the setting.

## How was this tested?

Generated a mini grid with both versions of difficulty_curve, and ran the webhost.

## If this makes graphical changes, please attach screenshots.

![image](https://github.com/user-attachments/assets/649b383f-de05-4770-9a16-b768d344c3fa)

![image](https://github.com/user-attachments/assets/66f983f4-ee80-4816-82e3-d01c0fa82800)
