### PR TITLE
Fix client mission order recustion in mission accessibility evaluation

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -2002,8 +2002,6 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
     ]
 
     accessible_objects: typing.List[MissionOrderObjectSlotData] = []
-    for mission_order_object in mission_order_objects:
-        mission_order_object.entry_rule.buffer_accessible = False
 
     while len(candidate_accessible_objects) > 0:
         accessible_missions: typing.List[MissionSlotData] = [mission_order_object for mission_order_object in accessible_objects if isinstance(mission_order_object, MissionSlotData)]

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1987,9 +1987,9 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
 
     accessible_rules: typing.Set[int] = set()
     mission_order_objects: typing.List[MissionOrderObjectSlotData] = []
-    for _, campaign in enumerate(ctx.custom_mission_order):
+    for campaign in ctx.custom_mission_order:
         mission_order_objects.append(campaign)
-        for _, layout in enumerate(campaign.layouts):
+        for layout in campaign.layouts:
             mission_order_objects.append(layout)
             for column in layout.missions:
                 for mission in column:

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -2003,8 +2003,7 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
 
     accessible_objects: typing.List[MissionOrderObjectSlotData] = []
     for mission_order_object in mission_order_objects:
-        if isinstance(mission_order_object.entry_rule, SubRuleRuleData):
-            mission_order_object.entry_rule.buffer_accessible = False
+        mission_order_object.entry_rule.buffer_accessible = False
 
     while len(candidate_accessible_objects) > 0:
         accessible_missions: typing.List[MissionSlotData] = [mission_order_object for mission_order_object in accessible_objects if isinstance(mission_order_object, MissionSlotData)]

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1998,7 +1998,7 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
 
     candidate_accessible_objects: typing.List[MissionOrderObjectSlotData] = [
         mission_order_object for mission_order_object in mission_order_objects
-        if mission_order_object.entry_rule.is_accessible(beaten_missions, received_items, ctx.mission_id_to_entry_rules, set(), [], True)
+        if mission_order_object.entry_rule.is_accessible(beaten_missions, received_items, ctx.mission_id_to_entry_rules)
     ]
 
     accessible_objects: typing.List[MissionOrderObjectSlotData] = []
@@ -2011,9 +2011,9 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
         accessible_objects_to_add: typing.List[MissionOrderObjectSlotData] = []
         for mission_order_object in candidate_accessible_objects:
             if (
-                    mission_order_object.entry_rule.is_accessible(beaten_accessible_missions, received_items, ctx.mission_id_to_entry_rules, set(), [], True)
+                    mission_order_object.entry_rule.is_accessible(beaten_accessible_missions, received_items, ctx.mission_id_to_entry_rules)
                     and all([
-                        parent_object.entry_rule.is_accessible(beaten_accessible_missions, received_items, ctx.mission_id_to_entry_rules, set(), [], True)
+                        parent_object.entry_rule.is_accessible(beaten_accessible_missions, received_items, ctx.mission_id_to_entry_rules)
                         for parent_object in parent_objects[mission_order_objects.index(mission_order_object)]
                     ])
             ):

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1991,6 +1991,7 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
                     if mission.mission_id == -1:
                         continue
                     mission_order_objects.append(mission)
+
     candidate_accessible_objects: typing.List[MissionOrderObjectSlotData] = [
         mission_order_object for mission_order_object in mission_order_objects
         if mission_order_object.entry_rule.is_accessible(beaten_missions, received_items, ctx.mission_id_to_entry_rules, set(), [], True)

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1998,7 +1998,7 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
 
     candidate_accessible_objects: typing.List[MissionOrderObjectSlotData] = [
         mission_order_object for mission_order_object in mission_order_objects
-        if mission_order_object.entry_rule.is_accessible(beaten_missions, received_items, ctx.mission_id_to_entry_rules)
+        if mission_order_object.entry_rule.is_accessible(beaten_missions, received_items)
     ]
 
     accessible_objects: typing.List[MissionOrderObjectSlotData] = []
@@ -2009,9 +2009,9 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
         accessible_objects_to_add: typing.List[MissionOrderObjectSlotData] = []
         for mission_order_object in candidate_accessible_objects:
             if (
-                    mission_order_object.entry_rule.is_accessible(beaten_accessible_missions, received_items, ctx.mission_id_to_entry_rules)
+                    mission_order_object.entry_rule.is_accessible(beaten_accessible_missions, received_items)
                     and all([
-                        parent_object.entry_rule.is_accessible(beaten_accessible_missions, received_items, ctx.mission_id_to_entry_rules)
+                        parent_object.entry_rule.is_accessible(beaten_accessible_missions, received_items)
                         for parent_object in parent_objects[mission_order_objects.index(mission_order_object)]
                     ])
             ):

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1975,17 +1975,12 @@ def is_mission_available(ctx: SC2Context, mission_id_to_check: int) -> bool:
     return mission_id_to_check in available_missions
 
 def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typing.Dict[int, typing.List[int]], typing.List[int]]:
