### PR TITLE
Added several logic updates

### DIFF
--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -4335,13 +4335,11 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                            lambda state: (
                                    logic.terran_common_unit(state)
                                    and logic.terran_basic_anti_air(state))
-                                   or adv_tactics
                            ),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_T.mission_name, "Southwest Psi-link Spire", SC2_RACESWAP_LOC_ID_OFFSET + 6507, LocationType.EXTRA,
                            lambda state: (
                                    logic.terran_common_unit(state)
                                    and logic.terran_competent_anti_air(state))
-                                   or adv_tactics
                            ),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_T.mission_name, "Nafash", SC2_RACESWAP_LOC_ID_OFFSET + 6508, LocationType.EXTRA,
                            lambda state: (
@@ -4373,13 +4371,11 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                            lambda state: (
                                    logic.protoss_common_unit(state)
                                    and logic.protoss_basic_anti_air(state))
-                                   or adv_tactics
                            ),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_P.mission_name, "Southwest Psi-link Spire", SC2_RACESWAP_LOC_ID_OFFSET + 6607, LocationType.EXTRA,
                            lambda state: (
                                    logic.protoss_common_unit(state)
                                    and logic.protoss_anti_armor_anti_air(state))
-                                   or adv_tactics
                            ),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_P.mission_name, "Nafash", SC2_RACESWAP_LOC_ID_OFFSET + 6608, LocationType.EXTRA,
                            lambda state: (

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2919,14 +2919,14 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.HAVENS_FALL_Z.mission_name, "East Gas Pickups", SC2_RACESWAP_LOC_ID_OFFSET + 1310, LocationType.EXTRA,
             lambda state: (
                 logic.zerg_common_unit(state)
-                and state.has(item_names.OVERLORD_VENTRAL_SACS, player)
+                and state.has_any({item_names.OVERLORD_VENTRAL_SACS, item_names.INFESTED_BANSHEE}), player)
                 and logic.zerg_competent_anti_air(state)
                 and logic.zerg_defense_rating(state, True) >= 3)
         ),
         make_location_data(SC2Mission.HAVENS_FALL_Z.mission_name, "Southeast Gas Pickups", SC2_RACESWAP_LOC_ID_OFFSET + 1311, LocationType.EXTRA,
             lambda state: (
                 logic.zerg_common_unit(state)
-                and state.has(item_names.OVERLORD_VENTRAL_SACS, player)
+                and state.has_any({item_names.OVERLORD_VENTRAL_SACS, item_names.INFESTED_BANSHEE}), player)
                 and logic.zerg_competent_anti_air(state)
                 and logic.zerg_defense_rating(state, True) >= 3)
         ),
@@ -4329,19 +4329,19 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                            ),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_T.mission_name, "Lost Base", SC2_RACESWAP_LOC_ID_OFFSET + 6504, LocationType.EXTRA),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_T.mission_name, "Northeast Psi-link Spire", SC2_RACESWAP_LOC_ID_OFFSET + 6505, LocationType.EXTRA,
-                           lambda state: (
-                                   logic.terran_common_unit(state)
-                                   and logic.terran_basic_anti_air(state))
+                           lambda state: logic.terran_common_unit(state) or adv_tactics
                            ),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_T.mission_name, "Northwest Psi-link Spire", SC2_RACESWAP_LOC_ID_OFFSET + 6506, LocationType.EXTRA,
                            lambda state: (
                                    logic.terran_common_unit(state)
                                    and logic.terran_basic_anti_air(state))
+                                   or adv_tactics
                            ),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_T.mission_name, "Southwest Psi-link Spire", SC2_RACESWAP_LOC_ID_OFFSET + 6507, LocationType.EXTRA,
                            lambda state: (
                                    logic.terran_common_unit(state)
                                    and logic.terran_competent_anti_air(state))
+                                   or adv_tactics
                            ),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_T.mission_name, "Nafash", SC2_RACESWAP_LOC_ID_OFFSET + 6508, LocationType.EXTRA,
                            lambda state: (
@@ -4367,17 +4367,19 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                            ),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_P.mission_name, "Lost Base", SC2_RACESWAP_LOC_ID_OFFSET + 6604, LocationType.EXTRA),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_P.mission_name, "Northeast Psi-link Spire", SC2_RACESWAP_LOC_ID_OFFSET + 6605, LocationType.EXTRA,
-                           logic.protoss_common_unit
+                           lambda state: logic.protoss_common_unit(state) or adv_tactics
                            ),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_P.mission_name, "Northwest Psi-link Spire", SC2_RACESWAP_LOC_ID_OFFSET + 6606, LocationType.EXTRA,
                            lambda state: (
                                    logic.protoss_common_unit(state)
                                    and logic.protoss_basic_anti_air(state))
