### PR TITLE
Removed NCO no-builds from infantry upgrade orphan clause

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -618,7 +618,7 @@ def flag_mission_based_item_excludes(world: SC2World, item_list: List[FilterItem
 def flag_allowed_orphan_items(world: SC2World, item_list: List[FilterItem]) -> None:
     """Adds the `Allowed_Orphan` flag to items that shouldn't be filtered with their parents, like combat shield"""
     missions = get_all_missions(world.custom_mission_order)
-    terran_nobuild_missions = any((MissionFlag.Terran|MissionFlag.NoBuild) in mission.flags for mission in missions)
+    terran_nobuild_missions = any((MissionFlag.Terran|MissionFlag.NoBuild) in mission.flags and mission.campaign != SC2Campaign.NCO for mission in missions)
     if terran_nobuild_missions:
         for item in item_list:
             if item.name in (


### PR DESCRIPTION
## What is this fixing or adding?

Generation currently allows orphaned Marine/Medic upgrades if any Terran no-build missions are present in the seed.  This does not make sense in the context of NCO, where neither of the no-build missions have controllable Marines.  This changes the check to ignore NCO missions.

If we do race-swapped no-builds in the future, it may be feasible for missions outside of WoL (but not in NCO) to want infantry unit upgrades.

## How was this tested?

Generated once.