### PR TITLE
sc2: any_units now only counts morphs as units if they are morphable

### DIFF
--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -117,6 +117,7 @@ class ItemGroupNames:
 
     ZERG_ITEMS = "Zerg Items"
     ZERG_UNITS = "Zerg Units"
+    ZERG_NONMORPH_UNITS = "Zerg Non-morph Units"
     ZERG_GENERIC_UPGRADES = "Zerg Generic Upgrades"
     """+attack/armour upgrades"""
     HOTS_UNITS = "HotS Units"
@@ -471,13 +472,17 @@ item_name_groups[ItemGroupNames.ZERG_BUILDINGS] = zerg_buildings = [
     item_names.INFESTED_MISSILE_TURRET,
     item_names.NYDUS_WORM,
     item_names.ECHIDNA_WORM]
-item_name_groups[ItemGroupNames.ZERG_UNITS] = zerg_units = [
+item_name_groups[ItemGroupNames.ZERG_NONMORPH_UNITS] = zerg_nonmorph_units = [
     item_name for item_name, item_data in item_tables.item_table.items()
     if item_data.type in (
-        item_tables.ZergItemType.Unit, item_tables.ZergItemType.Mercenary, item_tables.ZergItemType.Morph
+        item_tables.ZergItemType.Unit, item_tables.ZergItemType.Mercenary
     )
        and item_name not in zerg_buildings
 ]
+item_name_groups[ItemGroupNames.ZERG_MORPHS] = zerg_morphs = [
+    item_name for item_name, item_data in item_tables.item_table.items() if item_data.type == item_tables.ZergItemType.Morph
+]
+item_name_groups[ItemGroupNames.ZERG_UNITS] = zerg_units = zerg_nonmorph_units + zerg_morphs
 # For W/A upgrades
 zerg_ground_units = [
     item_names.ZERGLING, item_names.SWARM_QUEEN, item_names.ROACH, item_names.HYDRALISK, item_names.ABERRATION,
@@ -527,9 +532,6 @@ item_name_groups[ItemGroupNames.HOTS_MORPHS] = hots_morphs = [
     item_names.HYDRALISK_LURKER_ASPECT,
     item_names.MUTALISK_CORRUPTOR_VIPER_ASPECT,
     item_names.MUTALISK_CORRUPTOR_BROOD_LORD_ASPECT,
-]
-item_name_groups[ItemGroupNames.ZERG_MORPHS] = zerg_morphs = [
-    item_name for item_name, item_data in item_tables.item_table.items() if item_data.type == item_tables.ZergItemType.Morph
 ]
 item_name_groups[ItemGroupNames.ZERG_MERCENARIES] = zerg_mercenaries = [
     item_name for item_name, item_data in item_tables.item_table.items() if item_data.type == item_tables.ZergItemType.Mercenary

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -3264,52 +3264,49 @@ class SC2Logic:
         def _has_terran_units(state: CollectionState) -> bool:
             return (state.count_from_list_unique(item_groups.terran_units + item_groups.terran_buildings, self.player) >= target) and (
                 # Anything that can hit buildings
-                state.has_any(
-                    (
-                        # Infantry
-                        item_names.MARINE,
-                        item_names.FIREBAT,
-                        item_names.MARAUDER,
-                        item_names.REAPER,
-                        item_names.HERC,
-                        item_names.DOMINION_TROOPER,
-                        item_names.GHOST,
-                        item_names.SPECTRE,
-                        # Vehicles
-                        item_names.HELLION,
-                        item_names.VULTURE,
-                        item_names.SIEGE_TANK,
-                        item_names.WARHOUND,
-                        item_names.GOLIATH,
-                        item_names.DIAMONDBACK,
-                        item_names.THOR,
-                        item_names.PREDATOR,
-                        item_names.CYCLONE,
-                        # Ships
-                        item_names.WRAITH,
-                        item_names.VIKING,
-                        item_names.BANSHEE,
-                        item_names.RAVEN,
-                        item_names.BATTLECRUISER,
-                        # RG
-                        item_names.SON_OF_KORHAL,
-                        item_names.AEGIS_GUARD,
-                        item_names.EMPERORS_SHADOW,
-                        item_names.BULWARK_COMPANY,
-                        item_names.SHOCK_DIVISION,
-                        item_names.BLACKHAMMER,
-                        item_names.SKY_FURY,
-                        item_names.NIGHT_WOLF,
-                        item_names.NIGHT_HAWK,
-                        item_names.PRIDE_OF_AUGUSTRGRAD,
-                        # Mercs with shortest initial cooldown (300s)
-                        item_names.WAR_PIGS,
-                        item_names.DEATH_HEADS,
-                        item_names.HELS_ANGELS,
-                        item_names.WINGED_NIGHTMARES,
-                    ),
-                    self.player,
-                )
+                state.has_any((
+                    # Infantry
+                    item_names.MARINE,
+                    item_names.FIREBAT,
+                    item_names.MARAUDER,
+                    item_names.REAPER,
+                    item_names.HERC,
+                    item_names.DOMINION_TROOPER,
+                    item_names.GHOST,
+                    item_names.SPECTRE,
+                    # Vehicles
+                    item_names.HELLION,
+                    item_names.VULTURE,
+                    item_names.SIEGE_TANK,
+                    item_names.WARHOUND,
+                    item_names.GOLIATH,
+                    item_names.DIAMONDBACK,
+                    item_names.THOR,
+                    item_names.PREDATOR,
+                    item_names.CYCLONE,
+                    # Ships
+                    item_names.WRAITH,
+                    item_names.VIKING,
+                    item_names.BANSHEE,
+                    item_names.RAVEN,
+                    item_names.BATTLECRUISER,
+                    # RG
+                    item_names.SON_OF_KORHAL,
+                    item_names.AEGIS_GUARD,
+                    item_names.EMPERORS_SHADOW,
+                    item_names.BULWARK_COMPANY,
+                    item_names.SHOCK_DIVISION,
+                    item_names.BLACKHAMMER,
+                    item_names.SKY_FURY,
+                    item_names.NIGHT_WOLF,
+                    item_names.NIGHT_HAWK,
+                    item_names.PRIDE_OF_AUGUSTRGRAD,
+                    # Mercs with shortest initial cooldown (300s)
+                    item_names.WAR_PIGS,
+                    item_names.DEATH_HEADS,
+                    item_names.HELS_ANGELS,
+                    item_names.WINGED_NIGHTMARES,
+                ), self.player)
                 or state.has_all((item_names.LIBERATOR, item_names.LIBERATOR_RAID_ARTILLERY), self.player)
                 or state.has_all((item_names.EMPERORS_GUARDIAN, item_names.LIBERATOR_RAID_ARTILLERY), self.player)
                 or state.has_all((item_names.VALKYRIE, item_names.VALKYRIE_FLECHETTE_MISSILES), self.player)
@@ -3320,10 +3317,27 @@ class SC2Logic:
 
     def has_zerg_units(self, target: int) -> Callable[["CollectionState"], bool]:
         def _has_zerg_units(state: CollectionState) -> bool:
-            return (state.count_from_list_unique(item_groups.zerg_units + item_groups.zerg_buildings, self.player) >= target) and (
-                # Anything that can hit buildings
-                state.has_any(
-                    (
+            num_units = (
+                state.count_from_list_unique(
+                    item_groups.zerg_nonmorph_units + item_groups.zerg_buildings + [item_names.OVERLORD_OVERSEER_ASPECT],
+                    self.player
+                )
+                + self.morph_baneling(state)
+                + self.morph_ravager(state)
+                + self.morph_igniter(state)
+                + self.morph_lurker(state)
+                + self.morph_impaler(state)
+                + self.morph_viper(state)
+                + self.morph_devourer(state)
+                + self.morph_brood_lord(state)
+                + self.morph_guardian(state)
+                + self.morph_tyrannozor(state)
+            )
+            return (
+                num_units >= target
+                and (
+                    # Anything that can hit buildings
+                    state.has_any((
                         item_names.ZERGLING,
                         item_names.SWARM_QUEEN,
                         item_names.ROACH,
@@ -3343,20 +3357,20 @@ class SC2Logic:
                         item_names.HUNTER_KILLERS,
                         item_names.CAUSTIC_HORRORS,
                         item_names.HUNTERLING,
-                    ),
-                    self.player,
+                    ), self.player)
+                    or state.has_all((item_names.INFESTOR, item_names.INFESTOR_INFESTED_TERRAN), self.player)
+                    or self.morph_baneling(state)
+                    or self.morph_lurker(state)
+                    or self.morph_impaler(state)
+                    or self.morph_brood_lord(state)
+                    or self.morph_guardian(state)
+                    or self.morph_ravager(state)
+                    or self.morph_igniter(state)
+                    or self.morph_tyrannozor(state)
+                    or (self.morph_devourer(state)
+                        and state.has(item_names.DEVOURER_PRESCIENT_SPORES, self.player)
+                    )
                 )
-                or state.has_all((item_names.INFESTOR, item_names.INFESTOR_INFESTED_TERRAN), self.player)
-                or self.morph_baneling(state)
-                or self.morph_lurker(state)
-                or self.morph_impaler(state)
-                or self.morph_brood_lord(state)
-                or self.morph_guardian(state)
-                or self.morph_ravager(state)
-                or self.morph_igniter(state)
-                or self.morph_tyrannozor(state)
-                or self.morph_devourer(state)
-                and state.has(item_names.DEVOURER_PRESCIENT_SPORES, self.player)
             )
 
         return _has_zerg_units
@@ -3368,58 +3382,56 @@ class SC2Logic:
                 >= target
             ) and (
                 # Anything that can hit buildings
-                state.has_any(
-                    (
-                        # Gateway
-                        item_names.ZEALOT,
-                        item_names.CENTURION,
-                        item_names.SENTINEL,
-                        item_names.SUPPLICANT,
-                        item_names.STALKER,
-                        item_names.INSTIGATOR,
-                        item_names.SLAYER,
-                        item_names.DRAGOON,
-                        item_names.ADEPT,
-                        item_names.SENTRY,
-                        item_names.ENERGIZER,
-                        item_names.AVENGER,
-                        item_names.DARK_TEMPLAR,
-                        item_names.BLOOD_HUNTER,
-                        item_names.HIGH_TEMPLAR,
-                        item_names.SIGNIFIER,
-                        item_names.ASCENDANT,
-                        item_names.DARK_ARCHON,
-                        # Robo
-                        item_names.IMMORTAL,
-                        item_names.ANNIHILATOR,
-                        item_names.VANGUARD,
-                        item_names.STALWART,
-                        item_names.COLOSSUS,
-                        item_names.WRATHWALKER,
-                        item_names.REAVER,
-                        item_names.DISRUPTOR,
-                        # Stargate
-                        item_names.SKIRMISHER,
-                        item_names.SCOUT,
-                        item_names.MISTWING,
-                        item_names.OPPRESSOR,
-                        item_names.INTERCESSOR,
-                        item_names.VOID_RAY,
-                        item_names.DESTROYER,
-                        item_names.DAWNBRINGER,
-                        item_names.ARBITER,
-                        item_names.ORACLE,
-                        item_names.CARRIER,
-                        item_names.TRIREME,
-                        item_names.SKYLORD,
-                        item_names.TEMPEST,
-                        item_names.MOTHERSHIP,
-                    ),
-                    self.player,
-                )
+                state.has_any((
+                    # Gateway
+                    item_names.ZEALOT,
+                    item_names.CENTURION,
+                    item_names.SENTINEL,
+                    item_names.SUPPLICANT,
+                    item_names.STALKER,
+                    item_names.INSTIGATOR,
+                    item_names.SLAYER,
+                    item_names.DRAGOON,
+                    item_names.ADEPT,
+                    item_names.SENTRY,
+                    item_names.ENERGIZER,
+                    item_names.AVENGER,
+                    item_names.DARK_TEMPLAR,
+                    item_names.BLOOD_HUNTER,
+                    item_names.HIGH_TEMPLAR,
+                    item_names.SIGNIFIER,
+                    item_names.ASCENDANT,
+                    item_names.DARK_ARCHON,
+                    # Robo
+                    item_names.IMMORTAL,
+                    item_names.ANNIHILATOR,
+                    item_names.VANGUARD,
+                    item_names.STALWART,
+                    item_names.COLOSSUS,
+                    item_names.WRATHWALKER,
+                    item_names.REAVER,
+                    item_names.DISRUPTOR,
+                    # Stargate
+                    item_names.SKIRMISHER,
+                    item_names.SCOUT,
+                    item_names.MISTWING,
+                    item_names.OPPRESSOR,
+                    item_names.INTERCESSOR,
+                    item_names.VOID_RAY,
+                    item_names.DESTROYER,
+                    item_names.DAWNBRINGER,
+                    item_names.ARBITER,
+                    item_names.ORACLE,
+                    item_names.CARRIER,
+                    item_names.TRIREME,
+                    item_names.SKYLORD,
+                    item_names.TEMPEST,
+                    item_names.MOTHERSHIP,
+                ), self.player)
                 or state.has_all((item_names.WARP_PRISM, item_names.WARP_PRISM_PHASE_BLASTER), self.player)
                 or state.has_all((item_names.CALADRIUS, item_names.CALADRIUS_CORONA_BEAM), self.player)
                 or state.has_all((item_names.PHOTON_CANNON, item_names.KHALAI_INGENUITY), self.player)
+                or state.has_all((item_names.KHAYDARIN_MONOLITH, item_names.KHALAI_INGENUITY), self.player)
             )
 
         return _has_protoss_units


### PR DESCRIPTION
## What is this fixing or adding?
Durygathn reported this issue about a month ago now -- any_units would assume morphlings were enabled when tallying the unit count. This wouldn't apply to the more restricted first unit.

Added a new item group to make this easier to write, and exposed it for yaml use. `Zerg Non-morph Units`

## How was this tested?
Ran unit tests. Did a sample generation.

## If this makes graphical changes, please attach screenshots.
None