### PR TITLE
Make Hopscotch spacer configurable

### DIFF
--- a/worlds/sc2/docs/custom_mission_orders_en.md
+++ b/worlds/sc2/docs/custom_mission_orders_en.md
@@ -1002,16 +1002,17 @@ Canvas supports all of [Grid's index functions](#grid-index-functions), as well 
 ```yaml
 type: hopscotch
 width: 7 # Accepts numbers >= 4
+spacer: 2 # Accepts numbers >= 1
 two_start_positions: false # Accepts true/false
 ```
 
 This order alternates between one and two missions becoming available at a time.
 
-`width` determines how many mini columns are allowed to be next to one another before they wrap around the sides.
+`width` determines how many mini columns are allowed to be next to one another before they wrap around the sides. `spacer` determines the amount of empty slots between diagonals in the client.
 
 If `two_start_positions`, the top left corner will be set to `empty: true`, and its two neighbors will be entrances instead.
 
-A `size: 23`, `width: 4` Hopscotch layout has the following indices:
+A `size: 23`, `width: 4`, `spacer: 1` Hopscotch layout has the following indices:
 ```yaml
  0  2
  1  3  5

--- a/worlds/sc2/mission_order/layout_types.py
+++ b/worlds/sc2/mission_order/layout_types.py
@@ -389,6 +389,7 @@ class Hopscotch(LayoutType):
     """Alternating between one and two available missions.
     Default entrance is index 0 in the top left, default exit is index `size - 1` in the bottom right."""
     width: int
+    spacer: int
     two_start_positions: bool
 
     index_functions = [
@@ -406,6 +407,8 @@ class Hopscotch(LayoutType):
             self.size += 1
         width: int = options.pop("width", 7)
         self.width = max(width, 4)
+        spacer: int = options.pop("spacer", 2)
+        self.spacer = max(spacer, 1)
         return options
 
     def make_slots(self, mission_factory: Callable[[], SC2MOGenMission]) -> List[SC2MOGenMission]:
@@ -445,7 +448,6 @@ class Hopscotch(LayoutType):
             return []
 
     def get_visual_layout(self) -> List[List[int]]:
-        spacer = self.width - 3
         # size offset by 1 to account for first column of two slots
         cols: List[List[int]] = []
         col: List[int] = []
@@ -464,7 +466,7 @@ class Hopscotch(LayoutType):
         final_cols: List[List[int]] = [Hopscotch.space_at_column(idx) for idx in range(min(len(cols), self.width))]
         for (col_idx, col) in enumerate(cols):
             if col_idx >= self.width:
-                final_cols[col_idx % self.width].extend([-1 for _ in range(spacer)])
+                final_cols[col_idx % self.width].extend([-1 for _ in range(self.spacer)])
             final_cols[col_idx % self.width].extend(col)
         
         fill_to_longest(final_cols)


### PR DESCRIPTION
## What is this fixing or adding?
This changes the default spacing between diagonals in Hopscotch layouts to be constant 2 instead of width-dependent, and also makes `spacer` an attribute in custom mission orders.

## How was this tested?
I generated a `mission_order: hopscotch` to check the defaults, and a custom mission order with changed values to make sure the attribute works.

## If this makes graphical changes, please attach screenshots.
`mission_order: hopscotch`
![python_7zQJVevkV9](https://github.com/user-attachments/assets/2682a1e5-326c-4e8c-985f-a2bedd7a957a)

Custom Hopscotch layout with `width: 9` and `spacer: 4`
![python_Glsz40R5u1](https://github.com/user-attachments/assets/017d3796-0049-4cf8-8e2c-f7cc4be7249a)
