### PR TITLE
Fix starting missions not respecting Item rules

### DIFF
--- a/worlds/sc2/mission_order/generation.py
+++ b/worlds/sc2/mission_order/generation.py
@@ -143,13 +143,13 @@ def fill_depths(mission_order: SC2MOGenMissionOrder) -> None:
     Flood-fills the mission order by following its entry rules to determine the depth of all nodes.
     This also ensures theoretical total accessibility of all nodes, but this is allowed to be violated by item placement and the accessibility setting.
     """
-    accessible_campaigns: Set[SC2MOGenCampaign] = {campaign for campaign in mission_order.campaigns if campaign.is_always_unlocked()}
+    accessible_campaigns: Set[SC2MOGenCampaign] = {campaign for campaign in mission_order.campaigns if campaign.is_always_unlocked(in_region_creation=True)}
     next_campaigns: Set[SC2MOGenCampaign] = set(mission_order.campaigns).difference(accessible_campaigns)
 
     accessible_layouts: Set[SC2MOGenLayout] = {
         layout
         for campaign in accessible_campaigns for layout in campaign.layouts
-        if layout.is_always_unlocked()
+        if layout.is_always_unlocked(in_region_creation=True)
     }
     next_layouts: Set[SC2MOGenLayout] = {layout for campaign in accessible_campaigns for layout in campaign.layouts}.difference(accessible_layouts)
 
@@ -165,7 +165,7 @@ def fill_depths(mission_order: SC2MOGenMissionOrder) -> None:
         # Check for accessible missions
         cur_missions: Set[SC2MOGenMission] = {
             mission for mission in next_missions
-            if mission.is_unlocked(beaten_missions)
+            if mission.is_unlocked(beaten_missions, in_region_creation=True)
         }
         if len(cur_missions) == 0:
             raise Exception(f"Mission order ran out of accessible missions during iteration {iterations}")
@@ -193,7 +193,7 @@ def fill_depths(mission_order: SC2MOGenMissionOrder) -> None:
         # Check for newly accessible campaigns & layouts
         new_campaigns: Set[SC2MOGenCampaign] = set()
         for campaign in next_campaigns:
-            if campaign.is_unlocked(beaten_missions):
+            if campaign.is_unlocked(beaten_missions, in_region_creation=True):
                 new_campaigns.add(campaign)
         for campaign in new_campaigns:
             accessible_campaigns.add(campaign)
@@ -203,7 +203,7 @@ def fill_depths(mission_order: SC2MOGenMissionOrder) -> None:
                 layout.entry_rule.min_depth = campaign.entry_rule.get_depth(beaten_missions)
         new_layouts: Set[SC2MOGenLayout] = set()
         for layout in next_layouts:
-            if layout.is_unlocked(beaten_missions):
+            if layout.is_unlocked(beaten_missions, in_region_creation=True):
                 new_layouts.add(layout)
         for layout in new_layouts:
             accessible_layouts.add(layout)

--- a/worlds/sc2/mission_order/nodes.py
+++ b/worlds/sc2/mission_order/nodes.py
@@ -227,11 +227,11 @@ class SC2MOGenCampaign(MissionOrderNode):
     def is_beaten(self, beaten_missions: Set[SC2MOGenMission]) -> bool:
         return beaten_missions.issuperset(self.exits)
 
-    def is_always_unlocked(self) -> bool:
-        return self.entry_rule.is_always_fulfilled()
+    def is_always_unlocked(self, in_region_creation = False) -> bool:
+        return self.entry_rule.is_always_fulfilled(in_region_creation)
 
-    def is_unlocked(self, beaten_missions: Set[SC2MOGenMission]) -> bool:
-        return self.entry_rule.is_fulfilled(beaten_missions)
+    def is_unlocked(self, beaten_missions: Set[SC2MOGenMission], in_region_creation = False) -> bool:
+        return self.entry_rule.is_fulfilled(beaten_missions, in_region_creation)
 
     def search(self, term: str) -> Union[List[MissionOrderNode], None]:
         return [
@@ -421,11 +421,11 @@ class SC2MOGenLayout(MissionOrderNode):
     def is_beaten(self, beaten_missions: Set[SC2MOGenMission]) -> bool:
         return beaten_missions.issuperset(self.exits)
 
-    def is_always_unlocked(self) -> bool:
-        return self.entry_rule.is_always_fulfilled()
+    def is_always_unlocked(self, in_region_creation = False) -> bool:
+        return self.entry_rule.is_always_fulfilled(in_region_creation)
     
-    def is_unlocked(self, beaten_missions: Set[SC2MOGenMission]) -> bool:
-        return self.entry_rule.is_fulfilled(beaten_missions)
+    def is_unlocked(self, beaten_missions: Set[SC2MOGenMission], in_region_creation = False) -> bool:
+        return self.entry_rule.is_fulfilled(beaten_missions, in_region_creation)
 
     def resolve_index_term(self, term: Union[str, int], *, ignore_out_of_bounds: bool = True, reject_none: bool = True) -> Union[Set[int], None]:
         try:
@@ -558,11 +558,11 @@ class SC2MOGenMission(MissionOrderNode):
         self.option_mission_pool = data.get("mission_pool", self.option_mission_pool)
         self.option_victory_cache = data.get("victory_cache", -1)
     
-    def is_always_unlocked(self) -> bool:
-        return self.entry_rule.is_always_fulfilled()
+    def is_always_unlocked(self, in_region_creation = False) -> bool:
+        return self.entry_rule.is_always_fulfilled(in_region_creation)
     
-    def is_unlocked(self, beaten_missions: Set[SC2MOGenMission]) -> bool:
-        return self.entry_rule.is_fulfilled(beaten_missions)
+    def is_unlocked(self, beaten_missions: Set[SC2MOGenMission], in_region_creation = False) -> bool:
+        return self.entry_rule.is_fulfilled(beaten_missions, in_region_creation)
     
     def beat_item(self) -> str:
         return f"Beat {self.mission.mission_name}"


### PR DESCRIPTION
## What is this fixing or adding?
This changes some entry rule functions to take an argument specifying whether the calling process is part of region creation, to determine whether Item entry rules should be considered fulfilled (to not make the node a permanent blocker in the depth fill) or unfulfilled (to consider the node inaccessible for starting missions).

This fixes the reported issue that a world's starting unit can be generated based on an inaccessible (so non-starter) mission, if the only thing blocking that mission is an Item entry rule.

## How was this tested?
I generated with the YAML that caused the issue in the test async and verified via breakpoint that it only reported a single starting mission.