### PR TITLE
sc2: Fixing a generation bug and adjusting option ranges and defaults

### DIFF
--- a/worlds/sc2/mission_order/generation.py
+++ b/worlds/sc2/mission_order/generation.py
@@ -372,7 +372,7 @@ def fill_missions(
             remaining_count -= 1
         except IndexError:
             raise IndexError(
-                f"Slot at address \"{goal_slot.get_address_to_node()}\" ran out of possible missions to place "
+                f"Slot at address \"{mission_slot.get_address_to_node()}\" ran out of possible missions to place "
                 f"with {remaining_count} empty slots remaining."
             )
 

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -505,7 +505,7 @@ class MaxNumberOfUpgrades(Range):
     default = -1
 
 
-class MercenaryHighlanders(Toggle):
+class MercenaryHighlanders(DefaultOnToggle):
     """
     If enabled, it limits the controllable amount of certain mercenaries to 1, even if you have unlimited mercenaries upgrade.
     With this upgrade you can still call the mercenary again if it dies.
@@ -831,7 +831,7 @@ class NovaMaxWeapons(Range):
 
     Note: Nova can swap between unlocked weapons anytime during the gameplay.
     """
-    range_start = 1
+    range_start = 0
     range_end = len(nova_weapons)
     default = range_end
 
@@ -1561,10 +1561,14 @@ def get_enabled_races(world: Optional['SC2World']) -> Set[SC2Race]:
 
 
 def get_enabled_campaigns(world: Optional['SC2World']) -> Set[SC2Campaign]:
-    campaign_names = get_option_value(world, "enabled_campaigns")
+    if world is None:
+        return EnabledCampaigns.default
+    campaign_names = world.options.enabled_campaigns
     campaigns = {campaign for campaign in SC2Campaign if campaign.campaign_name in campaign_names}
-    if (get_option_value(world, "mission_order") == MissionOrder.option_vanilla
-            and get_option_value(world,"selected_races") != SelectRaces.valid_keys):
+    if (world.options.mission_order.value == MissionOrder.option_vanilla
+        and world.options.selected_races.value != SelectRaces.valid_keys
+        and SC2Campaign.EPILOGUE in campaigns
+    ):
         campaigns.remove(SC2Campaign.EPILOGUE)
     return campaigns
 


### PR DESCRIPTION
## What is this fixing or adding?
* Fixed a bug that caused a keyerror with the following preconditions:
  * epilogue is not enabled
  * mission order is vanilla
  * not all races are included
  * (reported by BL4Z3ST0RM [here](https://discord.com/channels/731205301247803413/1101186175722598521/1348870399475060787) )
* Fixed a bug where an undefined error would cover up an index error with a proper message when too many missions are excluded on vanilla mission order
* Set the minimum option value of max_nova_weapons to 0 instead of 1
* Set default of highlander option to true (why would it be false? it's a pretty cut-and-dry "click this to be more OP when you're at your most OP". people should opt-in to that)

## How was this tested?
Made a yaml with all the preconditions for the first and second bugs. Checked they produced the issue without my fix, and didn't show the issue with my fix.

## If this makes graphical changes, please attach screenshots.
None