### PR TITLE
Change trade lock time to be based on seconds instead of milliseconds

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -94,7 +94,7 @@ TRADE_RECEIVE_5_BUTTON = "AP_TradeStructureDummyReceive5" # ID of the button
 TRADE_DATASTORAGE_TEAM = "SC2_VoidTrade_" # + Team
 TRADE_DATASTORAGE_SLOT = "slot_" # + Slot
 TRADE_DATASTORAGE_LOCK = "_lock"
-TRADE_LOCK_TIME = 5000 # Time in ms that the DataStorage may be considered safe to edit
+TRADE_LOCK_TIME = 5 # Time in seconds that the DataStorage may be considered safe to edit
 TRADE_LOCK_WAIT_LIMIT = 540000 / 1.4 # Time in ms that the client may spend trying to get a lock (540000 = 9 minutes, 1.4 is 'faster' game speed's time scale)
 
 # Games
@@ -1076,7 +1076,7 @@ class SC2Context(CommonContext):
         acquire the lock.
         """
         while not self.exit_event.is_set() and self.last_bot and self.last_bot.game_running:
-            lock = int(time.time_ns() / 1000000)
+            lock = int(time.time_ns() / 1000000000) # in seconds
 
             # Make sure we're not past the waiting limit
             # SC2 needs to be notified within 10 minutes of game time (training time of the dummy units)
@@ -1135,7 +1135,7 @@ class SC2Context(CommonContext):
                 # too new when we replaced it, we should wait for increasingly longer periods so that
                 # eventually the lock will expire and a client will acquire it.
                 self.trade_lock_wait += TRADE_LOCK_TIME
-                self.trade_lock_wait += random.randrange(100, 500)
+                self.trade_lock_wait += random.randrange(100, 500) / 1000
 
                 await asyncio.sleep(self.trade_lock_wait)
                 continue

--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -309,6 +309,8 @@ class SC2Manager(GameManager):
         COLOR_FINAL_PARENT_LOCKED = "D0C0BE" # gray + orange
         COLOR_FINAL_MISSION_REMINDER = "FF5151" # light red
         COLOR_VICTORY_LOCATION = "FFC156" # gold
+        COLOR_TOOLTIP_DONE = "00FF00" # green
+        COLOR_TOOLTIP_NOT_DONE = "FF0000" # red
 
         text = mission_obj.mission_name
         tooltip: str = ""
@@ -344,7 +346,7 @@ class SC2Manager(GameManager):
                 text = f"[color={COLOR_MISSION_LOCKED}]{text}[/color]"
                 tooltip += "To unlock this mission, "
                 shown_rule = mission_rule
-            rule_tooltip = shown_rule.tooltip(0, lookup_id_to_mission)
+            rule_tooltip = shown_rule.tooltip(0, lookup_id_to_mission, COLOR_TOOLTIP_DONE, COLOR_TOOLTIP_NOT_DONE)
             tooltip += rule_tooltip.replace(rule_tooltip[0], rule_tooltip[0].lower(), 1)
             extra_word = "are"
             if shown_rule.shows_single_rule():


### PR DESCRIPTION
## What is this fixing or adding?
This changes trade to wait for a period of fractional seconds rather than whole milliseconds in the case of concurrent access to the data storage.

The original behavior was always questionable:
- The docs for `asyncio.sleep()` suggest that its wait time is specified in seconds.
- Pokemon Emerald's Wonder Trade's comments suggest that it aims to sleep 5 seconds at a time, and does this by passing 5000 to `asyncio.sleep()`, suggesting the wait time is specified in milliseconds.

I chose previously to believe the (presumably) working algorithm rather than the documentation, but upon further examination of the Emerald client have found that in a different place, unrelated to trade, they use `asyncio.sleep(0.75)` to wait on their emulator code to handle data. It makes no sense to me to wait a fraction of a millisecond for this purpose, but this code should run much more often than Wonder Trade, so I have to assume the docs for `asyncio.sleep()` are actually correct and it's Wonder Trade's code that is wrong.

Edit: After discussing one instance of the Void Trade hanging bug with an affected user, I am inclined to believe that the above is indeed the case and this has been the issue all along. I also learned that there's a bug in my previous trade PR where the trade message is not correctly consumed if the structure ceases to exist (by dying or changing missions), which I'm leaving in for now. If this PR fixes the issue, we can fully revert the previous change.

Edit 2: Because I had some time I also threw together a concept for partially coloring entry rules based on which parts are completed. It's not perfect and the colors aren't set in stone (supposedly AP main has changed the default Kivy theme), but it was requested a couple times and I would like more concrete feedback while we have the opportunity.

## How was this tested?
I don't know how to test concurrent access on my own, so the trade change is untested.

I tested coloring by connecting to my async slot and hovering a mission with more than one entry condition:
![python_q2PwMcjUsL](https://github.com/user-attachments/assets/933c0075-0284-4be3-8711-646ef26f1ec7)
