### PR TITLE
Add option to ban workers from Void Trade

### DIFF
--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -373,6 +373,18 @@ class VoidTradeAgeLimit(Choice):
     default = option_30_minutes
 
 
+class VoidTradeWorkers(Toggle):
+    """
+    If enabled, you are able to send and receive workers via Void Trade.
+
+    Sending workers is a cheap way to get a lot of units from other players,
+    at the cost of reducing the strength of received units for other players.
+
+    Receiving workers allows you to build units of other races, but potentially skips large parts of your multiworld progression.
+    """
+    display_name = "Allow Workers in Void Trade"
+
+
 class MaxUpgradeLevel(Range):
     """Controls the maximum number of weapon/armor upgrades that can be found or unlocked."""
     display_name = "Maximum Upgrade Level"
@@ -1338,6 +1350,7 @@ class Starcraft2Options(PerGameCommonOptions):
     required_tactics: RequiredTactics
     enable_void_trade: EnableVoidTrade
     void_trade_age_limit: VoidTradeAgeLimit
+    void_trade_workers: VoidTradeWorkers
     ensure_generic_items: EnsureGenericItems
     min_number_of_upgrades: MinNumberOfUpgrades
     max_number_of_upgrades: MaxNumberOfUpgrades
@@ -1500,6 +1513,7 @@ option_groups = [
         TakeOverAIAllies,
         EnableVoidTrade,
         VoidTradeAgeLimit,
+        VoidTradeWorkers,
         GrantStoryTech,
         CustomMissionOrder,
     ]),

--- a/worlds/sc2/transfer_data.py
+++ b/worlds/sc2/transfer_data.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 """
 This file is for handling SC2 data read via the bot
@@ -27,3 +27,12 @@ normalized_unit_types: Dict[str, str] = {
     "AP_ReaperResourceEfficiency": "AP_Reaper",
     "AP_MercReaperResourceEfficiency": "AP_MercReaper",
 }
+
+worker_units: List[str] = [
+    "AP_SCV",
+    "AP_MULE", # Mules can't currently build (or be traded due to timed life), this is future proofing just in case
+    "AP_Drone",
+    "AP_SISCV", # Infested SCV
+    "AP_Probe",
+    "AP_ElderProbe",
+]


### PR DESCRIPTION
## What is this fixing or adding?
This adds a `void_trade_workers: true/false` option to allow or ban workers from being sent or received in Void Trade.

Of note is that Dominion Troopers are still tradable when workers are disabled, because they only allow building defenses, so don't cause the same problems as regular workers.

Data changes: https://github.com/Ziktofel/Archipelago-SC2-data/pull/497

## How was this tested?
I generated a world with 3 players: two that could trade workers and one that couldn't. The first two could mutually send and receive workers, the third could only send and receive army units. The tested workers were `makeunit`-spawned Probes, Drones, SCVs, Infested SCVs, and Elder Probes, the tested army unit was built & starting Zerglings.
