### PR TITLE
sc2: Increasing the any_units logical requirement for challenge locations by one unit

### DIFF
--- a/worlds/sc2/mission_order/generation.py
+++ b/worlds/sc2/mission_order/generation.py
@@ -461,12 +461,18 @@ def create_region(
             victory_cache_locations += 1
         if world.options.required_tactics.value == world.options.required_tactics.option_any_units:
             if mission_needs_unit and not unit_given and location_data.type == easiest_category:
+                # Ensure there is at least one no-logic location if the first mission is a build mission
                 location = create_minimal_logic_location(world, location_data, region, location_cache, 0)
                 unit_given = True
             elif location_data.type == LocationType.MASTERY:
+                # Mastery locations always require max units regardless of position in the ramp
                 location = create_minimal_logic_location(world, location_data, region, location_cache, MAX_UNIT_REQUIREMENT)
             else:
-                location = create_minimal_logic_location(world, location_data, region, location_cache, min(slot.min_depth, MAX_UNIT_REQUIREMENT) + mission_needs_unit)
+                # Required number of units = mission depth; +1 if it's a starting build mission; +1 if it's a challenge location
+                location = create_minimal_logic_location(world, location_data, region, location_cache, min(
+                    slot.min_depth + mission_needs_unit + (location_data.type == LocationType.CHALLENGE),
+                    MAX_UNIT_REQUIREMENT
+                ))
         else:
             location = create_location(world.player, location_data, region, location_cache)
         region.locations.append(location)


### PR DESCRIPTION
## What is this fixing or adding?
This gives challenge locations on any_units a slightly higher logic requirement. Now it will require 1 additional unit over the victory location logic requirement, up to the maximum guarateed unit amount.

Snarky commented that he didn't think Zero Hour hatcheries seemed particularly doable on just one unit. While it may be possible  (with great effort) using just reapers like he had, there are definitely other possible starting units like War Pigs or building blaster widow mines that would pose a greater issue. In the before-keys days, having to go a little out of logic was a possibility to make things work; now with keys, the logic matters more as you can be hard-blocked on items in those locations. Mastery locations already have a failsafe that always requires the maximum guaranteed unit amount (currently 5 units).

## How was this tested?
Ran unit tests.

## If this makes graphical changes, please attach screenshots.
None