### PR TITLE
sc2: Add infested missile turret to infested terran items

### DIFF
--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -663,10 +663,13 @@ item_name_groups[ItemGroupNames.INF_TERRAN_UPGRADES] = infterr_upgrades = [
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_SIEGE_TANK,
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_LIBERATOR,
     item_names.FRIGHTFUL_FLESHWELDER_INFESTED_BANSHEE,
+    item_names.INFESTED_MISSILE_TURRET_BIOELECTRIC_PAYLOAD,
+    item_names.INFESTED_MISSILE_TURRET_ACID_SPORE_VENTS,
 ]
 item_name_groups[ItemGroupNames.INF_TERRAN_ITEMS] = (
     infterr_units
     + infterr_upgrades
+    + [item_names.INFESTED_MISSILE_TURRET]
 )
 
 # Protoss


### PR DESCRIPTION
## What is this fixing or adding?
Adds infested missile turrets to the infested Terran items group, and its upgrades to the infested Terran upgrades group. Feel free to reject this change, but I feel like it fits.

## How was this tested?
1. Add `infested terran items` group to `start_inventory` in YAML file
2. Generate world
3. Check Spoiler.txt file for presence of infested missile turret and upgrades
4. Find them 🥳