-    available_missions: typing.List[int] = []
-    available_layouts: typing.Dict[int, typing.List[int]] = {}
-    available_campaigns: typing.List[int] = []
-
     beaten_missions: typing.Set[int] = {mission_id for mission_id in ctx.mission_id_to_entry_rules if ctx.is_mission_completed(mission_id)}
     received_items: typing.Dict[int, int] = {}
     for network_item in ctx.items_received:
         received_items.setdefault(network_item.item, 0)
         received_items[network_item.item] += 1
 
-    accessible_rules: typing.Set[int] = set()
     mission_order_objects: typing.List[MissionOrderObjectSlotData] = []
     for campaign in ctx.custom_mission_order:
         mission_order_objects.append(campaign)
@@ -2021,7 +2016,7 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
         else:
             break
 
-    available_missions = [
+    available_missions: typing.List[int] = [
         mission_order_object.mission_id for mission_order_object in accessible_objects
         if isinstance(mission_order_object, MissionSlotData)
     ]
@@ -2029,7 +2024,7 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
         mission_order_object for mission_order_object in accessible_objects
         if isinstance(mission_order_object, CampaignSlotData)
     ]
-    available_campaigns = [
+    available_campaigns: typing.List[int] = [
         campaign_idx for campaign_idx, campaign in enumerate(ctx.custom_mission_order)
         if campaign in available_campaign_objects
     ]
@@ -2037,7 +2032,7 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
         mission_order_object for mission_order_object in accessible_objects
         if isinstance(mission_order_object, LayoutSlotData)
     ]
