### PR TITLE
Fix canvas not auto-determining size

### DIFF
--- a/worlds/sc2/mission_order/layout_types.py
+++ b/worlds/sc2/mission_order/layout_types.py
@@ -304,7 +304,7 @@ class Canvas(Grid):
         missions[-1].option_exit = False
 
         # Canvas spaces become empty slots
-        for idx in self.groups[" "]:
+        for idx in self.groups.get(" ", []):
             missions[idx].option_empty = True
 
         # Raycast into jump directions to find nearest empty space

--- a/worlds/sc2/mission_order/options.py
+++ b/worlds/sc2/mission_order/options.py
@@ -15,9 +15,9 @@ from ..mission_tables import lookup_name_to_mission
 from ..mission_groups import mission_groups
 from ..item.item_tables import item_table
 from ..item.item_groups import item_name_groups
-from .layout_types import LayoutType
+from . import layout_types
+from .layout_types import LayoutType, Column, Grid, Hopscotch, Gauntlet, Blitz, Canvas
 from .mission_pools import Difficulty
-from .layout_types import Column, Grid, Hopscotch, Gauntlet, Blitz, Canvas
 from .presets_static import (
     static_preset, preset_mini_wol_with_prophecy, preset_mini_wol, preset_mini_hots, preset_mini_prophecy,
     preset_mini_lotv_prologue, preset_mini_lotv, preset_mini_lotv_epilogue, preset_mini_nco,
@@ -25,7 +25,6 @@ from .presets_static import (
     preset_lotv_epilogue, preset_lotv, preset_nco
 )
 from .presets_scripted import make_golden_path
-from ...alttp import difficulties
 
 GENERIC_KEY_NAME = "Key".casefold()
 GENERIC_PROGRESSIVE_KEY_NAME = "Progressive Key".casefold()
@@ -143,7 +142,7 @@ class CustomMissionOrder(OptionDict):
                 "display_name": [str],
                 "unique_name": bool,
                 # Type options
-                "type": lambda val: issubclass(globals()[val], LayoutType),
+                "type": lambda val: issubclass(getattr(layout_types, val), LayoutType),
                 "size": IntOne,
                 # Link options
                 "exit": bool,
@@ -272,7 +271,7 @@ def _resolve_special_options(data: Dict[str, Any]):
         data[option] = new_value
 
     # Special case for canvas layouts determining their own size
-    if "type" in data and data["type"] == Canvas:
+    if "type" in data and data["type"] == Canvas.__name__:
         canvas: List[str] = data["canvas"]
         longest_line = max(len(line) for line in canvas)
         data["size"] = len(canvas) * longest_line


### PR DESCRIPTION
## What is this fixing or adding?
[This commit from yesterday](https://github.com/Ziktofel/Archipelago/commit/18a828585b5835bcaa7f9f6b908aeb7d94af90cb) overlooked an instance of special-casing for the Canvas layout type in the option parser, which meant canvases had to specify a `size` or `width` option. This PR fixes the issue so canvas size and width are once again parsed from the canvas itself.

This also fixes an issue where canvas layouts wouldn't generate if they contained no spaces. The documentation makes no note of this requirement, so I see no reason to enforce it.

Lastly, this changes a value lookup in `globals()` to a more restrictive one, because I don't know what kind of assertions we can make about the state of globals during YAML parsing.

## How was this tested?
I generated a YAML with a 6-mission canvas and relative/hard/medium max difficulties. I ran into some generation failures due to unreachable locations causing unbeatable games (which might be fine given it's only 6 missions?), but the canvas parsing succeeded.

I also tested a local webhost generation with an 11-mission grid and succeeded without errors as far as I could tell. I successfully connected via game client as well.