### PR TITLE
sc2: Fixing a crash for games generated with invalid/deprecated IDs

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1405,7 +1405,9 @@ def calculate_items(ctx: SC2Context) -> typing.Dict[SC2Race, typing.List[int]]:
     shields_from_air_upgrade: int = 0
 
     for network_item in items:
-        name: str = lookup_id_to_name[network_item.item]
+        name = lookup_id_to_name.get(network_item.item)
+        if name is None:
+            continue
         item_data: ItemData = item_list[name]
 
         if item_data.type.flag_word < 0:


### PR DESCRIPTION
## What is this fixing or adding?
Some people who generated with legacy items on and pulled in the update that deprecated the option are now having the client crash when it tries to calculate items. This is a quick (mostly untested) attempt at fixing the crash, where invalid network item IDs are simply ignored.

## How was this tested?
Not tested; going to link this fix to people who had the problem to see if it fixes it for them

## If this makes graphical changes, please attach screenshots.
None