### PR TITLE
sc2: Reworking grant story tech option to allow a third option to special-case Supreme

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -479,7 +479,7 @@ def flag_excludes_by_faction_presence(world: SC2World, item_list: List[FilterIte
             and item.data.type in (item_tables.ZergItemType.Unit, item_tables.ZergItemType.Mercenary, item_tables.ZergItemType.Evolution_Pit)
         ):
             if (SC2Mission.ENEMY_WITHIN not in missions
-                or world.options.grant_story_tech.value == GrantStoryTech.option_true
+                or world.options.grant_story_tech.value == GrantStoryTech.option_grant
                 or item.name not in (item_names.ZERGLING, item_names.ROACH, item_names.HYDRALISK, item_names.INFESTOR)
             ):
                 item.flags |= ItemFilterFlags.FilterExcluded
@@ -493,7 +493,7 @@ def flag_excludes_by_faction_presence(world: SC2World, item_list: List[FilterIte
             # Note(mm): This doesn't exclude things like automated assimilators or warp gate improvements
             # because that item type is mixed in with e.g. Reconstruction Beam and Overwatch
             if (SC2Mission.TEMPLAR_S_RETURN not in missions
-                or world.options.grant_story_tech.value == GrantStoryTech.option_true
+                or world.options.grant_story_tech.value == GrantStoryTech.option_grant
                 or item.name not in (
                             item_names.IMMORTAL, item_names.ANNIHILATOR,
                             item_names.COLOSSUS, item_names.VANGUARD, item_names.REAVER, item_names.DARK_TEMPLAR,

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -579,6 +579,17 @@ def flag_mission_based_item_excludes(world: SC2World, item_list: List[FilterItem
     else:
         soa_passive_presence = False
 
+    remove_kerrigan_abils = (
+        # TODO: Kerrigan presence Zerg/Everywhere
+        not kerrigan_is_present
+        or (world.options.grant_story_tech.value == GrantStoryTech.option_grant and not kerrigan_build_missions)
+        or (
+            world.options.grant_story_tech.value == GrantStoryTech.option_allow_substitutes
+            and len(kerrigan_missions) == 1
+            and kerrigan_missions[0] == SC2Mission.SUPREME
+        )
+    )
+
     for item in item_list:
         # Filter Nova equipment if you never get Nova
         if not nova_missions and (item.name in item_groups.nova_equipment):
@@ -592,12 +603,8 @@ def flag_mission_based_item_excludes(world: SC2World, item_list: List[FilterItem
             item.flags |= ItemFilterFlags.FilterExcluded
 
         # Remove Kerrigan abilities if there's no kerrigan
-        if item.data.type == item_tables.ZergItemType.Ability:
-            if not kerrigan_is_present:
-                # TODO: Kerrigan presence Zerg/Everywhere
-                item.flags |= ItemFilterFlags.FilterExcluded
-            elif world.options.grant_story_tech and not kerrigan_build_missions:
-                item.flags |= ItemFilterFlags.FilterExcluded
+        if item.data.type == item_tables.ZergItemType.Ability and remove_kerrigan_abils:
+            item.flags |= ItemFilterFlags.FilterExcluded
 
         # Remove Spear of Adun if it's off
         if item.name in item_tables.spear_of_adun_calldowns and not soa_presence:

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -830,7 +830,7 @@ class SC2Context(CommonContext):
             self.kerrigan_levels_per_mission_completed_cap = args["slot_data"].get("kerrigan_levels_per_mission_completed_cap", -1)
             self.kerrigan_total_level_cap = args["slot_data"].get("kerrigan_total_level_cap", -1)
             self.enable_morphling = args["slot_data"].get("enable_morphling", EnableMorphling.option_false)
-            self.grant_story_tech = args["slot_data"].get("grant_story_tech", GrantStoryTech.option_false)
+            self.grant_story_tech = args["slot_data"].get("grant_story_tech", GrantStoryTech.option_no_grant)
             self.grant_story_levels = args["slot_data"].get("grant_story_levels", GrantStoryLevels.option_additive)
             self.required_tactics = args["slot_data"].get("required_tactics", RequiredTactics.option_standard)
             self.take_over_ai_allies = args["slot_data"].get("take_over_ai_allies", TakeOverAIAllies.option_false)
@@ -1038,12 +1038,17 @@ class SC2Context(CommonContext):
         }
 
         for loc in self.server_locations:
-            offset = SC2WOL_LOC_ID_OFFSET if loc < SC2HOTS_LOC_ID_OFFSET \
+            offset = (
+                SC2WOL_LOC_ID_OFFSET
+                if loc < SC2HOTS_LOC_ID_OFFSET
                 else (SC2HOTS_LOC_ID_OFFSET - SC2Mission.ALL_IN.id * VICTORY_MODULO)
+            )
             mission_id, objective = divmod(loc - offset, VICTORY_MODULO)
             mission_id_to_location_ids[mission_id].add(objective)
-        self.mission_id_to_location_ids = {mission_id: sorted(objectives) for mission_id, objectives in
-                                           mission_id_to_location_ids.items()}
+        self.mission_id_to_location_ids = {
+            mission_id: sorted(objectives)
+            for mission_id, objectives in mission_id_to_location_ids.items()
+        }
 
     def locations_for_mission(self, mission: SC2Mission) -> typing.Iterable[int]:
         mission_id: int = mission.id

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -862,7 +862,7 @@ class SC2Context(CommonContext):
 
             if self.required_tactics == RequiredTactics.option_no_logic:
                 # Locking Grant Story Tech/Levels if no logic
-                self.grant_story_tech = GrantStoryTech.option_true
+                self.grant_story_tech = GrantStoryTech.option_grant
                 self.grant_story_levels = GrantStoryLevels.option_minimum
 
             self.location_inclusions = {

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2,8 +2,10 @@ import enum
 from typing import List, Tuple, Optional, Callable, NamedTuple, Set, TYPE_CHECKING
 from .item import item_names
 from .item.item_groups import kerrigan_logic_ultimates
-from .options import (get_option_value, RequiredTactics,
-    LocationInclusion, KerriganPresence, get_enabled_campaigns
+from .options import (
+    get_option_value, RequiredTactics,
+    LocationInclusion, KerriganPresence, get_enabled_campaigns,
+    GrantStoryTech,
 )
 from .mission_tables import SC2Mission, SC2Campaign
 
@@ -1053,16 +1055,16 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             flags=LocationFlag.SPEEDRUN
         ),
         make_location_data(SC2Mission.BACK_IN_THE_SADDLE.mission_name, "Victory", SC2HOTS_LOC_ID_OFFSET + 200, LocationType.VICTORY,
-            lambda state: logic.basic_kerrigan(state) or kerriganless or logic.grant_story_tech
+            lambda state: logic.basic_kerrigan(state) or kerriganless or logic.grant_story_tech == GrantStoryTech.option_grant
         ),
         make_location_data(SC2Mission.BACK_IN_THE_SADDLE.mission_name, "Defend the Tram", SC2HOTS_LOC_ID_OFFSET + 201, LocationType.EXTRA,
-            lambda state: logic.basic_kerrigan(state) or kerriganless or logic.grant_story_tech
+            lambda state: logic.basic_kerrigan(state) or kerriganless or logic.grant_story_tech == GrantStoryTech.option_grant
         ),
         make_location_data(SC2Mission.BACK_IN_THE_SADDLE.mission_name, "Kinetic Blast", SC2HOTS_LOC_ID_OFFSET + 202, LocationType.VANILLA),
         make_location_data(SC2Mission.BACK_IN_THE_SADDLE.mission_name, "Crushing Grip", SC2HOTS_LOC_ID_OFFSET + 203, LocationType.VANILLA),
         make_location_data(SC2Mission.BACK_IN_THE_SADDLE.mission_name, "Reach the Sublevel", SC2HOTS_LOC_ID_OFFSET + 204, LocationType.EXTRA),
         make_location_data(SC2Mission.BACK_IN_THE_SADDLE.mission_name, "Door Section Cleared", SC2HOTS_LOC_ID_OFFSET + 205, LocationType.EXTRA,
-            lambda state: logic.basic_kerrigan(state) or kerriganless or logic.grant_story_tech
+            lambda state: logic.basic_kerrigan(state) or kerriganless or logic.grant_story_tech == GrantStoryTech.option_grant
         ),
         make_location_data(SC2Mission.RENDEZVOUS.mission_name, "Victory", SC2HOTS_LOC_ID_OFFSET + 300, LocationType.VICTORY,
             lambda state: (
@@ -1196,7 +1198,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.ENEMY_WITHIN.mission_name, "Victory", SC2HOTS_LOC_ID_OFFSET + 600, LocationType.VICTORY,
             lambda state: (
                 logic.zerg_pass_vents(state)
-                and (logic.grant_story_tech
+                and (logic.grant_story_tech == GrantStoryTech.option_grant
                     or state.has_any({
                         item_names.ZERGLING_RAPTOR_STRAIN,
                         item_names.ROACH,
@@ -1599,7 +1601,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 kerriganless
                 or (
                     logic.two_kerrigan_actives(state)
-                    and (logic.basic_kerrigan(state) or logic.grant_story_tech)
+                    and (logic.basic_kerrigan(state) or logic.grant_story_tech == GrantStoryTech.option_grant)
                     and logic.kerrigan_levels(state, 25)
                 ))
         ),
@@ -1611,7 +1613,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 kerriganless
                 or (
                     logic.two_kerrigan_actives(state)
-                    and (logic.basic_kerrigan(state) or logic.grant_story_tech)
+                    and (logic.basic_kerrigan(state) or logic.grant_story_tech == GrantStoryTech.option_grant)
                     and logic.kerrigan_levels(state, 25)
                 ))
         ),
@@ -2532,7 +2534,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.IN_THE_ENEMY_S_SHADOW.mission_name, "Facility: Blazefire Gunblade", SC2NCO_LOC_ID_OFFSET + 706, LocationType.VANILLA,
             lambda state: (
                 logic.enemy_shadow_second_stage(state)
-                and (logic.grant_story_tech
+                and (logic.grant_story_tech == GrantStoryTech.option_grant
                     or state.has(item_names.NOVA_BLINK, player)
                     or (adv_tactics
                         and state.has_all({item_names.NOVA_DOMINATION, item_names.NOVA_HOLO_DECOY, item_names.NOVA_JUMP_SUIT_MODULE}, player)

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -1053,16 +1053,16 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
             flags=LocationFlag.SPEEDRUN
         ),
         make_location_data(SC2Mission.BACK_IN_THE_SADDLE.mission_name, "Victory", SC2HOTS_LOC_ID_OFFSET + 200, LocationType.VICTORY,
-            lambda state: logic.basic_kerrigan(state) or kerriganless or logic.story_tech_granted
+            lambda state: logic.basic_kerrigan(state) or kerriganless or logic.grant_story_tech
         ),
         make_location_data(SC2Mission.BACK_IN_THE_SADDLE.mission_name, "Defend the Tram", SC2HOTS_LOC_ID_OFFSET + 201, LocationType.EXTRA,
-            lambda state: logic.basic_kerrigan(state) or kerriganless or logic.story_tech_granted
+            lambda state: logic.basic_kerrigan(state) or kerriganless or logic.grant_story_tech
         ),
         make_location_data(SC2Mission.BACK_IN_THE_SADDLE.mission_name, "Kinetic Blast", SC2HOTS_LOC_ID_OFFSET + 202, LocationType.VANILLA),
         make_location_data(SC2Mission.BACK_IN_THE_SADDLE.mission_name, "Crushing Grip", SC2HOTS_LOC_ID_OFFSET + 203, LocationType.VANILLA),
         make_location_data(SC2Mission.BACK_IN_THE_SADDLE.mission_name, "Reach the Sublevel", SC2HOTS_LOC_ID_OFFSET + 204, LocationType.EXTRA),
         make_location_data(SC2Mission.BACK_IN_THE_SADDLE.mission_name, "Door Section Cleared", SC2HOTS_LOC_ID_OFFSET + 205, LocationType.EXTRA,
-            lambda state: logic.basic_kerrigan(state) or kerriganless or logic.story_tech_granted
+            lambda state: logic.basic_kerrigan(state) or kerriganless or logic.grant_story_tech
         ),
         make_location_data(SC2Mission.RENDEZVOUS.mission_name, "Victory", SC2HOTS_LOC_ID_OFFSET + 300, LocationType.VICTORY,
             lambda state: (
@@ -1196,7 +1196,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.ENEMY_WITHIN.mission_name, "Victory", SC2HOTS_LOC_ID_OFFSET + 600, LocationType.VICTORY,
             lambda state: (
                 logic.zerg_pass_vents(state)
-                and (logic.story_tech_granted
+                and (logic.grant_story_tech
                     or state.has_any({
                         item_names.ZERGLING_RAPTOR_STRAIN,
                         item_names.ROACH,
@@ -1599,7 +1599,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 kerriganless
                 or (
                     logic.two_kerrigan_actives(state)
-                    and (logic.basic_kerrigan(state) or logic.story_tech_granted)
+                    and (logic.basic_kerrigan(state) or logic.grant_story_tech)
                     and logic.kerrigan_levels(state, 25)
                 ))
         ),
@@ -1611,7 +1611,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
                 kerriganless
                 or (
                     logic.two_kerrigan_actives(state)
-                    and (logic.basic_kerrigan(state) or logic.story_tech_granted)
+                    and (logic.basic_kerrigan(state) or logic.grant_story_tech)
                     and logic.kerrigan_levels(state, 25)
                 ))
         ),
@@ -2532,7 +2532,7 @@ def get_locations(world: Optional['SC2World']) -> Tuple[LocationData, ...]:
         make_location_data(SC2Mission.IN_THE_ENEMY_S_SHADOW.mission_name, "Facility: Blazefire Gunblade", SC2NCO_LOC_ID_OFFSET + 706, LocationType.VANILLA,
             lambda state: (
                 logic.enemy_shadow_second_stage(state)
-                and (logic.story_tech_granted
+                and (logic.grant_story_tech
                     or state.has(item_names.NOVA_BLINK, player)
                     or (adv_tactics
                         and state.has_all({item_names.NOVA_DOMINATION, item_names.NOVA_HOLO_DECOY, item_names.NOVA_JUMP_SUIT_MODULE}, player)

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -754,7 +754,7 @@ class SpearOfAdunPassiveAbilityPresence(Choice):
     Affects abilities like Reconstruction Beam or Overwatch.
     Does not affect building abilities like Orbital Assimilators or Warp Harmonization.
 
-    Not Presents: Autocasts are not available.
+    Not Present: Autocasts are not available.
     LotV Protoss: Spear of Adun autocasts are only available in LotV main campaign
     Protoss: Spear of Adun autocasts are available in any Protoss mission
     Everywhere: Spear of Adun autocasts are available in any mission of any race
@@ -810,15 +810,20 @@ class SpearOfAdunMaxAutocastAbilities(Range):
     default = range_end
 
 
-class GrantStoryTech(Toggle):
+class GrantStoryTech(Choice):
     """
-    If set true, grants special tech required for story mission completion for duration of the mission.
-    Otherwise, you need to find these tech by a normal means as items.
-    Affects story missions like Back in the Saddle and Supreme
+    Controls handling of no-build missions that may require very specific items, such as Kerrigan or Nova abilities.
 
-    Locked to true if Required Tactics is set to no logic.
+    no_grant: don't grant anything special; the player must find items to play the missions
+    grant: grant a minimal inventory that will allow the player to beat the mission, in addition to other items found
+    allow_substitutes: Reworks the most constrained mission - Supreme - to allow other items to substitute for Leaping Strike and Mend
+
+    Locked to "grant" if Required Tactics is set to no logic.
     """
     display_name = "Grant Story Tech"
+    option_no_grant = 0
+    option_grant = 1
+    option_allow_substitutes = 2
 
 
 class GrantStoryLevels(Choice):

--- a/worlds/sc2/regions.py
+++ b/worlds/sc2/regions.py
@@ -10,7 +10,7 @@ from .options import (
     kerrigan_unit_available, TakeOverAIAllies, MissionOrder, get_excluded_missions, get_enabled_campaigns,
     static_mission_orders,
     TwoStartPositions, KeyMode, EnableMissionRaceBalancing, EnableRaceSwapVariants, NovaGhostOfAChanceVariant,
-    NerfUnitBaselines
+    NerfUnitBaselines, GrantStoryTech
 )
 from .mission_order.options import CustomMissionOrder
 from .mission_order import SC2MissionOrder
@@ -121,7 +121,7 @@ def adjust_mission_pools(world: 'SC2World', pools: SC2MOGenMissionPools):
     # HotS
     kerriganless = world.options.kerrigan_presence.value not in kerrigan_unit_available \
         or SC2Campaign.HOTS not in enabled_campaigns
-    if grant_story_tech:
+    if grant_story_tech == GrantStoryTech.option_grant:
         # Additional starter mission if player is granted story tech
         pools.move_mission(SC2Mission.ENEMY_WITHIN, Difficulty.EASY, Difficulty.STARTER)
         pools.move_mission(SC2Mission.TEMPLAR_S_RETURN, Difficulty.MEDIUM, Difficulty.STARTER)
@@ -129,19 +129,20 @@ def adjust_mission_pools(world: 'SC2World', pools: SC2MOGenMissionPools):
         pools.move_mission(SC2Mission.IN_THE_ENEMY_S_SHADOW, Difficulty.MEDIUM, Difficulty.STARTER)
     if not nerf_unit_baselines:
         pools.move_mission(SC2Mission.TEMPLAR_S_RETURN, Difficulty.MEDIUM, Difficulty.STARTER)
-    if (grant_story_tech and grant_story_levels) or kerriganless:
+    if (grant_story_tech == GrantStoryTech.option_grant and grant_story_levels) or kerriganless:
         # The player has, all the stuff he needs, provided under these settings
         pools.move_mission(SC2Mission.SUPREME, Difficulty.MEDIUM, Difficulty.STARTER)
         pools.move_mission(SC2Mission.THE_INFINITE_CYCLE, Difficulty.HARD, Difficulty.STARTER)
         pools.move_mission(SC2Mission.CONVICTION, Difficulty.MEDIUM, Difficulty.STARTER)
-    if \
-            not grant_story_tech \
-                    and (
-                    SC2Campaign.NCO in enabled_campaigns
-                    and world.options.nova_ghost_of_a_chance_variant.value == NovaGhostOfAChanceVariant.option_auto
-            ) or (
-                    world.options.nova_ghost_of_a_chance_variant == NovaGhostOfAChanceVariant.option_nco
-            ):
+    if (grant_story_tech != GrantStoryTech.option_grant
+        and (
+            world.options.nova_ghost_of_a_chance_variant == NovaGhostOfAChanceVariant.option_nco
+            or (
+                SC2Campaign.NCO in enabled_campaigns
+                and world.options.nova_ghost_of_a_chance_variant.value == NovaGhostOfAChanceVariant.option_auto
+            )
+        )
+    ):
         # Using NCO tech for this mission that must be acquired
         pools.move_mission(SC2Mission.GHOST_OF_A_CHANCE, Difficulty.STARTER, Difficulty.MEDIUM)
     if world.options.take_over_ai_allies.value == TakeOverAIAllies.option_true:

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -45,7 +45,7 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_unexcludes_cancel_out_excludes(self):
         world_options = {
-            'grant_story_tech': True,
+            'grant_story_tech': options.GrantStoryTech.option_grant,
             'excluded_items': {
                 item_groups.ItemGroupNames.NOVA_EQUIPMENT: 15,
                 item_names.MARINE_PROGRESSIVE_STIMPACK: 1,
@@ -379,7 +379,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'accessibility': 'locations',
-            'grant_story_tech': options.GrantStoryTech.option_true,
+            'grant_story_tech': options.GrantStoryTech.option_grant,
         }
         self.generate_world(world_options)
         missions = get_all_missions(self.world.custom_mission_order)


### PR DESCRIPTION
## What is this fixing or adding?
grant_story_tech is being reworked into a Choice with 3 options:
* no_grant -- same as old false
* grant -- same as old true
* allow_substitutes -- a new value that allows Supreme to use other items in place of Leaping Strike and Mend

Pairs with Snarky's [data PR #467](https://github.com/Ziktofel/Archipelago-SC2-data/pull/467)

## How was this tested?
Ran unit tests. Mod integration pending on Snarky.

## If this makes graphical changes, please attach screenshots.
None.