-    available_layouts = {
+    available_layouts: typing.Dict[int, typing.List[int]] = {
         campaign_idx: [
             layout_idx for layout_idx, layout in enumerate(campaign.layouts) if layout in available_layout_objects
         ]

--- a/worlds/sc2/mission_order/entry_rules.py
+++ b/worlds/sc2/mission_order/entry_rules.py
@@ -73,8 +73,7 @@ class RuleData(ABC):
 
     @abstractmethod
     def is_accessible(
-        self, beaten_missions: Set[int], received_items: Dict[int, int],
-        mission_id_to_entry_rules: Dict[int, MissionEntryRules]
+        self, beaten_missions: Set[int], received_items: Dict[int, int]
     ) -> bool:
         return False
 
@@ -125,8 +124,7 @@ class BeatMissionsRuleData(RuleData):
         return len(self.visual_reqs) == 1
 
     def is_accessible(
-        self, beaten_missions: Set[int], received_items: Dict[int, int],
-        mission_id_to_entry_rules: Dict[int, MissionEntryRules],
+        self, beaten_missions: Set[int], received_items: Dict[int, int]
     ) -> bool:
         # Beat rules are accessible if all their missions are beaten and accessible
         if not beaten_missions.issuperset(self.mission_ids):
@@ -201,8 +199,7 @@ class CountMissionsRuleData(RuleData):
         return len(self.visual_reqs) == 1
 
     def is_accessible(
-        self, beaten_missions: Set[int], received_items: Dict[int, int],
-        mission_id_to_entry_rules: Dict[int, MissionEntryRules],
+        self, beaten_missions: Set[int], received_items: Dict[int, int]
     ) -> bool:
         # Count rules are accessible if enough of their missions are beaten and accessible
         return len([mission_id for mission_id in self.mission_ids if mission_id in beaten_missions]) >= self.amount
@@ -319,15 +316,14 @@ class SubRuleRuleData(RuleData):
         return self.amount == len(self.sub_rules) == 1 and self.sub_rules[0].shows_single_rule()
 
     def is_accessible(
-        self, beaten_missions: Set[int], received_items: Dict[int, int],
-        mission_id_to_entry_rules: Dict[int, MissionEntryRules],
+        self, beaten_missions: Set[int], received_items: Dict[int, int]
     ) -> bool:
         # Sub-rule rules are accessible if enough of their child rules are accessible
         accessible_count = 0
         success = accessible_count >= self.amount
         if self.amount > 0:
             for rule in self.sub_rules:
-                if rule.is_accessible(beaten_missions, received_items, mission_id_to_entry_rules):
+                if rule.is_accessible(beaten_missions, received_items):
                     rule.was_accessible = True
                     accessible_count += 1
                     if accessible_count >= self.amount:
@@ -389,8 +385,7 @@ class ItemRuleData(RuleData):
         return len(self.visual_reqs) == 1
 
     def is_accessible(
-        self, beaten_missions: Set[int], received_items: Dict[int, int],
-        mission_id_to_entry_rules: Dict[int, MissionEntryRules]
+        self, beaten_missions: Set[int], received_items: Dict[int, int]
     ) -> bool:
         return all(
             item in received_items and received_items[item] >= amount

--- a/worlds/sc2/mission_order/entry_rules.py
+++ b/worlds/sc2/mission_order/entry_rules.py
@@ -213,7 +213,7 @@ class CountMissionsRuleData(RuleData):
         mission_id_to_entry_rules: Dict[int, MissionEntryRules],
         accessible_rules: Set[int], seen_rules: List[int], ignore_recursive_rules: bool = False
     ) -> bool:
-        # Count rules are accessible if enough of their missions is beaten and accessible
+        # Count rules are accessible if enough of their missions are beaten and accessible
         accessible_count = 0
         success = accessible_count >= self.amount
         if self.amount > 0:

--- a/worlds/sc2/mission_order/slot_data.py
+++ b/worlds/sc2/mission_order/slot_data.py
@@ -13,7 +13,7 @@ class MissionOrderObjectSlotData(Protocol):
     entry_rule: SubRuleRuleData
 
 @dataclass
-class CampaignSlotData(MissionOrderObjectSlotData):
+class CampaignSlotData:
     name: str
     entry_rule: SubRuleRuleData
     exits: List[int]
@@ -25,7 +25,7 @@ class CampaignSlotData(MissionOrderObjectSlotData):
 
 
 @dataclass
-class LayoutSlotData(MissionOrderObjectSlotData):
+class LayoutSlotData:
     name: str
     entry_rule: SubRuleRuleData
     exits: List[int]
@@ -37,7 +37,7 @@ class LayoutSlotData(MissionOrderObjectSlotData):
 
 
 @dataclass
-class MissionSlotData(MissionOrderObjectSlotData):
+class MissionSlotData:
     mission_id: int
     prev_mission_ids: List[int]
     entry_rule: SubRuleRuleData

--- a/worlds/sc2/mission_order/slot_data.py
+++ b/worlds/sc2/mission_order/slot_data.py
@@ -10,11 +10,21 @@ from dataclasses import dataclass
 from .entry_rules import SubRuleRuleData
 
 @dataclass
-class CampaignSlotData:
+class MissionOrderObjectSlotData:
+    entry_rule: SubRuleRuleData
+
+@dataclass
+class CampaignSlotData(MissionOrderObjectSlotData):
     name: str
     entry_rule: SubRuleRuleData
     exits: List[int]
     layouts: List[LayoutSlotData]
+
+    def __init__(self, name, entry_rule, exits, layouts):
+        self.name = name
+        self.entry_rule = entry_rule
+        self.exits = exits
+        self.layouts = layouts
 
     @staticmethod
     def legacy(name: str, layouts: List[LayoutSlotData]) -> CampaignSlotData:
@@ -22,11 +32,16 @@ class CampaignSlotData:
 
 
 @dataclass
-class LayoutSlotData:
+class LayoutSlotData(MissionOrderObjectSlotData):
     name: str
-    entry_rule: SubRuleRuleData
     exits: List[int]
     missions: List[List[MissionSlotData]]
+
+    def __init__(self, name, entry_rule, exits, missions):
+        self.name = name
+        self.entry_rule = entry_rule
+        self.exits = exits
+        self.missions = missions
 
     @staticmethod
     def legacy(name: str, missions: List[List[MissionSlotData]]) -> LayoutSlotData:
@@ -34,11 +49,16 @@ class LayoutSlotData:
 
 
 @dataclass
-class MissionSlotData:
+class MissionSlotData(MissionOrderObjectSlotData):
     mission_id: int
     prev_mission_ids: List[int]
-    entry_rule: SubRuleRuleData
     victory_cache_size: int = 0
+
+    def __init__(self, mission_id, entry_rule, prev_mission_ids, victory_cache_size = 0):
+        self.mission_id = mission_id
+        self.entry_rule = entry_rule
+        self.prev_mission_ids = prev_mission_ids
+        self.victory_cache_size = victory_cache_size
 
     @staticmethod
     def empty() -> MissionSlotData:

--- a/worlds/sc2/mission_order/slot_data.py
+++ b/worlds/sc2/mission_order/slot_data.py
@@ -4,13 +4,12 @@ Creating these is handled by the nodes they represent in .nodes.py.
 """
 
 from __future__ import annotations
-from typing import List
+from typing import List, Protocol
 from dataclasses import dataclass
 
 from .entry_rules import SubRuleRuleData
 
-@dataclass
-class MissionOrderObjectSlotData:
+class MissionOrderObjectSlotData(Protocol):
     entry_rule: SubRuleRuleData
 
 @dataclass
@@ -20,12 +19,6 @@ class CampaignSlotData(MissionOrderObjectSlotData):
     exits: List[int]
     layouts: List[LayoutSlotData]
 
-    def __init__(self, name, entry_rule, exits, layouts):
-        self.name = name
-        self.entry_rule = entry_rule
-        self.exits = exits
-        self.layouts = layouts
-
     @staticmethod
     def legacy(name: str, layouts: List[LayoutSlotData]) -> CampaignSlotData:
         return CampaignSlotData(name, SubRuleRuleData.empty(), [], layouts)
@@ -34,14 +27,9 @@ class CampaignSlotData(MissionOrderObjectSlotData):
 @dataclass
 class LayoutSlotData(MissionOrderObjectSlotData):
     name: str
+    entry_rule: SubRuleRuleData
     exits: List[int]
     missions: List[List[MissionSlotData]]
-
-    def __init__(self, name, entry_rule, exits, missions):
-        self.name = name
-        self.entry_rule = entry_rule
-        self.exits = exits
-        self.missions = missions
 
     @staticmethod
     def legacy(name: str, missions: List[List[MissionSlotData]]) -> LayoutSlotData:
@@ -52,13 +40,8 @@ class LayoutSlotData(MissionOrderObjectSlotData):
 class MissionSlotData(MissionOrderObjectSlotData):
     mission_id: int
     prev_mission_ids: List[int]
+    entry_rule: SubRuleRuleData
     victory_cache_size: int = 0
-
-    def __init__(self, mission_id, entry_rule, prev_mission_ids, victory_cache_size = 0):
-        self.mission_id = mission_id
-        self.entry_rule = entry_rule
-        self.prev_mission_ids = prev_mission_ids
-        self.victory_cache_size = victory_cache_size
 
     @staticmethod
     def empty() -> MissionSlotData:

--- a/worlds/sc2/mission_order/slot_data.py
+++ b/worlds/sc2/mission_order/slot_data.py
@@ -12,6 +12,7 @@ from .entry_rules import SubRuleRuleData
 class MissionOrderObjectSlotData(Protocol):
     entry_rule: SubRuleRuleData
 
+
 @dataclass
 class CampaignSlotData:
     name: str


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a problem with client being stuck in an infinite loop when logging into some slots in certain state

## How was this tested?
Logged into a game with client stuck in an infinite loop. It's gone while maintaining the chains

## If this makes graphical changes, please attach screenshots.
No