### PR TITLE
Sc2 next difficulty curve fix

### DIFF
--- a/worlds/sc2/mission_order/mission_pools.py
+++ b/worlds/sc2/mission_order/mission_pools.py
@@ -194,12 +194,12 @@ class SC2MOGenMissionPools:
             for diff in Difficulty if diff != Difficulty.RELATIVE
         }
 
-        final_pool: List[int] = []
         desired_difficulty = slot.option_difficulty
         if prefer_close_difficulty:
             # Iteratively look up and down around the slot's desired difficulty
             # Either a difficulty with valid missions is found, or an error is raised
             difficulty_offset = 0
+            final_pool = difficulty_pools[desired_difficulty]
             while len(final_pool) == 0:
                 higher_diff = min(desired_difficulty + difficulty_offset + 1, Difficulty.VERY_HARD)
                 final_pool = difficulty_pools[higher_diff]


### PR DESCRIPTION
## What is this fixing or adding?

Hallucinated the line `final_pool = difficulty_pools[desired_difficulty]` and initially wrote logic assuming that.  Line did not actually exist.  Fixed that.

## How was this tested?

Tested one Golden Path generation with both Difficulty Curve settings.