### PR TITLE
Connecting new ability for Spore Crawler to AP Client.

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -697,6 +697,7 @@ item_descriptions = {
     item_names.BROOD_LORD_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(DISPLAY_NAME_BROOD_LORD),
     item_names.INFESTOR_INFESTED_TERRAN: _ability_desc("Infestors", "Spawn Infested Terran"),
     item_names.INFESTOR_MICROBIAL_SHROUD: _ability_desc("Infestors", "Microbial Shroud", "reduces incoming damage from air units in an area"),
+    item_names.SPORE_CRAWLER_BIO_BONUS: "Spore Crawler +30 bonus damage against biological units.",
     item_names.SWARM_QUEEN_SPAWN_LARVAE: _ability_desc("Swarm Queens", "Spawn Larvae"),
     item_names.SWARM_QUEEN_DEEP_TUNNEL: _ability_desc("Swarm Queens", "Deep Tunnel"),
     item_names.SWARM_QUEEN_ORGANIC_CARAPACE: "Swarm Queens gain +25 life.",

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -437,6 +437,7 @@ MUTALISK_RAPID_REGENERATION                       = "Rapid Regeneration (Mutalis
 MUTALISK_SUNDERING_GLAIVE                         = "Sundering Glaive (Mutalisk)"
 MUTALISK_SEVERING_GLAIVE                          = "Severing Glaive (Mutalisk)"
 MUTALISK_AERODYNAMIC_GLAIVE_SHAPE                 = "Aerodynamic Glaive Shape (Mutalisk)"
+SPORE_CRAWLER_BIO_BONUS                           = "Bio Bonus (Spore Crawler)"
 SWARM_HOST_BURROW                                 = "Burrow (Swarm Host)"
 SWARM_HOST_RAPID_INCUBATION                       = "Rapid Incubation (Swarm Host)"
 SWARM_HOST_PRESSURIZED_GLANDS                     = "Pressurized Glands (Swarm Host)"

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1609,6 +1609,8 @@ item_table = {
         ItemData(389 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 16, SC2Race.ZERG, parent=item_names.BULLFROG),
     item_names.BULLFROG_RANGE:
         ItemData(390 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 17, SC2Race.ZERG, parent=item_names.BULLFROG),
+    item_names.SPORE_CRAWLER_BIO_BONUS: 
+        ItemData(391 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 18, SC2Race.ZERG, parent=item_names.SPORE_CRAWLER),
 
     item_names.KERRIGAN_KINETIC_BLAST: ItemData(400 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 0, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.KERRIGAN_HEROIC_FORTITUDE: ItemData(401 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 1, SC2Race.ZERG, classification=ItemClassification.progression),


### PR DESCRIPTION
This PR connects the new items SPORE_CRAWLER_BIO_BONUS to the archipelago client. Implementation was tested locally and deemed successful.

See also https://github.com/Ziktofel/Archipelago-SC2-data/pull/403.