### PR TITLE
SC2: Update Elder Probes

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -1126,7 +1126,7 @@ item_descriptions = {
         Level 2: No longer consumes or requires charges.
     """),
     item_names.PROBE_WARPIN: "You can warp in additonal Probes from your Nexus to any visible location within a Pylon's power field. Has a 30 second cooldown and can store up to 2 charges.",
-    item_names.ELDER_PROBES: "You can warp in a group of 5 Elder Probes, tougher builders from the Brood War. Can only be used once.",
+    item_names.ELDER_PROBES: "You can warp in a group of 5 Elder Probes, tough builders from the Brood War. Elder Probes can provide a Power Field and get reconstructed on death. Can only be used once per mission.",
 }
 
 # Key descriptions


### PR DESCRIPTION
## What is this fixing or adding?

After discussion on Discord, Elder Probes were considered fairly weak and not worth the gas investment. I wanted to buff them, without improving their impact on economy. This PR aims to improve their usability as a frontline probe:

- Elder Probes now provide a Power Field
  - this can be toggled on/off
- Elder Probes now automatically reconstruct on death at your Nexus
  - your Nexus get an autocast ability, that can reconstruct one Elder Probe every 20 seconds
  - this replaces the command card slot for the Elder Probe summon, as it is no longer needed after using it once
  - also uses the same hotkey
  - this ability gets 1 charge whenever an Elder Probe is destroyed
  - multiple Nexus have individual cooldowns, but share charges
  - you never get more than 5 Elder Probes at a time, but multiple Nexus allow you to reconstruct them faster
- Elder Probes get a slightly stronger weapon (5 > 7 damage) and are affected by Protoss Ground Weapon upgrades

----

- added custom icons for the abilities
- changed the Elder Probe handling trigger to use FindPlacement instead of spawning an additional Elder Probe (as that was messing with the reconstruction)

## How was this tested

Tested in local testmap. The client change only updates the description.

## Graphical changes
![grafik](https://github.com/user-attachments/assets/fedf4acc-f197-42e3-ab3d-8f397d9fcae8)
![grafik](https://github.com/user-attachments/assets/7badd6bc-d6ae-4590-b755-b054f8f47811) ![grafik](https://github.com/user-attachments/assets/d99746c4-30bd-4242-9a8d-7bdf96d539f3)
![grafik](https://github.com/user-attachments/assets/35b9786a-41d0-49e8-bb3a-c7eac6b2213a)

![grafik](https://github.com/user-attachments/assets/48f6cd74-50ec-47a1-9f6b-261f8e4fb542)

[Data PR](https://github.com/Ziktofel/Archipelago-SC2-data/pull/465)