+                                   or adv_tactics
                            ),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_P.mission_name, "Southwest Psi-link Spire", SC2_RACESWAP_LOC_ID_OFFSET + 6607, LocationType.EXTRA,
                            lambda state: (
                                    logic.protoss_common_unit(state)
                                    and logic.protoss_anti_armor_anti_air(state))
+                                   or adv_tactics
                            ),
         make_location_data(SC2Mission.HARVEST_OF_SCREAMS_P.mission_name, "Nafash", SC2_RACESWAP_LOC_ID_OFFSET + 6608, LocationType.EXTRA,
                            lambda state: (

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2914,7 +2914,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         ),
         make_location_data(SC2Mission.HAVENS_FALL_Z.mission_name, "Southwest Gas Pickups", SC2_RACESWAP_LOC_ID_OFFSET + 1309, LocationType.EXTRA,
             lambda state: state.has(item_names.OVERLORD_VENTRAL_SACS, player),
-            hard_rule=logic.zerg_any_gap_transport,
+            hard_rule=logic.zerg_can_collect_pickup_across_gap,
         ),
         make_location_data(SC2Mission.HAVENS_FALL_Z.mission_name, "East Gas Pickups", SC2_RACESWAP_LOC_ID_OFFSET + 1310, LocationType.EXTRA,
             lambda state: (

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2919,14 +2919,14 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.HAVENS_FALL_Z.mission_name, "East Gas Pickups", SC2_RACESWAP_LOC_ID_OFFSET + 1310, LocationType.EXTRA,
             lambda state: (
                 logic.zerg_common_unit(state)
-                and state.has_any({item_names.OVERLORD_VENTRAL_SACS, item_names.INFESTED_BANSHEE}), player)
+                and state.has_any({item_names.OVERLORD_VENTRAL_SACS, item_names.INFESTED_BANSHEE}, player)
                 and logic.zerg_competent_anti_air(state)
                 and logic.zerg_defense_rating(state, True) >= 3)
         ),
         make_location_data(SC2Mission.HAVENS_FALL_Z.mission_name, "Southeast Gas Pickups", SC2_RACESWAP_LOC_ID_OFFSET + 1311, LocationType.EXTRA,
             lambda state: (
                 logic.zerg_common_unit(state)
-                and state.has_any({item_names.OVERLORD_VENTRAL_SACS, item_names.INFESTED_BANSHEE}), player)
+                and state.has_any({item_names.OVERLORD_VENTRAL_SACS, item_names.INFESTED_BANSHEE}, player)
                 and logic.zerg_competent_anti_air(state)
                 and logic.zerg_defense_rating(state, True) >= 3)
         ),

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -933,8 +933,8 @@ class SC2Logic:
             self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_ZERG_FLYER_CARAPACE, state),
         )
     
-    def zerg_any_gap_transport(self, state: CollectionState) -> bool:
-        """Any way for zerg to get any ground unit across gaps longer than viper yoink range."""
+    def zerg_can_collect_pickup_across_gap(self, state: CollectionState) -> bool:
+        """Any way for zerg to get any ground unit across gaps longer than viper yoink range to collect a pickup."""
         return (
             state.has_any((
                 item_names.NYDUS_WORM,

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -941,6 +941,7 @@ class SC2Logic:
                 item_names.ECHIDNA_WORM,
                 item_names.OVERLORD_VENTRAL_SACS,
                 item_names.YGGDRASIL,
+                item_names.INFESTED_BANSHEE,
             ), self.player)
             or (self.morph_ravager(state) and state.has(item_names.RAVAGER_DEEP_TUNNEL, self.player))
             or state.has_all((
@@ -1838,6 +1839,7 @@ class SC2Logic:
                 self.morph_impaler(state)
                 or state.has_all({item_names.INFESTED_LIBERATOR, item_names.INFESTED_LIBERATOR_DEFENDER_MODE}, self.player)
                 or self.zerg_infested_tank_with_ammo(state)
+                or state.has(item_names.BILE_LAUNCHER, self.player)
             )
             and (
                 self.morph_devourer(state)


### PR DESCRIPTION
This PR proposes several logic updates.

* Harvest of Screams: Logic for Northeast Psi Link is inconsistent across races. Terran has an extra requirement for basic_anti_air. Furthermore, each individual Psi Link could be done with starting units (at least for Zerg), suggestive of adv_tactics. This PR removes the extra Terran requirement and adds an option for adv_tactics for all Psi Links (Zerg).

* Last Stand Zerg: There's a requirement in the logic for some kind of long-range defense units -- Currently Impaler, Liberator (defense mode), Infested tanks. Bile Launchers shine in this scenario under the same circumstances. This PR adds them to the logic.

* Haven's Fall Zerg: Infested Banshees can also hit the gas pickup locations. They are added as an alternative to transport overlords, and into the hard logic. The rule name has been adjusted to reflect the very specific purpose.