### PR TITLE
sc2: Making exclude_overpowered_items and legacy items sensitive to unexclusion

### DIFF
--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -467,7 +467,7 @@ class ExcludeOverpoweredItems(Toggle):
     If turned on, a curated list of very strong items are excluded.
     These items were selected for promoting repetitive strategies, or for providing a lot of power in a boring way.
     Recommended off for players looking for a challenge or for repeat playthroughs.
-    Locked Items may override these exclusions, but Unexcluded Items will not.
+    Excluded Items overrides this option rather than add to it. Locked items will override this option.
     """
     display_name = "Exclude Overpowered Items"
 

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -467,7 +467,8 @@ class ExcludeOverpoweredItems(Toggle):
     If turned on, a curated list of very strong items are excluded.
     These items were selected for promoting repetitive strategies, or for providing a lot of power in a boring way.
     Recommended off for players looking for a challenge or for repeat playthroughs.
-    Excluded Items overrides this option rather than add to it. Locked items will override this option.
+    Excluding an OP item overrides the exclusion from this item rather than add to it.
+    OP items may be unexcluded or locked with Unexcluded Items or Locked Items options.
     """
     display_name = "Exclude Overpowered Items"
 

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -1185,3 +1185,24 @@ class TestItemFiltering(Sc2SetupTestBase):
         itempool = [item.name for item in self.multiworld.itempool]
 
         self.assertNotIn(item_names.ROGUE_FORCES, itempool)
+    
+    def test_unexcluded_items_applies_over_op_items(self) -> None:
+        world_options = {
+            'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
+            'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
+            'unexcluded_items': [item_names.SOA_TIME_STOP],
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
+        }
+        self.generate_world(world_options)
+        itempool = [item.name for item in self.multiworld.itempool]
+        self.assertNotIn(
+            item_groups.overpowered_items[0],
+            itempool,
+            f"OP item {item_groups.overpowered_items[0]} in the item pool when exclude_overpowered_items was true"
+        )
+        self.assertIn(
+            item_names.SOA_TIME_STOP,
+            itempool,
+            f"{item_names.SOA_TIME_STOP} was not unexcluded by unexcluded_items when exclude_overpowered_items was true"
+        )


### PR DESCRIPTION
## What is this fixing or adding?
Allows unexcluded_items to affect items excluded by exclude_overpowered_items or by being in the legacy items group.

In part for ease of implementation, in part because I _suspect_ it's what players may want, but `excluded_items` does not add to `exclude_overpowered_items`, instead it just defaults to excluding the items in the group iff nothing is specified in `excluded_items` for that item.

## How was this tested?
* Added a unit test.
* Generated with a yaml that excluded overpowered items and unexcluded HMEs; hinted for various items in the server console and confirmed HMEs were in the pool and Indomitable Will and Time Stop were not.

## If this makes graphical changes, please attach screenshots.
None