### PR TITLE
sc2: Adding SOA presence option any_race_lotv; refactoringhow SOA options are sent to the game

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -26,6 +26,7 @@ from .options import (
     GrantStoryTech, GenericUpgradeResearch, RequiredTactics,
     upgrade_included_names, EnableVoidTrade, FillerItemsDistribution, MissionOrderScouting, option_groups,
     NovaGhostOfAChanceVariant, MissionOrder, VanillaItemsOnly, ExcludeOverpoweredItems,
+    is_mission_in_soa_presence,
 )
 from .rules import get_basic_units, SC2Logic
 from . import settings
@@ -560,13 +561,12 @@ def flag_mission_based_item_excludes(world: SC2World, item_list: List[FilterItem
     # Check if SOA actives should be present
     if world.options.spear_of_adun_presence != SpearOfAdunPresence.option_not_present:
         soa_missions = missions
+        soa_missions = [
+            m for m in soa_missions
+            if is_mission_in_soa_presence(world.options.spear_of_adun_presence.value, m)
+        ]
         if not world.options.spear_of_adun_present_in_no_build:
             soa_missions = [m for m in soa_missions if MissionFlag.NoBuild not in m.flags]
-        if world.options.spear_of_adun_presence == SpearOfAdunPresence.option_lotv_protoss:
-            soa_missions = [m for m in soa_missions if m.campaign == SC2Campaign.LOTV]
-        if world.options.spear_of_adun_presence in [SpearOfAdunPresence.option_lotv_protoss, SpearOfAdunPresence.option_protoss]:
-            soa_missions = [m for m in soa_missions if MissionFlag.Protoss in m.flags]
-
         soa_presence = len(soa_missions) > 0
     else:
         soa_presence = False
@@ -574,13 +574,16 @@ def flag_mission_based_item_excludes(world: SC2World, item_list: List[FilterItem
     # Check if SOA passives should be present
     if world.options.spear_of_adun_passive_ability_presence != SpearOfAdunPassiveAbilityPresence.option_not_present:
         soa_missions = missions
+        soa_missions = [
+            m for m in soa_missions
+            if is_mission_in_soa_presence(
+                world.options.spear_of_adun_passive_ability_presence.value,
+                m,
+                SpearOfAdunPassiveAbilityPresence
+            )
+        ]
         if not world.options.spear_of_adun_passive_present_in_no_build:
             soa_missions = [m for m in soa_missions if MissionFlag.NoBuild not in m.flags]
-        if world.options.spear_of_adun_passive_ability_presence == SpearOfAdunPassiveAbilityPresence.option_lotv_protoss:
-            soa_missions = [m for m in soa_missions if m.campaign == SC2Campaign.LOTV]
-        if world.options.spear_of_adun_passive_ability_presence in [SpearOfAdunPassiveAbilityPresence.option_protoss, SpearOfAdunPassiveAbilityPresence.option_lotv_protoss]:
-            soa_missions = [m for m in soa_missions if MissionFlag.Protoss in m.flags]
-
         soa_passive_presence = len(soa_missions) > 0
     else:
         soa_passive_presence = False
@@ -1031,6 +1034,7 @@ def fill_pool_with_kerrigan_levels(world: SC2World, item_pool: List[StarcraftIte
         else:
             round_func = ceil
         add_kerrigan_level_items(size, round_func(float(total_levels) / size))
+
 
 def push_precollected_items_to_multiworld(world: SC2World, item_list: List[StarcraftItem]) -> None:
     # Clear the pre-collected items, as AP will try to do this for us,

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -38,7 +38,8 @@ from .options import (
     DisableForcedCamera, SkipCutscenes, GrantStoryTech, GrantStoryLevels, TakeOverAIAllies, RequiredTactics,
     SpearOfAdunPresence, SpearOfAdunPresentInNoBuild, SpearOfAdunPassiveAbilityPresence,
     SpearOfAdunPassivesPresentInNoBuild, EnableVoidTrade, VoidTradeAgeLimit, void_trade_age_limits_ms, VoidTradeWorkers,
-    DifficultyDamageModifier, MissionOrderScouting, GenericUpgradeResearchSpeedup, MercenaryHighlanders, WarCouncilNerfs
+    DifficultyDamageModifier, MissionOrderScouting, GenericUpgradeResearchSpeedup, MercenaryHighlanders, WarCouncilNerfs,
+    is_mission_in_soa_presence,
 )
 from .mission_order.slot_data import CampaignSlotData, LayoutSlotData, MissionSlotData, MissionOrderObjectSlotData
 from .mission_order.entry_rules import SubRuleRuleData, CountMissionsRuleData, MissionEntryRules
@@ -1579,16 +1580,7 @@ def caclulate_soa_options(ctx: SC2Context, mission: SC2Mission) -> int:
     # Bits 0, 1
     # SoA Calldowns available
     soa_presence_value = 0
-    if (
-        (ctx.spear_of_adun_presence == SpearOfAdunPresence.option_everywhere)
-        or (ctx.spear_of_adun_presence == SpearOfAdunPresence.option_protoss and MissionFlag.Protoss in mission.flags)
-        or (ctx.spear_of_adun_presence == SpearOfAdunPresence.option_any_race_lotv and mission.campaign == SC2Campaign.LOTV)
-        or (ctx.spear_of_adun_presence == SpearOfAdunPresence.option_lotv_protoss
-            and (MissionFlag.VanillaSoa in mission.flags  # Keeps SOA off on Growing Shadow, as that's vanilla behaviour
-                or (MissionFlag.NoBuild in mission.flags and mission.campaign == SC2Campaign.LOTV)
-            )
-        )
-    ):
+    if is_mission_in_soa_presence(ctx.spear_of_adun_presence, mission):
         soa_presence_value = 3
     result |= soa_presence_value << 0
 
@@ -1600,20 +1592,7 @@ def caclulate_soa_options(ctx: SC2Context, mission: SC2Mission) -> int:
     # Bits 3,4
     # Autocasts
     soa_autocasts_presence_value = 0
-    if (
-        (ctx.spear_of_adun_passive_ability_presence == SpearOfAdunPassiveAbilityPresence.option_everywhere)
-        or (ctx.spear_of_adun_passive_ability_presence == SpearOfAdunPassiveAbilityPresence.option_protoss
-            and MissionFlag.Protoss in mission.flags
-        )
-        or (ctx.spear_of_adun_passive_ability_presence == SpearOfAdunPassiveAbilityPresence.option_any_race_lotv
-            and (mission.campaign == SC2Campaign.LOTV or mission == SC2Mission.INTO_THE_VOID)
-        )
-        or (ctx.spear_of_adun_passive_ability_presence == SpearOfAdunPassiveAbilityPresence.option_lotv_protoss
-            and (MissionFlag.VanillaSoa in mission.flags  # Keeps SOA off on Growing Shadow, as that's vanilla behaviour
-                or (MissionFlag.NoBuild in mission.flags and mission.campaign == SC2Campaign.LOTV)
-            )
-        )
-    ):
+    if is_mission_in_soa_presence(ctx.spear_of_adun_passive_ability_presence, mission, SpearOfAdunPassiveAbilityPresence):
         soa_autocasts_presence_value = 3
     # Guardian Shell breaks without SoA on version 4+, but can be generated without SoA on version 3
     if ctx.slot_data_version < 4 and MissionFlag.Protoss in mission.flags:

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1606,7 +1606,7 @@ def caclulate_soa_options(ctx: SC2Context, mission: SC2Mission) -> int:
             and MissionFlag.Protoss in mission.flags
         )
         or (ctx.spear_of_adun_passive_ability_presence == SpearOfAdunPassiveAbilityPresence.option_any_race_lotv
-            and mission.campaign == SC2Campaign.LOTV
+            and (mission.campaign == SC2Campaign.LOTV or mission == SC2Mission.INTO_THE_VOID)
         )
         or (ctx.spear_of_adun_passive_ability_presence == SpearOfAdunPassiveAbilityPresence.option_lotv_protoss
             and (MissionFlag.VanillaSoa in mission.flags  # Keeps SOA off on Growing Shadow, as that's vanilla behaviour

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -729,12 +729,14 @@ class SpearOfAdunPresence(Choice):
     LotV Protoss: Spear of Adun calldowns are only available in LotV main campaign
     Protoss: Spear of Adun calldowns are available in any Protoss mission
     Everywhere: Spear of Adun calldowns are available in any mission of any race
+    Any Race LotV: Spear of Adun calldowns are available in any race-swapped variant of a LotV mission
     """
     display_name = "Spear of Adun Presence"
     option_not_present = 0
     option_lotv_protoss = 1
     option_protoss = 2
     option_everywhere = 3
+    option_any_race_lotv = 4
     default = option_lotv_protoss
 
     # Fix case
@@ -766,12 +768,14 @@ class SpearOfAdunPassiveAbilityPresence(Choice):
     LotV Protoss: Spear of Adun autocasts are only available in LotV main campaign
     Protoss: Spear of Adun autocasts are available in any Protoss mission
     Everywhere: Spear of Adun autocasts are available in any mission of any race
+    Any Race LotV: Spear of Adun autocasts are available in any race-swapped variant of a LotV mission
     """
     display_name = "Spear of Adun Passive Ability Presence"
     option_not_present = 0
     option_lotv_protoss = 1
     option_protoss = 2
     option_everywhere = 3
+    option_any_race_lotv = 4
     default = option_lotv_protoss
 
     # Fix case

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -726,17 +726,17 @@ class SpearOfAdunPresence(Choice):
     Affects only abilities used from Spear of Adun top menu.
 
     Not Present: Spear of Adun calldowns are unavailable.
-    Vanilla: Spear of Adun calldowns are only available where they appear in the basegame (protoss missions after The Growing Shadow)
+    Vanilla: Spear of Adun calldowns are only available where they appear in the basegame (Protoss missions after The Growing Shadow)
     Protoss: Spear of Adun calldowns are available in any Protoss mission
     Everywhere: Spear of Adun calldowns are available in any mission of any race
     Any Race LotV: Spear of Adun calldowns are available in any race-swapped variant of a LotV mission
     """
     display_name = "Spear of Adun Presence"
     option_not_present = 0
-    option_vanilla = 1
+    option_vanilla = 4
     option_protoss = 2
     option_everywhere = 3
-    option_any_race_lotv = 4
+    option_any_race_lotv = 1
     default = option_vanilla
 
     # Fix case
@@ -765,17 +765,17 @@ class SpearOfAdunPassiveAbilityPresence(Choice):
     Does not affect building abilities like Orbital Assimilators or Warp Harmonization.
 
     Not Present: Autocasts are not available.
-    Vanilla: Spear of Adun calldowns are only available where it appears in the basegame (protoss missions after The Growing Shadow)
+    Vanilla: Spear of Adun calldowns are only available where it appears in the basegame (Protoss missions after The Growing Shadow)
     Protoss: Spear of Adun autocasts are available in any Protoss mission
     Everywhere: Spear of Adun autocasts are available in any mission of any race
     Any Race LotV: Spear of Adun autocasts are available in any race-swapped variant of a LotV mission
     """
     display_name = "Spear of Adun Passive Ability Presence"
     option_not_present = 0
-    option_vanilla = 1
+    option_vanilla = 4
     option_protoss = 2
     option_everywhere = 3
-    option_any_race_lotv = 4
+    option_any_race_lotv = 1
     default = option_vanilla
 
     # Fix case
@@ -1661,7 +1661,7 @@ def is_mission_in_soa_presence(
         (spear_of_adun_presence == option_class.option_everywhere)
         or (spear_of_adun_presence == option_class.option_protoss and MissionFlag.Protoss in mission.flags)
         or (spear_of_adun_presence == option_class.option_any_race_lotv
-            and (mission.campaign == SC2Campaign.LOTV or mission == SC2Mission.INTO_THE_VOID)
+            and (mission.campaign == SC2Campaign.LOTV or MissionFlag.VanillaSoa in mission.flags)
         )
         or (spear_of_adun_presence == option_class.option_vanilla
             and (MissionFlag.VanillaSoa in mission.flags  # Keeps SOA off on Growing Shadow, as that's vanilla behaviour

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -726,24 +726,24 @@ class SpearOfAdunPresence(Choice):
     Affects only abilities used from Spear of Adun top menu.
 
     Not Present: Spear of Adun calldowns are unavailable.
-    LotV Protoss: Spear of Adun calldowns are only available in LotV main campaign
+    Vanilla: Spear of Adun calldowns are only available where they appear in the basegame (protoss missions after The Growing Shadow)
     Protoss: Spear of Adun calldowns are available in any Protoss mission
     Everywhere: Spear of Adun calldowns are available in any mission of any race
     Any Race LotV: Spear of Adun calldowns are available in any race-swapped variant of a LotV mission
     """
     display_name = "Spear of Adun Presence"
     option_not_present = 0
-    option_lotv_protoss = 1
+    option_vanilla = 1
     option_protoss = 2
     option_everywhere = 3
     option_any_race_lotv = 4
-    default = option_lotv_protoss
+    default = option_vanilla
 
     # Fix case
     @classmethod
     def get_option_name(cls, value: int) -> str:
-        if value == SpearOfAdunPresence.option_lotv_protoss:
-            return "LotV Protoss"
+        if value == SpearOfAdunPresence.option_any_race_lotv:
+            return "Any Race LotV"
         else:
             return super().get_option_name(value)
 
@@ -765,24 +765,24 @@ class SpearOfAdunPassiveAbilityPresence(Choice):
     Does not affect building abilities like Orbital Assimilators or Warp Harmonization.
 
     Not Present: Autocasts are not available.
-    LotV Protoss: Spear of Adun autocasts are only available in LotV main campaign
+    Vanilla: Spear of Adun calldowns are only available where it appears in the basegame (protoss missions after The Growing Shadow)
     Protoss: Spear of Adun autocasts are available in any Protoss mission
     Everywhere: Spear of Adun autocasts are available in any mission of any race
     Any Race LotV: Spear of Adun autocasts are available in any race-swapped variant of a LotV mission
     """
     display_name = "Spear of Adun Passive Ability Presence"
     option_not_present = 0
-    option_lotv_protoss = 1
+    option_vanilla = 1
     option_protoss = 2
     option_everywhere = 3
     option_any_race_lotv = 4
-    default = option_lotv_protoss
+    default = option_vanilla
 
     # Fix case
     @classmethod
     def get_option_name(cls, value: int) -> str:
-        if value == SpearOfAdunPresence.option_lotv_protoss:
-            return "LotV Protoss"
+        if value == SpearOfAdunPresence.option_any_race_lotv:
+            return "Any Race LotV"
         else:
             return super().get_option_name(value)
 
@@ -1646,6 +1646,30 @@ def get_excluded_missions(world: 'SC2World') -> Set[SC2Mission]:
                 excluded_missions = excluded_missions.union(variants)
 
     return excluded_missions
+
+
+def is_mission_in_soa_presence(
+    spear_of_adun_presence: int,
+    mission: SC2Mission,
+    option_class: Type[SpearOfAdunPresence] | Type[SpearOfAdunPassiveAbilityPresence] = SpearOfAdunPresence
+) -> bool:
+    """
+    Returns True if the mission can have Spear of Adun abilities.
+    No-build presence must be checked separately.
+    """
+    return (
+        (spear_of_adun_presence == option_class.option_everywhere)
+        or (spear_of_adun_presence == option_class.option_protoss and MissionFlag.Protoss in mission.flags)
+        or (spear_of_adun_presence == option_class.option_any_race_lotv
+            and (mission.campaign == SC2Campaign.LOTV or mission == SC2Mission.INTO_THE_VOID)
+        )
+        or (spear_of_adun_presence == option_class.option_vanilla
+            and (MissionFlag.VanillaSoa in mission.flags  # Keeps SOA off on Growing Shadow, as that's vanilla behaviour
+                or (MissionFlag.NoBuild in mission.flags and mission.campaign == SC2Campaign.LOTV)
+            )
+        )
+    )
+
 
 
 static_mission_orders = [

--- a/worlds/sc2/regions.py
+++ b/worlds/sc2/regions.py
@@ -91,6 +91,8 @@ def adjust_mission_pools(world: 'SC2World', pools: SC2MOGenMissionPools):
         pools.move_mission(SC2Mission.DEVILS_PLAYGROUND_Z, Difficulty.EASY, Difficulty.STARTER)
         pools.move_mission(SC2Mission.DEVILS_PLAYGROUND_P, Difficulty.EASY, Difficulty.STARTER)
         if world.options.required_tactics != RequiredTactics.option_any_units:
+            # Per playtester feedback: doing this mission with only one unit is flaky
+            # but there are enough viable comps that >= 2 random units is probably workable
             pools.move_mission(SC2Mission.THE_GREAT_TRAIN_ROBBERY, Difficulty.EASY, Difficulty.STARTER)
             pools.move_mission(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z, Difficulty.EASY, Difficulty.STARTER)
             pools.move_mission(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P, Difficulty.EASY, Difficulty.STARTER)

--- a/worlds/sc2/regions.py
+++ b/worlds/sc2/regions.py
@@ -90,9 +90,10 @@ def adjust_mission_pools(world: 'SC2World', pools: SC2MOGenMissionPools):
         pools.move_mission(SC2Mission.DEVILS_PLAYGROUND, Difficulty.EASY, Difficulty.STARTER)
         pools.move_mission(SC2Mission.DEVILS_PLAYGROUND_Z, Difficulty.EASY, Difficulty.STARTER)
         pools.move_mission(SC2Mission.DEVILS_PLAYGROUND_P, Difficulty.EASY, Difficulty.STARTER)
-        pools.move_mission(SC2Mission.THE_GREAT_TRAIN_ROBBERY, Difficulty.EASY, Difficulty.STARTER)
-        pools.move_mission(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z, Difficulty.EASY, Difficulty.STARTER)
-        pools.move_mission(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P, Difficulty.EASY, Difficulty.STARTER)
+        if world.options.required_tactics != RequiredTactics.option_any_units:
+            pools.move_mission(SC2Mission.THE_GREAT_TRAIN_ROBBERY, Difficulty.EASY, Difficulty.STARTER)
+            pools.move_mission(SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z, Difficulty.EASY, Difficulty.STARTER)
+            pools.move_mission(SC2Mission.THE_GREAT_TRAIN_ROBBERY_P, Difficulty.EASY, Difficulty.STARTER)
         # LotV
         pools.move_mission(SC2Mission.THE_GROWING_SHADOW, Difficulty.EASY, Difficulty.STARTER)
         if shuffle_no_build == ShuffleNoBuild.option_false:


### PR DESCRIPTION
## What is this fixing or adding?
Adding the much-requested LotV any race option to SOA presence options.

To save myself having to touch triggers at all, I did all the option sending logic in the client. The client has all the information anyways, so not much logic should be necessary on the mod-side anyways. I still tried to accurately send things around

Also stopped moving trains to starter mission pool on any_units

### Notes
This change only ever sets the SOA presence bitfield values to 0 or 3. This means the mod-side logic in `AP_Triggers_checkSoA` can now be simplified to only look at 1 bit at a time, and not do special processing depending on what mission it is. I have not done that locally, that would be a separate PR

Currently any_race_lotv and vanilla behave slightly differently around Growing Shadow. In vanilla presence, Growing Shadow does not have SOA as you only unlock that in the next mission. But I'm treating any_race_lotv like the name implies, where Growing Shadow _is_ a lotv mission. I could see people wanting to change this, but when I asked people didn't feel too strongly. I personally want a true vanilla option but don't think it's worth having two slightly-different options to include/exclude Growing Shadow.

## How was this tested?
* Set SoA presence to any LotV, set passive presence to LotV protoss, gave orbital strike and reconstruction beam
* Started Templar's Charge (Terran) -- verified that SOA actives were present and passives were not
<img width="823" height="228" alt="image" src="https://github.com/user-attachments/assets/3e594280-0e2c-435b-925a-01c9da9d98ab" />

* Started Infested (Protoss) -- verified SOA did not appear
* Started Rak'Shir (Protoss) -- verified SOA actives and passives both appeared
<img width="773" height="278" alt="image" src="https://github.com/user-attachments/assets/a284076d-91e0-4f30-a908-05f570662cd3" />

* After updating the PR, tested again on any_race_lotv and verified:
  * Sky Shield (Terran) had SOA
  * For Aiur! had SOA (with presence in nobuild)
  * Into the Void had SOA
  * Shatter the Sky (Protoss) did not have SOA

## If this makes graphical changes, please attach screenshots.
None