### PR TITLE
sc2: item parent minor fixes

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -759,7 +759,7 @@ item_descriptions = {
     item_names.NYDUS_WORM_ECHIDNA_WORM_JORMUNGANDR_STRAIN: f"Removes emerge time for {DISPLAY_NAME_WORMS}, and allows them to be salvaged to return the resources spent on them.", 
     item_names.NYDUS_WORM_RAVENOUS_APPETITE: "Allows Nydus Worms to unload and load units nearly instantly.",
     item_names.NYDUS_WORM_ECHIDNA_WORM_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(DISPLAY_NAME_WORMS),
-    item_names.ECHIDNA_WORM_OUROBOROS_STRAIN: "Allows Echidna Worms to train a limited assortment of combat units (Zerglings, Roachs, Hydralisks, and Aberrations) at a reduced time and cost.",
+    item_names.ECHIDNA_WORM_OUROBOROS_STRAIN: "Allows Echidna Worms to train a limited assortment of combat units (Zerglings, Roaches, Hydralisks, and Aberrations) at a reduced time and cost.",
     item_names.INFESTED_SIEGE_TANK_PROGRESSIVE_AUTOMATED_MITOSIS:  inspect.cleandoc("""
         Level 1: Infested Siege Tanks generate 1 Volatile Biomass every 30 seconds.
         Level 2: Infested Siege Tanks generate 1 Volatile Biomass every 10 seconds.

--- a/worlds/sc2/item/item_parents.py
+++ b/worlds/sc2/item/item_parents.py
@@ -142,7 +142,7 @@ parent_present[parent_names.BANELING_SOURCE] = AnyOf(
 parent_present[parent_names.INFESTED_UNITS] = AnyOf(item_groups.infterr_units, display_string='Infested')
 parent_present[parent_names.MORPH_SOURCE_AIR] = MorphlingOrAnyOf((item_names.MUTALISK, item_names.CORRUPTOR), "Mutalisk/Corruptor Morphs")
 parent_present[parent_names.MORPH_SOURCE_ROACH] = MorphlingOrItem(item_names.ROACH)
-parent_present[parent_names.MORPH_SOURCE_ZERGLING] = MorphlingOrAnyOf((item_names.ZERGLING, item_names.ZERGLING_RECONSTITUTION), "Zergling Morphs")
+parent_present[parent_names.MORPH_SOURCE_ZERGLING] = MorphlingOrItem(item_names.ZERGLING)
 parent_present[parent_names.MORPH_SOURCE_HYDRALISK] = MorphlingOrItem(item_names.HYDRALISK)
 parent_present[parent_names.MORPH_SOURCE_ULTRALISK] = MorphlingOrItem(item_names.ULTRALISK)
 parent_present[parent_names.ZERG_UPROOTABLE_BUILDINGS] = AnyOf(
@@ -153,6 +153,10 @@ parent_present[parent_names.ZERG_MISSILE_ATTACKER] = AnyOf(item_groups.zerg_rang
 parent_present[parent_names.ZERG_CARAPACE_UNIT] = AnyOf(item_groups.zerg_ground_units, display_string='Zerg Flyers')
 parent_present[parent_names.ZERG_FLYING_UNIT] = AnyOf(item_groups.zerg_air_units, display_string='Zerg Flyers')
 parent_present[parent_names.ZERG_MERCENARIES] = AnyOf(item_groups.zerg_mercenaries, display_string='Zerg Mercenaries')
+parent_present[parent_names.ZERG_OUROBOUROS_CONDITION] = AnyOfGroupAndOneOtherItem(
+    (item_names.ZERGLING, item_names.ROACH, item_names.HYDRALISK, item_names.ABERRATION),
+    item_names.ECHIDNA_WORM
+)
 
 # Protoss
 parent_present[parent_names.ARCHON_SOURCE] = AnyOf(

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1419,7 +1419,7 @@ item_table = {
     item_names.NYDUS_WORM_ECHIDNA_WORM_RESOURCE_EFFICIENCY:
         ItemData(356 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 14, SC2Race.ZERG, parent=parent_names.ANY_NYDUS_WORM),
     item_names.ECHIDNA_WORM_OUROBOROS_STRAIN:
-        ItemData(357 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 15, SC2Race.ZERG, parent=item_names.ECHIDNA_WORM),
+        ItemData(357 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 15, SC2Race.ZERG, parent=parent_names.ZERG_OUROBOUROS_CONDITION),
     item_names.NYDUS_WORM_RAVENOUS_APPETITE:
         ItemData(358 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_4, 16, SC2Race.ZERG, parent=item_names.NYDUS_WORM),
     item_names.INFESTED_SIEGE_TANK_PROGRESSIVE_AUTOMATED_MITOSIS:

--- a/worlds/sc2/item/parent_names.py
+++ b/worlds/sc2/item/parent_names.py
@@ -33,6 +33,7 @@ ZERG_MISSILE_ATTACKER = "Zerg Missile Attacker"
 ZERG_CARAPACE_UNIT = "Zerg Carapace Unit"
 ZERG_FLYING_UNIT = "Zerg Flying Unit"
 ZERG_MERCENARIES = "Zerg Mercenaries"
+ZERG_OUROBOUROS_CONDITION = "Zerg Ourobouros Condition"
 
 # Protoss
 ARCHON_SOURCE = "Any Archon Source"


### PR DESCRIPTION

## What is this fixing or adding?
* Updating ourobouros strain parent to require a buildable unit
* updating zergling morph source to not accept zergling reconstitution as a source

## How was this tested?
Ran a quick generation. Gen'd a game, sent ouroborous strain, checked `/received` still formatted it under echidna worms.

## If this makes graphical changes, please attach screenshots.
None