### PR TITLE
sc2: Add fact/starport req for biomech stockpiling

### DIFF
--- a/worlds/sc2/item/item_parents.py
+++ b/worlds/sc2/item/item_parents.py
@@ -140,6 +140,9 @@ parent_present[parent_names.BANELING_SOURCE] = AnyOf(
     item_names.ZERGLING_BANELING_ASPECT,
 )
 parent_present[parent_names.INFESTED_UNITS] = AnyOf(item_groups.infterr_units, display_string='Infested')
+parent_present[parent_names.INFESTED_FACTORY_OR_STARPORT] = AnyOf(
+    (item_names.INFESTED_DIAMONDBACK, item_names.INFESTED_SIEGE_TANK, item_names.INFESTED_LIBERATOR, item_names.INFESTED_BANSHEE, item_names.BULLFROG)
+)
 parent_present[parent_names.MORPH_SOURCE_AIR] = MorphlingOrAnyOf((item_names.MUTALISK, item_names.CORRUPTOR), "Mutalisk/Corruptor Morphs")
 parent_present[parent_names.MORPH_SOURCE_ROACH] = MorphlingOrItem(item_names.ROACH)
 parent_present[parent_names.MORPH_SOURCE_ZERGLING] = MorphlingOrItem(item_names.ZERGLING)

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1560,7 +1560,7 @@ item_table = {
     item_names.ZERG_CREEP_STOMACH: ItemData(705 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 10, SC2Race.ZERG),
     item_names.HIVE_CLUSTER_MATURATION: ItemData(706 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 12, SC2Race.ZERG),
     item_names.MACROSCOPIC_RECUPERATION: ItemData(707 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 13, SC2Race.ZERG),
-    item_names.BIOMECHANICAL_STOCKPILING: ItemData(708 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 14, SC2Race.ZERG),
+    item_names.BIOMECHANICAL_STOCKPILING: ItemData(708 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 14, SC2Race.ZERG, parent=parent_names.INFESTED_FACTORY_OR_STARPORT),
     item_names.BROODLING_SPORE_SATURATION: ItemData(709 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 15, SC2Race.ZERG),
     item_names.CELL_DIVISION: ItemData(710 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 16, SC2Race.ZERG, parent=parent_names.ZERG_MERCENARIES),
     item_names.SELF_SUFFICIENT: ItemData(711 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 17, SC2Race.ZERG, parent=parent_names.ZERG_MERCENARIES),

--- a/worlds/sc2/item/parent_names.py
+++ b/worlds/sc2/item/parent_names.py
@@ -22,6 +22,7 @@ TERRAN_MERCENARIES = "Terran Mercenaries"
 ANY_NYDUS_WORM = "Any Nydus Worm"
 BANELING_SOURCE = "Any Baneling Source"  # Baneling aspect | Kerrigan Spawn Banelings
 INFESTED_UNITS = "Infested Units"
+INFESTED_FACTORY_OR_STARPORT = "Infested Factory or Starport"
 MORPH_SOURCE_AIR = "Air Morph Source"  # Morphling | Mutalisk | Corruptor
 MORPH_SOURCE_ROACH = "Roach Morph Source"  # Morphling | Roach
 MORPH_SOURCE_ZERGLING = "Zergling Morph Source"  # Morphling | Zergling


### PR DESCRIPTION
## What is this fixing or adding?
Create a new parent for the Biomechanical Stockpiling upgrade, requiring an infested factory or infested starport to be buildable.

## How was this tested?
1. Excluded all units which are built from infested factory and infested starport in YAML file
2. Generated a world with enough locations to generate filler items
3. Checked Spoiler.txt in generated world for presence of Biomechanical Stockpiling upgrade
4. Didn't find one 🥳