### PR TITLE
Mm/tracker fix

### DIFF
--- a/WebHostLib/static/styles/sc2Tracker.css
+++ b/WebHostLib/static/styles/sc2Tracker.css
@@ -89,6 +89,10 @@ input[type="checkbox"]{
 .item-counter img{
   filter: none;
 }
+.spacer{
+  width: var(--icon-size);
+  height: var(--icon-size);
+}
 
 /* Item groups */
 .item-class{

--- a/WebHostLib/static/styles/sc2Tracker.css
+++ b/WebHostLib/static/styles/sc2Tracker.css
@@ -1,332 +1,280 @@
-* {
-    margin: 0;
-    font-family: "JuraBook", monospace;
+*{
+  margin: 0;
+  font-family: "JuraBook", monospace;
 }
-
-body {
-    --icon-size: 36px;
-    --item-class-padding: 4px;
+body{
+  --icon-size: 36px;
+  --item-class-padding: 4px;
 }
-
-a {
-    color: #1ae;
+a{
+  color: #1ae;
 }
 
 /* Section colours */
-#player-info {
-    background-color: #37a;
+#player-info{
+  background-color: #37a;
 }
-
-.player-tracker {
-    max-width: 100%;
+.player-tracker{
+  max-width: 100%;
 }
-
-.tracker-section {
-    background-color: grey;
+.tracker-section{
+  background-color: grey;
 }
-
-#terran-items {
-    background-color: #3a7;
+#terran-items{
+  background-color: #3a7;
 }
-
-#zerg-items {
-    background-color: #d94;
+#zerg-items{
+  background-color: #d94;
 }
-
-#protoss-items {
-    background-color: #37a;
+#protoss-items{
+  background-color: #37a;
 }
-
-#nova-items {
-    background-color: #777;
+#nova-items{
+  background-color: #777;
 }
-
-#kerrigan-items {
-    background-color: #a37;
+#kerrigan-items{
+  background-color: #a37;
 }
-
-#keys {
-    background-color: #aa2;
+#keys{
+  background-color: #aa2;
 }
 
 /* Sections */
