### PR TITLE
sc2: Switching standard difficulty curve to fill out->in difficulty-wise

### DIFF
--- a/worlds/sc2/mission_order/generation.py
+++ b/worlds/sc2/mission_order/generation.py
@@ -320,7 +320,8 @@ def fill_missions(
     for difficulty in sorted(mission_order.sorted_missions.keys()):
         world.random.shuffle(mission_order.sorted_missions[difficulty])
         sorted_goals.extend(mission for mission in mission_order.sorted_missions[difficulty] if mission in mission_order.goal_missions)
-    # Sort standard slot difficulties from highest to lowest when using hard bias
+    # Sort slots by difficulty, with difficulties sorted by fill order
+    # standard curve/close difficulty fills difficulties out->in, uneven fills easy->hard
     if prefer_close_difficulty:
         all_slots = [slot for diff in STANDARD_DIFFICULTY_FILL_ORDER for slot in mission_order.sorted_missions[diff]]
     else:

--- a/worlds/sc2/mission_order/mission_pools.py
+++ b/worlds/sc2/mission_order/mission_pools.py
@@ -18,12 +18,22 @@ class Difficulty(IntEnum):
 # TODO figure out an organic way to get these
 DEFAULT_DIFFICULTY_THRESHOLDS = {
     Difficulty.STARTER: 0,
-    Difficulty.EASY: 5,
+    Difficulty.EASY: 10,
     Difficulty.MEDIUM: 35,
     Difficulty.HARD: 65,
-    Difficulty.VERY_HARD: 95,
+    Difficulty.VERY_HARD: 90,
     Difficulty.VERY_HARD + 1: 100
 }
+
+STANDARD_DIFFICULTY_FILL_ORDER = (
+    Difficulty.VERY_HARD,
+    Difficulty.STARTER,
+    Difficulty.HARD,
+    Difficulty.EASY,
+    Difficulty.MEDIUM,
+)
+"""Fill mission slots outer->inner difficulties,
+so if multiple pools get exhausted, they will tend to overflow towards the middle."""
 
 def modified_difficulty_thresholds(min_difficulty: Difficulty, max_difficulty: Difficulty) -> Dict[int, Difficulty]:
     if min_difficulty == Difficulty.RELATIVE:


### PR DESCRIPTION
## What is this fixing or adding?
Trying to prevent very hard missions carrying on to the starter slots.

See [PsiGuy's bug report](https://discord.com/channels/731205301247803413/1154164338769268859/1354893133887967232)

## How was this tested?
Used [PsiGuy's yaml](https://discord.com/channels/731205301247803413/1154164338769268859/1354900975462256640) and made sure very hard missions didn't generate early.

Got layouts more like this:
![image](https://github.com/user-attachments/assets/0d9b1352-a2ca-4de4-b791-4da5055865b8)

## If this makes graphical changes, please attach screenshots.
None