### PR TITLE
sc2: Fixing options not in groups

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -21,7 +21,7 @@ from .mission_order.layout_types import Gauntlet
 from .options import (
     get_option_value, LocationInclusion, KerriganLevelItemDistribution,
     KerriganPresence, KerriganPrimalStatus, kerrigan_unit_available, StarterUnit, SpearOfAdunPresence,
-    get_enabled_campaigns, SpearOfAdunAutonomouslyCastAbilityPresence, Starcraft2Options,
+    get_enabled_campaigns, SpearOfAdunPassiveAbilityPresence, Starcraft2Options,
     GrantStoryTech, GenericUpgradeResearch, RequiredTactics,
     upgrade_included_names, EnableVoidTrade, FillerRatio, MissionOrderScouting, option_groups,
     NovaGhostOfAChanceVariant, MissionOrder,
@@ -537,13 +537,13 @@ def flag_mission_based_item_excludes(world: SC2World, item_list: List[FilterItem
         soa_presence = False
     
     # Check if SOA passives should be present
-    if world.options.spear_of_adun_autonomously_cast_ability_presence != SpearOfAdunAutonomouslyCastAbilityPresence.option_not_present:
+    if world.options.spear_of_adun_passive_ability_presence != SpearOfAdunPassiveAbilityPresence.option_not_present:
         soa_missions = missions
-        if not world.options.spear_of_adun_autonomously_cast_present_in_no_build:
+        if not world.options.spear_of_adun_passive_present_in_no_build:
             soa_missions = [m for m in soa_missions if MissionFlag.NoBuild not in m.flags]
-        if world.options.spear_of_adun_autonomously_cast_ability_presence == SpearOfAdunAutonomouslyCastAbilityPresence.option_lotv_protoss:
+        if world.options.spear_of_adun_passive_ability_presence == SpearOfAdunPassiveAbilityPresence.option_lotv_protoss:
             soa_missions = [m for m in soa_missions if m.campaign == SC2Campaign.LOTV]
-        if world.options.spear_of_adun_autonomously_cast_ability_presence in [SpearOfAdunAutonomouslyCastAbilityPresence.option_protoss, SpearOfAdunAutonomouslyCastAbilityPresence.option_lotv_protoss]:
+        if world.options.spear_of_adun_passive_ability_presence in [SpearOfAdunPassiveAbilityPresence.option_protoss, SpearOfAdunPassiveAbilityPresence.option_lotv_protoss]:
             soa_missions = [m for m in soa_missions if MissionFlag.Protoss in m.flags]
         
         soa_passive_presence = len(soa_missions) > 0

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2273,6 +2273,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 and logic.terran_competent_comp(state)
                 and logic.terran_base_trasher(state)
             ),
+            flags=LocationFlag.BASEBUST,
         ),
         make_location_data(SC2Mission.ENEMY_INTELLIGENCE.mission_name, "Victory", SC2NCO_LOC_ID_OFFSET + 300, LocationType.VICTORY,
             logic.enemy_intelligence_third_stage_requirement,

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -773,6 +773,7 @@ class SpearOfAdunMaxActiveAbilities(Range):
 
     Note: Warp in Reinforcements is treated as a second level of Warp in Pylon
     """
+    display_name = "Spear of Adun Maximum Active Abilities"
     range_start = 0
     range_end = sum([item.quantity for item_name, item in item_tables.get_full_item_list().items() if item_name in item_tables.spear_of_adun_calldowns])
     default = range_end
@@ -783,6 +784,7 @@ class SpearOfAdunMaxAutocastAbilities(Range):
     Determines the maximum number of Spear of Adun autonomously cast abilities that can be present in the game
     Additional abilities may spawn if those are required to beat the game.
     """
+    display_name = "Spear of Adun Maximum Passive Abilities"
     range_start = 0
     range_end = sum(item.quantity for item_name, item in item_tables.get_full_item_list().items() if item_name in item_tables.spear_of_adun_castable_passives)
     default = range_end
@@ -831,21 +833,24 @@ class NovaMaxWeapons(Range):
 
     Note: Nova can swap between unlocked weapons anytime during the gameplay.
     """
+    display_name = "Nova Maximum Weapons"
     range_start = 0
     range_end = len(nova_weapons)
     default = range_end
 
 
-class NovaMaxGadgets(Range):
+class NovaMaxAbilities(Range):
     """
-    Determines maximum number of Nova gadgets that can be present in the game
-    Additional gadgets may spawn if those are required to beat the game.
+    Determines maximum number of Nova non-weapon abilities that can be present in the game
+    Additional abilities may spawn if those are required to beat the game.
 
-    Note: Nova can use any unlocked gadget anytime during the gameplay.
+    Note: Nova can use any unlocked ability anytime during gameplay.
     """
+    display_name = "Nova Maximum Abilities"
     range_start = 0
     range_end = len(nova_gadgets)
     default = range_end
+
 
 class NovaGhostOfAChanceVariant(Choice):
     """
@@ -1246,12 +1251,14 @@ class LowestMaximumSupply(Range):
 
 class ResearchCostReductionPerItem(Range):
     """
-    Controls how much weapon/armor research cost is cut per item.
+    Controls how much weapon/armor research cost is cut per research cost filler item.
     Affects both minerals and vespene.
     """
+    display_name = "Upgrade Cost Discount Per Item"
     range_start = 0
     range_end = 10
     default = 2
+
 
 class FillerRatio(Option[Dict[str, int]], VerifyKeys, Mapping[str, int]):
     """
@@ -1397,7 +1404,7 @@ class Starcraft2Options(PerGameCommonOptions):
     grant_story_tech: GrantStoryTech
     grant_story_levels: GrantStoryLevels
     nova_max_weapons: NovaMaxWeapons
-    nova_max_gadgets: NovaMaxGadgets
+    nova_max_abilities: NovaMaxAbilities
     nova_ghost_of_a_chance_variant: NovaGhostOfAChanceVariant
     take_over_ai_allies: TakeOverAIAllies
     locked_items: LockedItems
@@ -1487,7 +1494,7 @@ option_groups = [
     ]),
     OptionGroup("Nova", [
         NovaMaxWeapons,
-        NovaMaxGadgets,
+        NovaMaxAbilities,
         NovaGhostOfAChanceVariant,
     ]),
     OptionGroup("Race Specific Options", [

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -784,6 +784,7 @@ class SpearOfAdunMaxAutocastAbilities(Range):
     """
     Determines the maximum number of Spear of Adun passive abilities that can be present in the game
     Additional abilities may spawn if those are required to beat the game.
+    Does not affect building abilities like Orbital Assimilators or Warp Harmonization.
     """
     display_name = "Spear of Adun Maximum Passive Abilities"
     range_start = 0

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -1432,7 +1432,6 @@ option_groups = [
     OptionGroup("Difficulty Settings", [
         GameDifficulty,
         GameSpeed,
-        # VanillaItemsOnly,
         StarterUnit,
         RequiredTactics,
         NerfUnitBaselines,
@@ -1463,6 +1462,7 @@ option_groups = [
         GenericUpgradeResearch,
         GenericUpgradeResearchSpeedup,
         GenericUpgradeItems,
+        # VanillaItemsOnly,
     ]),
     OptionGroup("Kerrigan", [
         KerriganPresence,
@@ -1512,6 +1512,7 @@ option_groups = [
         MaximumSupplyPerItem,
         MaximumSupplyReductionPerItem,
         LowestMaximumSupply,
+        ResearchCostReductionPerItem,
         FillerRatio,
     ]),
     OptionGroup("Inclusions & Exclusions", [
@@ -1521,6 +1522,7 @@ option_groups = [
         ExcludedMissions,
     ]),
     OptionGroup("Advanced Gameplay", [
+        MissionOrderScouting,
         DifficultyDamageModifier,
         TakeOverAIAllies,
         EnableVoidTrade,

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -730,17 +730,18 @@ class SpearOfAdunPresentInNoBuild(Toggle):
     display_name = "Spear of Adun Present in No-Build"
 
 
-class SpearOfAdunAutonomouslyCastAbilityPresence(Choice):
+class SpearOfAdunPassiveAbilityPresence(Choice):
     """
-    Determines availability of Spear of Adun powers, that are autonomously cast.
-    Affects abilities like Reconstruction Beam or Overwatch
+    Determines availability of Spear of Adun passive powers.
+    Affects abilities like Reconstruction Beam or Overwatch.
+    Does not affect building abilities like Orbital Assimilators or Warp Harmonization.
 
     Not Presents: Autocasts are not available.
     LotV Protoss: Spear of Adun autocasts are only available in LotV main campaign
     Protoss: Spear of Adun autocasts are available in any Protoss mission
     Everywhere: Spear of Adun autocasts are available in any mission of any race
     """
-    display_name = "Spear of Adun Autonomously Cast Powers Presence"
+    display_name = "Spear of Adun Passive Ability Presence"
     option_not_present = 0
     option_lotv_protoss = 1
     option_protoss = 2
@@ -756,14 +757,14 @@ class SpearOfAdunAutonomouslyCastAbilityPresence(Choice):
             return super().get_option_name(value)
 
 
-class SpearOfAdunAutonomouslyCastPresentInNoBuild(Toggle):
+class SpearOfAdunPassivesPresentInNoBuild(Toggle):
     """
     Determines if Spear of Adun autocasts are available in no-build missions.
 
-    If turned on, Spear of Adun autocasts are available in missions specified under "Spear of Adun Autonomously Cast Powers Presence".
+    If turned on, Spear of Adun autocasts are available in missions specified under "Spear of Adun Passive Ability Presence".
     If turned off, Spear of Adun autocasts are unavailable in all no-build missions
     """
-    display_name = "Spear of Adun Autonomously Cast Powers Present in No-Build"
+    display_name = "Spear of Adun Passive Abilities Present in No-Build"
 
 
 class SpearOfAdunMaxActiveAbilities(Range):
@@ -781,7 +782,7 @@ class SpearOfAdunMaxActiveAbilities(Range):
 
 class SpearOfAdunMaxAutocastAbilities(Range):
     """
-    Determines the maximum number of Spear of Adun autonomously cast abilities that can be present in the game
+    Determines the maximum number of Spear of Adun passive abilities that can be present in the game
     Additional abilities may spawn if those are required to beat the game.
     """
     display_name = "Spear of Adun Maximum Passive Abilities"
@@ -1397,10 +1398,10 @@ class Starcraft2Options(PerGameCommonOptions):
     nerf_unit_baselines: NerfUnitBaselines
     spear_of_adun_presence: SpearOfAdunPresence
     spear_of_adun_present_in_no_build: SpearOfAdunPresentInNoBuild
-    spear_of_adun_autonomously_cast_ability_presence: SpearOfAdunAutonomouslyCastAbilityPresence
-    spear_of_adun_autonomously_cast_present_in_no_build: SpearOfAdunAutonomouslyCastPresentInNoBuild
+    spear_of_adun_passive_ability_presence: SpearOfAdunPassiveAbilityPresence
+    spear_of_adun_passive_present_in_no_build: SpearOfAdunPassivesPresentInNoBuild
     spear_of_adun_max_active_abilities: SpearOfAdunMaxActiveAbilities
-    spear_of_adun_max_autonomously_cast_abilities: SpearOfAdunMaxAutocastAbilities
+    spear_of_adun_max_passive_abilities: SpearOfAdunMaxAutocastAbilities
     grant_story_tech: GrantStoryTech
     grant_story_levels: GrantStoryLevels
     nova_max_weapons: NovaMaxWeapons
@@ -1487,8 +1488,8 @@ option_groups = [
     OptionGroup("Spear of Adun", [
         SpearOfAdunPresence,
         SpearOfAdunPresentInNoBuild,
-        SpearOfAdunAutonomouslyCastAbilityPresence,
-        SpearOfAdunAutonomouslyCastPresentInNoBuild,
+        SpearOfAdunPassiveAbilityPresence,
+        SpearOfAdunPassivesPresentInNoBuild,
         SpearOfAdunMaxActiveAbilities,
         SpearOfAdunMaxAutocastAbilities,
     ]),

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -840,14 +840,15 @@ class NovaMaxWeapons(Range):
     default = range_end
 
 
-class NovaMaxAbilities(Range):
+class NovaMaxGadgets(Range):
     """
-    Determines maximum number of Nova non-weapon abilities that can be present in the game
-    Additional abilities may spawn if those are required to beat the game.
+    Determines maximum number of Nova gadgets that can be present in the game.
+    Gadgets are a vanilla category including 2 grenade abilities, Stim, Holo Decoy, and Ionic Force Field.
+    Additional gadgets may spawn if those are required to beat the game.
 
     Note: Nova can use any unlocked ability anytime during gameplay.
     """
-    display_name = "Nova Maximum Abilities"
+    display_name = "Nova Maximum Gadgets"
     range_start = 0
     range_end = len(nova_gadgets)
     default = range_end
@@ -1405,7 +1406,7 @@ class Starcraft2Options(PerGameCommonOptions):
     grant_story_tech: GrantStoryTech
     grant_story_levels: GrantStoryLevels
     nova_max_weapons: NovaMaxWeapons
-    nova_max_abilities: NovaMaxAbilities
+    nova_max_gadgets: NovaMaxGadgets
     nova_ghost_of_a_chance_variant: NovaGhostOfAChanceVariant
     take_over_ai_allies: TakeOverAIAllies
     locked_items: LockedItems
@@ -1495,7 +1496,7 @@ option_groups = [
     ]),
     OptionGroup("Nova", [
         NovaMaxWeapons,
-        NovaMaxAbilities,
+        NovaMaxGadgets,
         NovaGhostOfAChanceVariant,
     ]),
     OptionGroup("Race Specific Options", [

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -282,7 +282,7 @@ class ValidInventory:
 
         nova_gadget_items = [item for item in inventory if item.name in item_groups.nova_gadgets]
         self.world.random.shuffle(nova_gadget_items)
-        cull_items_over_maximum(nova_gadget_items, self.world.options.nova_max_gadgets.value)
+        cull_items_over_maximum(nova_gadget_items, self.world.options.nova_max_abilities.value)
 
         # Determining if the full-size inventory can complete campaign
         # Note(mm): Now that user excludes are checked against logic, this can probably never fail unless there's a bug.

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -273,7 +273,7 @@ class ValidInventory:
 
         spear_of_adun_autocasts = [item for item in inventory if item.name in spear_of_adun_castable_passives]
         self.world.random.shuffle(spear_of_adun_autocasts)
-        cull_items_over_maximum(spear_of_adun_autocasts, self.world.options.spear_of_adun_max_autonomously_cast_abilities.value)
+        cull_items_over_maximum(spear_of_adun_autocasts, self.world.options.spear_of_adun_max_passive_abilities.value)
 
         # Nova items
         nova_weapon_items = [item for item in inventory if item.name in item_groups.nova_weapons]

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -282,7 +282,7 @@ class ValidInventory:
 
         nova_gadget_items = [item for item in inventory if item.name in item_groups.nova_gadgets]
         self.world.random.shuffle(nova_gadget_items)
-        cull_items_over_maximum(nova_gadget_items, self.world.options.nova_max_abilities.value)
+        cull_items_over_maximum(nova_gadget_items, self.world.options.nova_max_gadgets.value)
 
         # Determining if the full-size inventory can complete campaign
         # Note(mm): Now that user excludes are checked against logic, this can probably never fail unless there's a bug.

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -1030,7 +1030,8 @@ class SC2Logic:
                 state.has(item_names.INFESTED_SIEGE_TANK, self.player)
                 and (
                         state.has_all({item_names.INFESTOR, item_names.INFESTOR_INFESTED_TERRAN}, self.player)
-                        or state.has_any((item_names.INFESTED_BUNKER, item_names.INFESTED_MARINE), self.player)
+                        or state.has(item_names.INFESTED_BUNKER, self.player)
+                        or (self.advanced_tactics and state.has(item_names.INFESTED_MARINE, self.player))
                         or state.count(item_names.INFESTED_SIEGE_TANK_PROGRESSIVE_AUTOMATED_MITOSIS, self.player) >= (1 if self.advanced_tactics else 2)
                 )
         )

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Set, Optional, Callable, Dict, Tuple
 from BaseClasses import CollectionState, Location
 from .options import (
     get_option_value, RequiredTactics, kerrigan_unit_available, AllInMap,
-    GrantStoryTech, GrantStoryLevels, SpearOfAdunAutonomouslyCastAbilityPresence,
+    GrantStoryTech, GrantStoryLevels, SpearOfAdunPassiveAbilityPresence,
     SpearOfAdunPresence, MissionOrder, EnableMorphling,
     get_enabled_campaigns, get_enabled_races,
 )
@@ -42,7 +42,7 @@ class SC2Logic:
         self.basic_zerg_units = get_basic_units(self.logic_level, SC2Race.ZERG)
         self.basic_protoss_units = get_basic_units(self.logic_level, SC2Race.PROTOSS)
         self.spear_of_adun_presence = SpearOfAdunPresence.default if world is None else world.options.spear_of_adun_presence.value
-        self.spear_of_adun_autonomously_cast_presence = get_option_value(world, "spear_of_adun_autonomously_cast_ability_presence")
+        self.spear_of_adun_passive_presence = get_option_value(world, "spear_of_adun_passive_ability_presence")
         self.enabled_campaigns = get_enabled_campaigns(world)
         self.mission_order = get_option_value(world, "mission_order")
         self.generic_upgrade_missions = get_option_value(world, "generic_upgrade_missions")
@@ -2271,7 +2271,7 @@ class SC2Logic:
                             or self.protoss_fleet(state)
                         )
                         and (self.terran_sustainable_mech_heal(state)
-                            or (self.spear_of_adun_autonomously_cast_presence == SpearOfAdunAutonomouslyCastAbilityPresence.option_everywhere
+                            or (self.spear_of_adun_passive_presence == SpearOfAdunPassiveAbilityPresence.option_everywhere
                                  and state.has(item_names.RECONSTRUCTION_BEAM, self.player)
                             )
                         )

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -1030,7 +1030,7 @@ class SC2Logic:
                 state.has(item_names.INFESTED_SIEGE_TANK, self.player)
                 and (
                         state.has_all({item_names.INFESTOR, item_names.INFESTOR_INFESTED_TERRAN}, self.player)
-                        or state.has(item_names.INFESTED_BUNKER, self.player)
+                        or state.has_any((item_names.INFESTED_BUNKER, item_names.INFESTED_MARINE), self.player)
                         or state.count(item_names.INFESTED_SIEGE_TANK_PROGRESSIVE_AUTOMATED_MITOSIS, self.player) >= (1 if self.advanced_tactics else 2)
                 )
         )

--- a/worlds/sc2/test/test_rules.py
+++ b/worlds/sc2/test/test_rules.py
@@ -108,14 +108,14 @@ class TestRules(unittest.TestCase):
         take_over_ai_allies: int = options.TakeOverAIAllies.default,
         kerrigan_presence: int = options.KerriganPresence.default,
         # setting this to everywhere catches one extra logic check for Amon's Fall without missing any
-        spear_of_adun_passive_presence: int = options.SpearOfAdunAutonomouslyCastAbilityPresence.option_everywhere,
+        spear_of_adun_passive_presence: int = options.SpearOfAdunPassiveAbilityPresence.option_everywhere,
     ) -> TestWorld:
         test_world = TestWorld()
         test_world.options.required_tactics.value = required_tactics
         test_world.options.all_in_map.value = all_in_map
         test_world.options.take_over_ai_allies.value = take_over_ai_allies
         test_world.options.kerrigan_presence.value = kerrigan_presence
-        test_world.options.spear_of_adun_autonomously_cast_ability_presence.value = spear_of_adun_passive_presence
+        test_world.options.spear_of_adun_passive_ability_presence.value = spear_of_adun_passive_presence
         test_world.logic = SC2Logic(test_world)  # type: ignore
         return test_world
 

--- a/worlds/sc2/test/test_usecases.py
+++ b/worlds/sc2/test/test_usecases.py
@@ -424,7 +424,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
         self.assertLessEqual(len(nova_weapons), target_number)
 
 
-    def test_nova_max_gadgets(self):
+    def test_nova_max_abilities(self):
         target_number: int = 3
         world_options = {
             'mission_order': options.MissionOrder.option_grid,
@@ -433,7 +433,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
                 SC2Race.TERRAN.get_title(),
             },
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
-            'nova_max_gadgets': target_number,
+            'nova_max_abilities': target_number,
         }
 
         self.generate_world(world_options)

--- a/worlds/sc2/test/test_usecases.py
+++ b/worlds/sc2/test/test_usecases.py
@@ -424,7 +424,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
         self.assertLessEqual(len(nova_weapons), target_number)
 
 
-    def test_nova_max_abilities(self):
+    def test_nova_max_gadgets(self):
         target_number: int = 3
         world_options = {
             'mission_order': options.MissionOrder.option_grid,
@@ -433,7 +433,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
                 SC2Race.TERRAN.get_title(),
             },
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
-            'nova_max_abilities': target_number,
+            'nova_max_gadgets': target_number,
         }
 
         self.generate_world(world_options)

--- a/worlds/sc2/test/test_usecases.py
+++ b/worlds/sc2/test/test_usecases.py
@@ -395,7 +395,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
                 SC2Race.PROTOSS.get_title(),
             },
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
-            'spear_of_adun_max_autonomously_cast_abilities': target_number,
+            'spear_of_adun_max_passive_abilities': target_number,
         }
 
         self.generate_world(world_options)


### PR DESCRIPTION
## What is this fixing or adding?
* Fixing mission order scouting and research cost reduction per item options not in any groups
  * Mission Order Scouting is now in advanced options, Research Cost Reduction Per Item is now in filler options
* adding infested marines to infested siege tank ammo logic
* Adding display names for Nova and SOA max abilities options
  * Updated "Nova Gadgets" to "Nova Abilities", as I have no idea what a gadget is at a glance and I had to check the code. It's ambiguous whether it includes things like suits/passive buffs
* Updating SOA "autonomously cast" option names to "passive" (I still have no idea what "autonomously cast" is supposed to mean)
  * Included backwards compat for loading options from slot data of version < 4
* Adding missing basebust flag to Sudden Strike zerg base location

## How was this tested?
Ran webhost and checked options page. Ran unit tests.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/2d1d2310-63e0-4494-aa59-ae65aa83a04d)
![image](https://github.com/user-attachments/assets/f902690f-058c-452a-9fba-ee803caf9ef1)
![image](https://github.com/user-attachments/assets/5c77ceea-3c29-4310-a440-3102525c3b07)
![image](https://github.com/user-attachments/assets/e3642a91-85cd-467a-a51c-bebf70197344)
