### PR TITLE
Various client UI improvements

### DIFF
--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -216,6 +216,7 @@ class SC2Manager(GameManager):
             data_changed
             and not hovering_tooltip
             or not self.refresh_from_launching
+            or self.last_data_out_of_date != self.ctx.data_out_of_date
             or self.first_check
         )
         self.last_shown_tooltip = shown_tooltip


### PR DESCRIPTION
## What is this fixing or adding?
First a couple of bug fixes and requested changes:
- Goal missions now have a clearer message after being beaten, see screenshots.
- Entry rules use slightly softer colors to label fulfilled & unfulfilled portions, to match existing color usage.
- Fix the out-of-date data warning being squished from the second mission list draw onwards.
- Tooltips are now cleared when the mission list is redrawn. Previously you could only see a tooltip on redraw when receiving a location change from the server (eg. collect), but this is now more common (see below) and caused an outdated tooltip to stick around despite its parent button being deleted.

Now the more complex changes:
- The mission list now redraws when received items change, and thus keeps track of received items. Ideally it would only redraw if a critical item is received (so one that finishes an Item rule), I opted for the simple implementation for now.
- The rules to redraw the mission list have changed: As before, the first-time draw and mission launching both always cause a redraw, but data changes will not cause a redraw while the user is hovering a single mission. Hovering a different mission will allow the redraw from data changes.
  - I found the sudden tooltip disappearance and redraw lag to be jarring while testing, and figured it would feel even worse if you received multiple items in quick succession during a sync, so this change was made to preserve interactivity.
  - The mission launch still checks against the real game state, so this can cause wrong tooltips until the user hovers a different mission, but I think it's more important that the user is not prevented from reading & pressing a button they're looking at.
- Forcibly draw the currently hovered tooltip on mission list redraw. The underlying HoverBehavior only sends an event on mouse movement despite correctly identifying that a button is hovered, so this is a bug fix.
  - This alone would nearly fix the previous issue, but:
    - There would still be unknown behavior when pressing a button during redraw lag.
    - Every new tooltip has to go through a one-time fade-in animation, so this still interrupts tooltip readability.

To be honest, all this makes me wonder why we redraw the whole mission list on every update anyway, instead of just updating the existing buttons. Might be a project for next cycle.

## How was this tested?
Opening the client and trying a bunch of interactions, mainly hovering different missions while using !getitem to redraw the mission list. I also tested a 160 item release (on localhost, so without network lag) and only got a single redraw.

## If this makes graphical changes, please attach screenshots.
This showcases the new colors, note that the red now matches the goal mission reminder.
![python_LtjDFg8C4M](https://github.com/user-attachments/assets/df7d315f-bd00-4669-a9b6-2d6f7be751f3)
This is is the new "beat more goals" message.
![python_k3SNqwIX67](https://github.com/user-attachments/assets/c8227c06-9875-430b-9c18-57bcf011e8f6)