-.section-body {
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: flex-start;
-    align-items: flex-start;
-    padding-bottom: 3px;
+.section-body{
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: flex-start;
+  align-items: flex-start;
+  padding-bottom: 3px;
 }
-
-.section-body-2 {
-    display: flex;
-    flex-direction: column;
+.section-body-2{
+  display: flex;
+  flex-direction: column;
 }
-
 .tracker-section:has(input.collapse-section[type=checkbox]:checked) .section-body,
-.tracker-section:has(input.collapse-section[type=checkbox]:checked) .section-body-2 {
-    display: none;
+.tracker-section:has(input.collapse-section[type=checkbox]:checked) .section-body-2{
+  display: none;
 }
-
-.section-title {
-    position: relative;
-    border-bottom: 3px solid black;
-    /* Prevent text selection */
-    user-select: none;
-    -webkit-user-select: none;
-    -ms-user-select: none;
+.section-title{
+  position: relative;
+  border-bottom: 3px solid black;
+  /* Prevent text selection */
+  user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
 }
-
-input[type="checkbox"] {
-    position: absolute;
-    cursor: pointer;
-    opacity: 0;
-    z-index: 1;
-    width: 100%;
-    height: 100%;
+input[type="checkbox"]{
+  position: absolute;
+  cursor: pointer;
+  opacity: 0;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
 }
-
-.section-title:hover h2 {
-    text-shadow: 0 0 4px #ddd;
+.section-title:hover h2{
+  text-shadow: 0 0 4px #ddd;
 }
 
 /* Acquire item filters */
-.tracker-section img {
-    height: 100%;
-    max-width: var(--icon-size);
-    max-height: var(--icon-size);
-    filter: grayscale(100%) contrast(80%) brightness(42%) blur(0.5px);
-    background-color: black;
+.tracker-section img{
+  height: 100%;
+  max-width: var(--icon-size);
+  max-height: var(--icon-size);
+  filter: grayscale(100%) contrast(80%) brightness(42%) blur(0.5px);
+  background-color: black;
 }
-
-.tracker-section img.acquired {
-    filter: none;
+.tracker-section img.acquired{
+  filter: none;
 }
-
-.item-counter img {
-    filter: none;
-}
-
-.spacer {
-    width: var(--icon-size);
-    height: var(--icon-size);
+.item-counter img{
+  filter: none;
 }
 
 /* Item groups */
-.item-class {
-    display: flex;
-    flex-flow: column;
-    justify-content: center;
-    padding: var(--item-class-padding);
+.item-class{
+  display: flex;
+  flex-flow: column;
+  justify-content: center;
+  padding: var(--item-class-padding);
 }
-
-.item-class-header {
-    display: flex;
-    flex-flow: row;
+.item-class-header{
+  display: flex;
+  flex-flow: row;
 }
-
-.item-class-upgrades {
-    /* Note: {display: flex; flex-flow: column wrap} */
-    /* just breaks on Firefox (width does not scale to content) */
-    display: grid;
-    grid-template-rows: repeat(4, auto);
-    grid-auto-flow: column;
+.item-class-upgrades{
+  /* Note: {display: flex; flex-flow: column wrap} */
+  /* just breaks on Firefox (width does not scale to content) */
+  display: grid;
+  grid-template-rows: repeat(4, auto);
+  grid-auto-flow: column;
 }
 
 /* Subsections */
-.section-toc {
-    display: flex;
-    flex-direction: row;
+.section-toc{
+  display: flex;
+  flex-direction: row;
 }
-
-.toc-box {
-    position: relative;
-    padding-left: 15px;
-    padding-right: 15px;
+.toc-box{
+  position: relative;
+  padding-left: 15px;
+  padding-right: 15px;
 }
-
-.toc-box:hover {
-    text-shadow: 0 0 7px white;
+.toc-box:hover{
+  text-shadow: 0 0 7px white;
 }
-
-.ss-header {
-    position: relative;
-    text-align: center;
-    writing-mode: sideways-lr;
-    user-select: none;
-    padding-top: 5px;
-    font-size: 115%;
+.ss-header{
+  position: relative;
+  text-align: center;
+  writing-mode: sideways-lr;
+  user-select: none;
+  padding-top: 5px;
+  font-size: 115%;
 }
-
-.tracker-section:has(input.ss-1-toggle:checked) .ss-1 {
-    display: none;
+.tracker-section:has(input.ss-1-toggle:checked) .ss-1{
+  display: none;
 }
-
-.tracker-section:has(input.ss-2-toggle:checked) .ss-2 {
-    display: none;
+.tracker-section:has(input.ss-2-toggle:checked) .ss-2{
+  display: none;
 }
-
-.tracker-section:has(input.ss-3-toggle:checked) .ss-3 {
-    display: none;
+.tracker-section:has(input.ss-3-toggle:checked) .ss-3{
+  display: none;
 }
-
-.tracker-section:has(input.ss-4-toggle:checked) .ss-4 {
-    display: none;
+.tracker-section:has(input.ss-4-toggle:checked) .ss-4{
+  display: none;
 }
-
-.tracker-section:has(input.ss-5-toggle:checked) .ss-5 {
-    display: none;
+.tracker-section:has(input.ss-5-toggle:checked) .ss-5{
+  display: none;
 }
-
-.tracker-section:has(input.ss-6-toggle:checked) .ss-6 {
-    display: none;
+.tracker-section:has(input.ss-6-toggle:checked) .ss-6{
+  display: none;
 }
-
-.tracker-section:has(input.ss-7-toggle:checked) .ss-7 {
-    display: none;
+.tracker-section:has(input.ss-7-toggle:checked) .ss-7{
+  display: none;
 }
-
-.tracker-section:has(input.ss-1-toggle:hover) .ss-1 {
-    background-color: #fff5;
-    box-shadow: 0 0 1px 1px white;
+.tracker-section:has(input.ss-1-toggle:hover) .ss-1{
+  background-color: #fff5;
+  box-shadow: 0 0 1px 1px white;
 }
-
-.tracker-section:has(input.ss-2-toggle:hover) .ss-2 {
-    background-color: #fff5;
-    box-shadow: 0 0 1px 1px white;
+.tracker-section:has(input.ss-2-toggle:hover) .ss-2{
+  background-color: #fff5;
+  box-shadow: 0 0 1px 1px white;
 }
-
-.tracker-section:has(input.ss-3-toggle:hover) .ss-3 {
-    background-color: #fff5;
-    box-shadow: 0 0 1px 1px white;
+.tracker-section:has(input.ss-3-toggle:hover) .ss-3{
+  background-color: #fff5;
+  box-shadow: 0 0 1px 1px white;
 }
-
-.tracker-section:has(input.ss-4-toggle:hover) .ss-4 {
-    background-color: #fff5;
-    box-shadow: 0 0 1px 1px white;
+.tracker-section:has(input.ss-4-toggle:hover) .ss-4{
+  background-color: #fff5;
+  box-shadow: 0 0 1px 1px white;
 }
-
-.tracker-section:has(input.ss-5-toggle:hover) .ss-5 {
-    background-color: #fff5;
-    box-shadow: 0 0 1px 1px white;
+.tracker-section:has(input.ss-5-toggle:hover) .ss-5{
+  background-color: #fff5;
+  box-shadow: 0 0 1px 1px white;
 }
-
-.tracker-section:has(input.ss-6-toggle:hover) .ss-6 {
-    background-color: #fff5;
-    box-shadow: 0 0 1px 1px white;
+.tracker-section:has(input.ss-6-toggle:hover) .ss-6{
+  background-color: #fff5;
+  box-shadow: 0 0 1px 1px white;
 }
-
-.tracker-section:has(input.ss-7-toggle:hover) .ss-7 {
-    background-color: #fff5;
-    box-shadow: 0 0 1px 1px white;
+.tracker-section:has(input.ss-7-toggle:hover) .ss-7{
+  background-color: #fff5;
+  box-shadow: 0 0 1px 1px white;
 }
 
 /* Progressive items */
-.progressive {
-    max-height: var(--icon-size);
-    display: contents;
+.progressive{
+  max-height: var(--icon-size);
+  display: contents;
 }
 
 .lvl-1 img, .lvl-2 img,
 .lvl-3 img, .lvl-4 img,
-.lvl-5 img {
-    filter: none;
+.lvl-5 img{
+  filter: none;
 }
-
 .lvl-0 :nth-child(2),
 .lvl-0 :nth-child(3),
 .lvl-0 :nth-child(4),
-.lvl-0 :nth-child(5) {
-    display: none;
+.lvl-0 :nth-child(5){
+  display: none;
 }
-
 .lvl-1 :nth-child(2),
 .lvl-1 :nth-child(3),
 .lvl-1 :nth-child(4),
-.lvl-1 :nth-child(5) {
-    display: none;
+.lvl-1 :nth-child(5){
+  display: none;
 }
-
 .lvl-2 :nth-child(1),
 .lvl-2 :nth-child(3),
 .lvl-2 :nth-child(4),
-.lvl-2 :nth-child(5) {
-    display: none;
+.lvl-2 :nth-child(5){
+  display: none;
 }
-
 .lvl-3 :nth-child(1),
 .lvl-3 :nth-child(2),
 .lvl-3 :nth-child(4),
-.lvl-3 :nth-child(5) {
-    display: none;
+.lvl-3 :nth-child(5){
+  display: none;
 }
-
 .lvl-4 :nth-child(1),
 .lvl-4 :nth-child(2),
 .lvl-4 :nth-child(3),
-.lvl-4 :nth-child(5) {
-    display: none;
+.lvl-4 :nth-child(5){
+  display: none;
 }
-
 .lvl-5 :nth-child(1),
 .lvl-5 :nth-child(2),
 .lvl-5 :nth-child(3),
-.lvl-5 :nth-child(4) {
-    display: none;
+.lvl-5 :nth-child(4){
+  display: none;
 }
 
 /* Filler item counters */
-.item-counter {
-    display: table;
-    text-align: center;
-    padding: var(--item-class-padding);
+.item-counter{
+  display: table;
+  text-align: center;
+  padding: var(--item-class-padding);
 }
-
-.item-count {
-    display: table-cell;
-    vertical-align: middle;
-    padding-left: 3px;
-    padding-right: 15px;
+.item-count{
+  display: table-cell;
+  vertical-align: middle;
+  padding-left: 3px;
+  padding-right: 15px;
 }
 
 /* Hidden items */
-.hidden-class:not(:has(img.acquired)) {
-    display: none;
+.hidden-class:not(:has(img.acquired)){
+  display: none;
 }
-
-.hidden-item:not(.acquired) {
-    display: none;
+.hidden-item:not(.acquired){
+  display:none;
 }
 
 /* Keys */
-#keys ol, #keys ul {
-    columns: 3;
-    -webkit-columns: 3;
-    -moz-columns: 3;
+#keys ol, #keys ul{
+  columns: 3;
+  -webkit-columns: 3;
+  -moz-columns: 3;
 }
-
-#keys li {
-    padding-right: 15pt;
+#keys li{
+  padding-right: 15pt;
 }
 
 /* Locations */
-#section-locations {
+#section-locations{
     padding-left: 5px;
 }
-
-@media only screen and (min-width: 120ch) {
-    #section-locations ul {
-        columns: 2;
-        -webkit-columns: 2;
-        -moz-columns: 2;
-    }
+@media only screen and (min-width: 120ch){
+  #section-locations ul{
+    columns: 2;
+    -webkit-columns: 2;
+    -moz-columns: 2;
+  }
 }
-
-#locations li.checked {
-    list-style-type: "✔ ";
+#locations li.checked{
+  list-style-type: "✔ ";
 }
 
 /* Allowing scrolling down a little further */
-.bottom-padding {
-    min-height: 33vh;
+.bottom-padding{
+  min-height: 33vh;
 }

--- a/WebHostLib/templates/tracker__Starcraft2.html
+++ b/WebHostLib/templates/tracker__Starcraft2.html
@@ -13,7 +13,7 @@
   </div>
   <div id="player-tracker" data-tracker="{{ room.tracker|suuid }}">
     <div id="player-info">
-      <h1>{{ player_name }}&apos;s Starcraft 2 Tracker{{' - Finished' if game_finished}}</h3>
+      <h1>{{ player_name }}&apos;s Starcraft 2 Tracker{{' - Finished' if game_finished}}</h1>
     </div>
     <div id="filler-items" class="tracker-section">
       <div class="section-title">
@@ -1040,7 +1040,7 @@
             <img id="Centrifugal Hooks (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-zerg-centrifugalhooks.png" title="Centrifugal Hooks (Baneling)&#10;Increases the movement speed of Banelings." class="{{'acquired' if inventory[2231] > 0}}">
             <img id="Corrosive Acid (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-zerg-corrosiveacid.png" title="Corrosive Acid (Baneling)&#10;Increases the damage banelings deal to their primary target. Splash damage remains the same." class="{{'acquired' if inventory[2209] > 0}}">
             <img id="Hunter Strain (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-unit-zerg-baneling-hunter.png" title="Hunter Strain (Baneling)&#10;Allows Banelings to jump up and down cliffs and leap onto enemies." class="{{'acquired' if inventory[2307] > 0}}">
-            <img id="Rapid Metamorph (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-rapid-metamorph.png" title="Rapid Metamorph (Baneling)&#10;Banelings morph faster." class="{{'acquired' if inventory[2233] > 0}}">
+            <img id="Rapid Metamorph (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-rapid-metamorph.png" title="Rapid Metamorph (Baneling)&#10;Banelings morph faster and no longer cost vespene gas to morph." class="{{'acquired' if inventory[2233] > 0}}">
             <img id="Regenerative Acid (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-zerg-regenerativebile.png" title="Regenerative Acid (Baneling)&#10;Banelings will heal nearby friendly units when they explode." class="{{'acquired' if inventory[2211] > 0}}">
             <img id="Rupture (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-zerg-rupture.png" title="Rupture (Baneling)&#10;Increases the splash radius of baneling attacks." class="{{'acquired' if inventory[2210] > 0}}">
             <img id="Splitter Strain (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/talent-zagara-level14-unlocksplitterling.png" title="Splitter Strain (Baneling)&#10;Banelings will split into two smaller Splitterlings on exploding." class="{{'acquired' if inventory[2306] > 0}}">
@@ -1283,6 +1283,9 @@
           </div>
         </div>
         <div id="class-zerg-worm" class="item-class ss-5">
+          <div class="item-class-header">
+            <div class="spacer"></div>
+          </div>
           <div class="item-class-upgrades">
             <img id="Jormungandr Strain (Nydus Worm/Echidna Worm)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-zerg-enduringcorruption.png" title="Jormungandr Strain (Nydus Worm/Echidna Worm)&#10;Removes emerge time for Nydus Worm and Echidna Worm, and allows them to be salvaged to return the resources spent on them." class="{{'acquired' if inventory[2355] > 0}}">
             <img id="Resource Efficiency (Nydus Worm/Echidna Worm)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-hornerhan-salvagebonus.png" title="Resource Efficiency (Nydus Worm/Echidna Worm)&#10;Reduces Nydus Worm and Echidna Worm cost by 50 minerals and 75 gas." class="{{'acquired' if inventory[2356] > 0}}">
@@ -1439,6 +1442,9 @@
           </div>
         </div>
         <div id="class-zealot-tier" class="item-class ss-1">
+          <div class="item-class-header">
+            <div class="spacer"></div>
+          </div>
           <div class="item-class-upgrades">
             <img id="Leg Enhancements (Zealot/Sentinel/Centurion)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-protoss-lightningdash.png" title="Leg Enhancements (Zealot/Sentinel/Centurion)&#10;Zealots, Sentinels, and Centurions gain increased movement speed." class="{{'acquired' if inventory[3376] > 0}}">
             <img id="Shield Capacity (Zealot/Sentinel/Centurion)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-shield-capacity.png" title="Shield Capacity (Zealot/Sentinel/Centurion)&#10;Zealots, Sentinels, and Centurions gain +30 maximum shields." class="{{'acquired' if inventory[3377] > 0}}">
@@ -1483,6 +1489,9 @@
           </div>
         </div>
         <div id="class-stalker-tier" class="item-class ss-1">
+          <div class="item-class-header">
+            <div class="spacer"></div>
+          </div>
           <div class="item-class-upgrades">
             <img id="Disintegrating Particles (Stalker/Instigator/Slayer)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-disintegrating-particles.png" title="Disintegrating Particles (Stalker/Instigator/Slayer)&#10;Increases weapon damage of Stalkers, Instigators, and Slayers." class="{{'acquired' if inventory[3306] > 0}}">
             <img id="Particle Reflection (Stalker/Instigator/Slayer)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-fenix-adeptchampionbounceattack.png" title="Particle Reflection (Stalker/Instigator/Slayer)&#10;Attacks fired by Stalkers, Instigators, and Slayers have a chance to bounce to additional targets for reduced damage." class="{{'acquired' if inventory[3307] > 0}}">
@@ -1519,6 +1528,9 @@
           </div>
         </div>
         <div id="class-sentry-tier" class="item-class ss-1">
+          <div class="item-class-header">
+            <div class="spacer"></div>
+          </div>
           <div class="item-class-upgrades">
             <img id="Cloaking Module (Sentry/Energizer/Havoc)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-alarak-permanentcloak.png" title="Cloaking Module (Sentry/Energizer/Havoc)&#10;Sentries, Energizers, and Havocs become permanently cloaked." class="{{'acquired' if inventory[3368] > 0}}">
             <img id="Rapid Recharging (Sentry/Energizer/Havoc/Shield Battery)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-karax-energyregen200.png" title="Rapid Recharging (Sentry/Energizer/Havoc/Shield Battery)&#10;Sentries, Energizers, and Havocs gain +100% energy regeneration rate." class="{{'acquired' if inventory[3369] > 0}}">
@@ -1576,6 +1588,9 @@
           </div>
         </div>
         <div id="class-high-templar-tier" class="item-class ss-1">
+          <div class="item-class-header">
+            <div class="spacer"></div>
+          </div>
           <div class="item-class-upgrades">
             <img id="Hallucination (High Templar/Signifier)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-protoss-hallucination-color.png" title="Hallucination (High Templar/Signifier)&#10;High Templar and Signifiers gain the Hallucination ability, &#10;which creates 2 hallucinated copies of a target unit." class="{{'acquired' if inventory[3359] > 0}}">
             <img id="Khaydarin Amulet (High Templar/Signifier)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-khaydarinamulet.png" title="Khaydarin Amulet (High Templar/Signifier)&#10;High Templar and Signifiers gain +150 starting energy and +50 maximum energy." class="{{'acquired' if inventory[3360] > 0}}">
@@ -1583,6 +1598,9 @@
           </div>
         </div>
         <div id="class-archon" class="item-class ss-1">
+          <div class="item-class-header">
+            <div class="spacer"></div>
+          </div>
           <div class="item-class-upgrades">
             <img id="High Archon (Archon)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-unit-protoss-archon-upgraded.png" title="High Archon (Archon)&#10;Archons can use High Templar abilities." class="{{'acquired' if inventory[3361] > 0}}">
             <img id="Transcendence (Archon)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-protoss-astralwind.png" title="Transcendence (Archon)&#10;Archons can float in the air. Can traverse cliffs and phase through most units. Increases Archon attack range by 1." class="{{'acquired' if inventory[3391] > 0}}">
@@ -1630,6 +1648,9 @@
           </div>
         </div>
         <div id="class-dark-templar-tier" class="item-class ss-1">
+          <div class="item-class-header">
+            <div class="spacer"></div>
+          </div>
           <div class="item-class-upgrades">
             <img id="Blink (Dark Templar/Avenger/Blood Hunter)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-protoss-shadowdash.png" title="Blink (Dark Templar/Avenger/Blood Hunter)&#10;Dark Templar, Avengers, and Blood Hunters gain the Blink ability." class="{{'acquired' if inventory[3355] > 0}}">
             <img id="Resource Efficiency (Dark Templar/Avenger/Blood Hunter)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-hornerhan-salvagebonus.png" title="Resource Efficiency (Dark Templar/Avenger/Blood Hunter)&#10;Reduces Dark Templar, Avenger, and Blood Hunter cost by 50 gas." class="{{'acquired' if inventory[3356] > 0}}">
@@ -1657,6 +1678,9 @@
           </div>
         </div>
         <div id="class-immortal-tier" class="item-class ss-2">
+          <div class="item-class-header">
+            <div class="spacer"></div>
+          </div>
           <div class="item-class-upgrades">
             <img id="Advanced Targeting (Immortal/Annihilator)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-advanced-targeting.png" title="Advanced Targeting (Immortal/Annihilator)&#10;Immortals and Annihilators can attack air units." class="{{'acquired' if inventory[3349] > 0}}">
             <img id="Disruptor Dispersion (Immortal/Annihilator)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-disruptor-dispersion.png" title="Disruptor Dispersion (Immortal/Annihilator)&#10;Immortals and Annihilators deal minor splash damage." class="{{'acquired' if inventory[3380] > 0}}">
@@ -1778,6 +1802,9 @@
           </div>
         </div>
         <div id="class-phoenix-tier" class="item-class ss-3">
+          <div class="item-class-header">
+            <div class="spacer"></div>
+          </div>
           <div class="item-class-upgrades">
             <img id="Anion Pulse-Crystals (Phoenix/Mirage/Skirmisher)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-phoenixrange.png" title="Anion Pulse-Crystals (Phoenix/Mirage/Skirmisher)&#10;Increases Phoenix, Mirage, and Skirmiser range by +2." class="{{'acquired' if inventory[3320] > 0}}">
             <img id="Ionic Wavelength Flux (Phoenix/Mirage/Skirmisher)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-iconic-wavelength-flux.png" title="Ionic Wavelength Flux (Phoenix/Mirage/Skirmisher)&#10;Increases Phoenix, Mirage, and Skirmisher weapon damage by +2." class="{{'acquired' if inventory[3319] > 0}}">
@@ -1833,6 +1860,9 @@
           </div>
         </div>
         <div id="class-void-ray-tier" class="item-class ss-3">
+          <div class="item-class-header">
+            <div class="spacer"></div>
+          </div>
           <div class="item-class-upgrades">
             <img id="Flux Vanes (Void Ray/Destroyer/Pulsar/Dawnbringer)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-fluxvanes.png" title="Flux Vanes (Void Ray/Destroyer/Pulsar/Dawnbringer)&#10;Increases movement speed of Void Ray variants." class="{{'acquired' if inventory[3335] > 0}}">
           </div>
@@ -1880,6 +1910,9 @@
           </div>
         </div>
         <div id="class-scout-tier" class="item-class ss-3">
+          <div class="item-class-header">
+            <div class="spacer"></div>
+          </div>
           <div class="item-class-upgrades">
             <img id="Advanced Photon Blasters (Scout/Oppressor/Mist Wing)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-advanced-photon-blasters.png" title="Advanced Photon Blasters (Scout/Oppressor/Mist Wing)&#10;Scouts, Oppressors and Mist Wings gain increased damage against ground targets." class="{{'acquired' if inventory[3315] > 0}}">
             <img id="Combat Sensor Array (Scout/Oppressor/Caladrius/Mist Wing)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-fenix-scoutchampionrange.png" title="Combat Sensor Array (Scout/Oppressor/Caladrius/Mist Wing)&#10;All Scout variants gain increased range against air and ground." class="{{'acquired' if inventory[3312] > 0}}">
@@ -1911,6 +1944,9 @@
           </div>
         </div>
         <div id="class-carrier-tier" class="item-class ss-3">
+          <div class="item-class-header">
+            <div class="spacer"></div>
+          </div>
           <div class="item-class-upgrades">
             <img id="Hull of Past Glories (Carrier/Skylord/Trireme)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-hull-of-past-glories.png" title="Hull of Past Glories (Carrier/Skylord/Trireme)&#10;Carrier-class ships gain +2 armor." class="{{'acquired' if inventory[3334] > 0}}">
             <img id="Graviton Catapult (Carrier/Trireme)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-gravitoncatapult.png" title="Graviton Catapult (Carrier/Trireme)&#10;Carriers and Triremes can launch Interceptors and Bombers more quickly." class="{{'acquired' if inventory[3333] > 0}}">

--- a/WebHostLib/templates/tracker__Starcraft2.html
+++ b/WebHostLib/templates/tracker__Starcraft2.html
@@ -13,7 +13,7 @@
   </div>
   <div id="player-tracker" data-tracker="{{ room.tracker|suuid }}">
     <div id="player-info">
-      <h1>{{ player_name }}&apos;s Starcraft 2 Tracker{{' - Finished' if game_finished}}</h1>
+      <h1>{{ player_name }}&apos;s Starcraft 2 Tracker{{' - Finished' if game_finished}}</h3>
     </div>
     <div id="filler-items" class="tracker-section">
       <div class="section-title">
@@ -1040,7 +1040,7 @@
             <img id="Centrifugal Hooks (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-zerg-centrifugalhooks.png" title="Centrifugal Hooks (Baneling)&#10;Increases the movement speed of Banelings." class="{{'acquired' if inventory[2231] > 0}}">
             <img id="Corrosive Acid (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-zerg-corrosiveacid.png" title="Corrosive Acid (Baneling)&#10;Increases the damage banelings deal to their primary target. Splash damage remains the same." class="{{'acquired' if inventory[2209] > 0}}">
             <img id="Hunter Strain (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-unit-zerg-baneling-hunter.png" title="Hunter Strain (Baneling)&#10;Allows Banelings to jump up and down cliffs and leap onto enemies." class="{{'acquired' if inventory[2307] > 0}}">
-            <img id="Rapid Metamorph (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-rapid-metamorph.png" title="Rapid Metamorph (Baneling)&#10;Banelings morph faster and no longer cost vespene gas to morph." class="{{'acquired' if inventory[2233] > 0}}">
+            <img id="Rapid Metamorph (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-rapid-metamorph.png" title="Rapid Metamorph (Baneling)&#10;Banelings morph faster." class="{{'acquired' if inventory[2233] > 0}}">
             <img id="Regenerative Acid (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-zerg-regenerativebile.png" title="Regenerative Acid (Baneling)&#10;Banelings will heal nearby friendly units when they explode." class="{{'acquired' if inventory[2211] > 0}}">
             <img id="Rupture (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-zerg-rupture.png" title="Rupture (Baneling)&#10;Increases the splash radius of baneling attacks." class="{{'acquired' if inventory[2210] > 0}}">
             <img id="Splitter Strain (Baneling)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/talent-zagara-level14-unlocksplitterling.png" title="Splitter Strain (Baneling)&#10;Banelings will split into two smaller Splitterlings on exploding." class="{{'acquired' if inventory[2306] > 0}}">
@@ -1284,7 +1284,6 @@
         </div>
         <div id="class-zerg-worm" class="item-class ss-5">
           <div class="item-class-upgrades">
-            <div class="spacer"></div>
             <img id="Jormungandr Strain (Nydus Worm/Echidna Worm)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-zerg-enduringcorruption.png" title="Jormungandr Strain (Nydus Worm/Echidna Worm)&#10;Removes emerge time for Nydus Worm and Echidna Worm, and allows them to be salvaged to return the resources spent on them." class="{{'acquired' if inventory[2355] > 0}}">
             <img id="Resource Efficiency (Nydus Worm/Echidna Worm)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-hornerhan-salvagebonus.png" title="Resource Efficiency (Nydus Worm/Echidna Worm)&#10;Reduces Nydus Worm and Echidna Worm cost by 50 minerals and 75 gas." class="{{'acquired' if inventory[2356] > 0}}">
             <img id="Subterranean Scales (Nydus Worm/Echidna Worm)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-zerg-buildingarmor.png" title="Subterranean Scales (Nydus Worm/Echidna Worm)&#10;Increases Nydus Worm and Echidna Worm maximum health by 250 and armor by 1." class="{{'acquired' if inventory[2354] > 0}}">
@@ -1441,7 +1440,6 @@
         </div>
         <div id="class-zealot-tier" class="item-class ss-1">
           <div class="item-class-upgrades">
-            <div class="spacer"></div>
             <img id="Leg Enhancements (Zealot/Sentinel/Centurion)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-protoss-lightningdash.png" title="Leg Enhancements (Zealot/Sentinel/Centurion)&#10;Zealots, Sentinels, and Centurions gain increased movement speed." class="{{'acquired' if inventory[3376] > 0}}">
             <img id="Shield Capacity (Zealot/Sentinel/Centurion)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-shield-capacity.png" title="Shield Capacity (Zealot/Sentinel/Centurion)&#10;Zealots, Sentinels, and Centurions gain +30 maximum shields." class="{{'acquired' if inventory[3377] > 0}}">
           </div>
@@ -1486,7 +1484,6 @@
         </div>
         <div id="class-stalker-tier" class="item-class ss-1">
           <div class="item-class-upgrades">
-            <div class="spacer"></div>
             <img id="Disintegrating Particles (Stalker/Instigator/Slayer)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-disintegrating-particles.png" title="Disintegrating Particles (Stalker/Instigator/Slayer)&#10;Increases weapon damage of Stalkers, Instigators, and Slayers." class="{{'acquired' if inventory[3306] > 0}}">
             <img id="Particle Reflection (Stalker/Instigator/Slayer)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-fenix-adeptchampionbounceattack.png" title="Particle Reflection (Stalker/Instigator/Slayer)&#10;Attacks fired by Stalkers, Instigators, and Slayers have a chance to bounce to additional targets for reduced damage." class="{{'acquired' if inventory[3307] > 0}}">
           </div>
@@ -1523,7 +1520,6 @@
         </div>
         <div id="class-sentry-tier" class="item-class ss-1">
           <div class="item-class-upgrades">
-            <div class="spacer"></div>
             <img id="Cloaking Module (Sentry/Energizer/Havoc)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-alarak-permanentcloak.png" title="Cloaking Module (Sentry/Energizer/Havoc)&#10;Sentries, Energizers, and Havocs become permanently cloaked." class="{{'acquired' if inventory[3368] > 0}}">
             <img id="Rapid Recharging (Sentry/Energizer/Havoc/Shield Battery)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-karax-energyregen200.png" title="Rapid Recharging (Sentry/Energizer/Havoc/Shield Battery)&#10;Sentries, Energizers, and Havocs gain +100% energy regeneration rate." class="{{'acquired' if inventory[3369] > 0}}">
           </div>
@@ -1581,7 +1577,6 @@
         </div>
         <div id="class-high-templar-tier" class="item-class ss-1">
           <div class="item-class-upgrades">
-            <div class="spacer"></div>
             <img id="Hallucination (High Templar/Signifier)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-protoss-hallucination-color.png" title="Hallucination (High Templar/Signifier)&#10;High Templar and Signifiers gain the Hallucination ability, &#10;which creates 2 hallucinated copies of a target unit." class="{{'acquired' if inventory[3359] > 0}}">
             <img id="Khaydarin Amulet (High Templar/Signifier)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-khaydarinamulet.png" title="Khaydarin Amulet (High Templar/Signifier)&#10;High Templar and Signifiers gain +150 starting energy and +50 maximum energy." class="{{'acquired' if inventory[3360] > 0}}">
             <img id="Unshackled Psionic Storm (High Templar/Signifier)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-unshackled-psionic-storm.png" title="Unshackled Psionic Storm (High Templar/Signifier)&#10;High Templar and Signifiers deal increased damage with Psi Storm." class="{{'acquired' if inventory[3358] > 0}}">
@@ -1589,11 +1584,9 @@
         </div>
         <div id="class-archon" class="item-class ss-1">
           <div class="item-class-upgrades">
-            <div class="spacer"></div>
             <img id="High Archon (Archon)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-unit-protoss-archon-upgraded.png" title="High Archon (Archon)&#10;Archons can use High Templar abilities." class="{{'acquired' if inventory[3361] > 0}}">
             <img id="Transcendence (Archon)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-protoss-astralwind.png" title="Transcendence (Archon)&#10;Archons can float in the air. Can traverse cliffs and phase through most units. Increases Archon attack range by 1." class="{{'acquired' if inventory[3391] > 0}}">
             <img id="Power Siphon (Archon)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-protoss-shieldrecharge.png" title="Power Siphon (Archon)&#10;Archons gain the Power Siphon ability, &#10;which deals damage to a target and replenishes shields over 2 seconds." class="{{'acquired' if inventory[3392] > 0}}">
-            <div class="spacer"></div>
             <img id="Eradicate (Archon)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-protoss-recallondeath.png" title="Eradicate (Archon)&#10;On death, Archons launch towards nearby enemy ground units, dealing damage on impact." class="{{'acquired' if inventory[3393] > 0}}">
             <img id="Obliterate (Archon)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-obliterate.png" title="Obliterate (Archon)&#10;Archon attacks get increased area of effect, and deal their biological bonus damage to all targets." class="{{'acquired' if inventory[3394] > 0}}">
           </div>
@@ -1638,11 +1631,9 @@
         </div>
         <div id="class-dark-templar-tier" class="item-class ss-1">
           <div class="item-class-upgrades">
-            <div class="spacer"></div>
             <img id="Blink (Dark Templar/Avenger/Blood Hunter)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-protoss-shadowdash.png" title="Blink (Dark Templar/Avenger/Blood Hunter)&#10;Dark Templar, Avengers, and Blood Hunters gain the Blink ability." class="{{'acquired' if inventory[3355] > 0}}">
             <img id="Resource Efficiency (Dark Templar/Avenger/Blood Hunter)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-ability-hornerhan-salvagebonus.png" title="Resource Efficiency (Dark Templar/Avenger/Blood Hunter)&#10;Reduces Dark Templar, Avenger, and Blood Hunter cost by 50 gas." class="{{'acquired' if inventory[3356] > 0}}">
             <img id="Shadow Guard Training (Dark Templar/Avenger/Blood Hunter)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-shadow-guard-training.png" title="Shadow Guard Training (Dark Templar/Avenger/Blood Hunter)&#10;Increases Dark Templar, Avenger, and Blood Hunter maximum life by +40." class="{{'acquired' if inventory[3354] > 0}}">
-            <div class="spacer"></div>
             <img id="Shroud of Adun (Dark Templar/Avenger/Blood Hunter)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/talent-vorazun-level01-shadowstalk.png" title="Shroud of Adun (Dark Templar/Avenger/Blood Hunter)&#10;Increases Dark Templar, Avenger, and Blood Hunter maximum shields by +80." class="{{'acquired' if inventory[3353] > 0}}">
           </div>
         </div>
@@ -1667,7 +1658,6 @@
         </div>
         <div id="class-immortal-tier" class="item-class ss-2">
           <div class="item-class-upgrades">
-            <div class="spacer"></div>
             <img id="Advanced Targeting (Immortal/Annihilator)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-advanced-targeting.png" title="Advanced Targeting (Immortal/Annihilator)&#10;Immortals and Annihilators can attack air units." class="{{'acquired' if inventory[3349] > 0}}">
             <img id="Disruptor Dispersion (Immortal/Annihilator)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-disruptor-dispersion.png" title="Disruptor Dispersion (Immortal/Annihilator)&#10;Immortals and Annihilators deal minor splash damage." class="{{'acquired' if inventory[3380] > 0}}">
             <img id="Singularity Charge (Immortal/Annihilator)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-artanis-singularitycharge.png" title="Singularity Charge (Immortal/Annihilator)&#10;Increases Immortal and Annihilator attack range by +2." class="{{'acquired' if inventory[3348] > 0}}">
@@ -1789,7 +1779,6 @@
         </div>
         <div id="class-phoenix-tier" class="item-class ss-3">
           <div class="item-class-upgrades">
-            <div class="spacer"></div>
             <img id="Anion Pulse-Crystals (Phoenix/Mirage/Skirmisher)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-phoenixrange.png" title="Anion Pulse-Crystals (Phoenix/Mirage/Skirmisher)&#10;Increases Phoenix, Mirage, and Skirmiser range by +2." class="{{'acquired' if inventory[3320] > 0}}">
             <img id="Ionic Wavelength Flux (Phoenix/Mirage/Skirmisher)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-iconic-wavelength-flux.png" title="Ionic Wavelength Flux (Phoenix/Mirage/Skirmisher)&#10;Increases Phoenix, Mirage, and Skirmisher weapon damage by +2." class="{{'acquired' if inventory[3319] > 0}}">
           </div>
@@ -1845,7 +1834,6 @@
         </div>
         <div id="class-void-ray-tier" class="item-class ss-3">
           <div class="item-class-upgrades">
-            <div class="spacer"></div>
             <img id="Flux Vanes (Void Ray/Destroyer/Pulsar/Dawnbringer)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-fluxvanes.png" title="Flux Vanes (Void Ray/Destroyer/Pulsar/Dawnbringer)&#10;Increases movement speed of Void Ray variants." class="{{'acquired' if inventory[3335] > 0}}">
           </div>
         </div>
@@ -1893,7 +1881,6 @@
         </div>
         <div id="class-scout-tier" class="item-class ss-3">
           <div class="item-class-upgrades">
-            <div class="spacer"></div>
             <img id="Advanced Photon Blasters (Scout/Oppressor/Mist Wing)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-advanced-photon-blasters.png" title="Advanced Photon Blasters (Scout/Oppressor/Mist Wing)&#10;Scouts, Oppressors and Mist Wings gain increased damage against ground targets." class="{{'acquired' if inventory[3315] > 0}}">
             <img id="Combat Sensor Array (Scout/Oppressor/Caladrius/Mist Wing)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-fenix-scoutchampionrange.png" title="Combat Sensor Array (Scout/Oppressor/Caladrius/Mist Wing)&#10;All Scout variants gain increased range against air and ground." class="{{'acquired' if inventory[3312] > 0}}">
             <img id="Gravitic Thrusters (Scout/Oppressor/Caladrius/Mist Wing)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-gravitic-thrusters.png" title="Gravitic Thrusters (Scout/Oppressor/Caladrius/Mist Wing)&#10;All Scout variants gain increased movement speed." class="{{'acquired' if inventory[3314] > 0}}">
@@ -1925,7 +1912,6 @@
         </div>
         <div id="class-carrier-tier" class="item-class ss-3">
           <div class="item-class-upgrades">
-            <div class="spacer"></div>
             <img id="Hull of Past Glories (Carrier/Skylord/Trireme)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/original/btn-hull-of-past-glories.png" title="Hull of Past Glories (Carrier/Skylord/Trireme)&#10;Carrier-class ships gain +2 armor." class="{{'acquired' if inventory[3334] > 0}}">
             <img id="Graviton Catapult (Carrier/Trireme)" src="https://matthewmarinets.github.io/ap_sc2_icons/icons/blizzard/btn-upgrade-protoss-gravitoncatapult.png" title="Graviton Catapult (Carrier/Trireme)&#10;Carriers and Triremes can launch Interceptors and Bombers more quickly." class="{{'acquired' if inventory[3333] > 0}}">
           </div>


### PR DESCRIPTION
## What is this fixing or adding?
* Fixing some not-great codegen used to make the indented item groups (putting the spacer in the block header instead of multiple ones in the footer).
* Fixing the break from AP-mandated css styling

## How was this tested?
Ran webtracker -- sections are still indented.

## If this makes graphical changes, please attach screenshots.
<img width="1522" height="634" alt="image" src="https://github.com/user-attachments/assets/fd2940c4-cc12-4e29-a166-7f1e0489cf36" />
<img width="1516" height="425" alt="image" src="https://github.com/user-attachments/assets/dbac7ce3-fb1c-4010-bfd9-df8061f17d87" />
