### PR TITLE
sc2: Updating Nova vs stone logic rule on any units; tightening constraints on starting with mercs for any_units

### DIFF
--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -871,15 +871,15 @@ item_table = {
     item_names.ADVANCED_OPTICS:
         ItemData(622 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 11, SC2Race.TERRAN),
     item_names.ROGUE_FORCES:
-        ItemData(623 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 12, SC2Race.TERRAN, parent=parent_names.TERRAN_MERCENARIES),
+        ItemData(623 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 12, SC2Race.TERRAN, classification=ItemClassification.progression, parent=parent_names.TERRAN_MERCENARIES),
     item_names.MECHANICAL_KNOW_HOW:
         ItemData(624 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 13, SC2Race.TERRAN),
     item_names.MERCENARY_MUNITIONS:
         ItemData(625 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 14, SC2Race.TERRAN),
     item_names.PROGRESSIVE_FAST_DELIVERY:
-        ItemData(626 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive_2, 8, SC2Race.TERRAN, quantity=2, parent=parent_names.TERRAN_MERCENARIES),
+        ItemData(626 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive_2, 8, SC2Race.TERRAN, quantity=2, classification=ItemClassification.progression, parent=parent_names.TERRAN_MERCENARIES),
     item_names.RAPID_REINFORCEMENT:
-        ItemData(627 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 16, SC2Race.TERRAN, parent=parent_names.TERRAN_MERCENARIES),
+        ItemData(627 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 16, SC2Race.TERRAN, classification=ItemClassification.progression, parent=parent_names.TERRAN_MERCENARIES),
     item_names.FUSION_CORE_FUSION_REACTOR:
         ItemData(628 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Laboratory, 17, SC2Race.TERRAN),
     item_names.SONIC_DISRUPTER:
@@ -1563,10 +1563,10 @@ item_table = {
     item_names.MACROSCOPIC_RECUPERATION: ItemData(707 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 13, SC2Race.ZERG),
     item_names.BIOMECHANICAL_STOCKPILING: ItemData(708 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 14, SC2Race.ZERG, parent=parent_names.INFESTED_FACTORY_OR_STARPORT),
     item_names.BROODLING_SPORE_SATURATION: ItemData(709 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 15, SC2Race.ZERG),
-    item_names.CELL_DIVISION: ItemData(710 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 16, SC2Race.ZERG, parent=parent_names.ZERG_MERCENARIES),
-    item_names.SELF_SUFFICIENT: ItemData(711 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 17, SC2Race.ZERG, parent=parent_names.ZERG_MERCENARIES),
-    item_names.UNRESTRICTED_MUTATION: ItemData(712 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 18, SC2Race.ZERG, parent=parent_names.ZERG_MERCENARIES),
-    item_names.EVOLUTIONARY_LEAP: ItemData(713 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 19, SC2Race.ZERG, parent=parent_names.ZERG_MERCENARIES),
+    item_names.CELL_DIVISION: ItemData(710 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 16, SC2Race.ZERG, classification=ItemClassification.progression, parent=parent_names.ZERG_MERCENARIES),
+    item_names.SELF_SUFFICIENT: ItemData(711 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 17, SC2Race.ZERG, classification=ItemClassification.progression, parent=parent_names.ZERG_MERCENARIES),
+    item_names.UNRESTRICTED_MUTATION: ItemData(712 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 18, SC2Race.ZERG, classification=ItemClassification.progression, parent=parent_names.ZERG_MERCENARIES),
+    item_names.EVOLUTIONARY_LEAP: ItemData(713 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Evolution_Pit, 19, SC2Race.ZERG, classification=ItemClassification.progression, parent=parent_names.ZERG_MERCENARIES),
 
     # Morphs
     item_names.MUTALISK_CORRUPTOR_GUARDIAN_ASPECT: ItemData(800 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 6, SC2Race.ZERG, classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_AIR),

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1007,7 +1007,8 @@ item_table = {
         ItemData(904 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Progressive_2, 0, SC2Race.TERRAN, quantity=2,
                  classification=ItemClassification.progression),
     item_names.NOVA_ENERGY_SUIT_MODULE:
-        ItemData(905 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Nova_Gear, 4, SC2Race.TERRAN),
+        ItemData(905 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Nova_Gear, 4, SC2Race.TERRAN,
+                 classification=ItemClassification.progression),
     item_names.NOVA_ARMORED_SUIT_MODULE:
         ItemData(906 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Nova_Gear, 5, SC2Race.TERRAN,
                  classification=ItemClassification.progression),

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -5662,8 +5662,8 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 700,
             LocationType.VICTORY,
             logic.enemy_shadow_victory,
-            hard_rule=lambda state: logic.nova_any_nobuild_damage(state)
-            and logic.enemy_shadow_door_unlocks_tool(state),
+            hard_rule=lambda state: logic.nova_beat_stone(state)
+                and logic.enemy_shadow_door_unlocks_tool(state),
         ),
         make_location_data(
             SC2Mission.IN_THE_ENEMY_S_SHADOW.mission_name,

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -3121,13 +3121,14 @@ class SC2Logic:
             ), self.player)
             or (self.advanced_tactics
                 and state.has(item_names.ROGUE_FORCES, self.player)
-                and state.has_any((
+                and state.count_from_list((
                     item_names.WAR_PIGS,
                     item_names.HAMMER_SECURITIES,
+                    item_names.DEATH_HEADS,
                     item_names.SPARTAN_COMPANY,
                     item_names.HELS_ANGELS,
                     item_names.BRYNHILDS,
-                ), self.player)
+                ), self.player) >= 3
             )
         )
 
@@ -3268,7 +3269,7 @@ class SC2Logic:
         return self.enemy_shadow_second_stage(state) and (self.grant_story_tech == GrantStoryTech.option_grant or self.enemy_shadow_door_unlocks_tool(state))
 
     def enemy_shadow_victory(self, state: CollectionState) -> bool:
-        return self.enemy_shadow_door_controls(state) and (self.grant_story_tech == GrantStoryTech.option_grant or self.nova_heal(state))
+        return self.enemy_shadow_door_controls(state) and (self.grant_story_tech == GrantStoryTech.option_grant or (self.nova_heal(state) and self.nova_beat_stone(state)))
 
     def dark_skies_requirement(self, state: CollectionState) -> bool:
         return self.terran_common_unit(state) and self.terran_beats_protoss_deathball(state) and self.terran_defense_rating(state, False, True) >= 8

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -644,6 +644,40 @@ class SC2Logic:
 
     def nova_escape_assist(self, state: CollectionState) -> bool:
         return state.has_any({item_names.NOVA_BLINK, item_names.NOVA_HOLO_DECOY, item_names.NOVA_IONIC_FORCE_FIELD}, self.player)
+    
+    def nova_beat_stone(self, state: CollectionState) -> bool:
+        """
+        Used for any units logic for beating Stone. Shotgun may not be possible; may need feedback.
+        """
+        return (
+            state.has_any((
+                item_names.NOVA_DOMINATION,
+                item_names.NOVA_BLAZEFIRE_GUNBLADE,
+                item_names.NOVA_C20A_CANISTER_RIFLE,
+            ), self.player)
+            or ((
+                    state.has_any((
+                        item_names.NOVA_PLASMA_RIFLE,
+                        item_names.NOVA_MONOMOLECULAR_BLADE,
+                    ), self.player)
+                    or state.has_all((
+                        item_names.NOVA_HELLFIRE_SHOTGUN,
+                        item_names.NOVA_STIM_INFUSION
+                    ), self.player)
+                )
+                and state.has_any((
+                    item_names.NOVA_JUMP_SUIT_MODULE,
+                    item_names.NOVA_ARMORED_SUIT_MODULE,
+                    item_names.NOVA_ENERGY_SUIT_MODULE,
+                ), self.player)
+                and state.has_any((
+                    item_names.NOVA_FLASHBANG_GRENADES,
+                    item_names.NOVA_STIM_INFUSION,
+                    item_names.NOVA_BLINK,
+                    item_names.NOVA_IONIC_FORCE_FIELD,
+                ), self.player)
+            )
+        )
 
     # Global Zerg
     def zerg_power_rating(self, state: CollectionState) -> int:
@@ -3310,16 +3344,27 @@ class SC2Logic:
                     item_names.NIGHT_WOLF,
                     item_names.NIGHT_HAWK,
                     item_names.PRIDE_OF_AUGUSTRGRAD,
-                    # Mercs with shortest initial cooldown (300s)
-                    item_names.WAR_PIGS,
-                    item_names.DEATH_HEADS,
-                    item_names.HELS_ANGELS,
-                    item_names.WINGED_NIGHTMARES,
                 ), self.player)
                 or state.has_all((item_names.LIBERATOR, item_names.LIBERATOR_RAID_ARTILLERY), self.player)
                 or state.has_all((item_names.EMPERORS_GUARDIAN, item_names.LIBERATOR_RAID_ARTILLERY), self.player)
                 or state.has_all((item_names.VALKYRIE, item_names.VALKYRIE_FLECHETTE_MISSILES), self.player)
                 or state.has_all((item_names.WIDOW_MINE, item_names.WIDOW_MINE_DEMOLITION_PAYLOAD), self.player)
+                or (
+                    state.has_any((
+                        # Mercs with shortest initial cooldown (300s)
+                        item_names.WAR_PIGS,
+                        item_names.DEATH_HEADS,
+                        item_names.HELS_ANGELS,
+                        item_names.WINGED_NIGHTMARES,
+                    ), self.player)
+                    # + 2 upgrades that allow getting faster/earlier mercs
+                    and state.count_from_list((
+                        item_names.RAPID_REINFORCEMENT,
+                        item_names.PROGRESSIVE_FAST_DELIVERY,
+                        item_names.ROGUE_FORCES,
+                        # item_names.SIGNAL_BEACON,  # Probably doesn't help too much on the first unit
+                    ), self.player) >= 2
+                )
             )
 
         return _has_terran_units
@@ -3379,6 +3424,22 @@ class SC2Logic:
                     or (self.morph_devourer(state)
                         and state.has(item_names.DEVOURER_PRESCIENT_SPORES, self.player)
                     )
+                    or (
+                    state.has_any((
+                        # Mercs with <= 300s first drop time
+                        item_names.DEVOURING_ONES,
+                        item_names.HUNTER_KILLERS,
+                        item_names.CAUSTIC_HORRORS,
+                        item_names.HUNTERLING,
+                    ), self.player)
+                    # + 2 upgrades that allow getting faster/earlier mercs
+                    and state.count_from_list((
+                        item_names.UNRESTRICTED_MUTATION,
+                        item_names.EVOLUTIONARY_LEAP,
+                        item_names.CELL_DIVISION,
+                        item_names.SELF_SUFFICIENT,
+                    ), self.player) >= 2
+                )
                 )
             )
 

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -3133,7 +3133,10 @@ class SC2Logic:
 
     def enemy_intelligence_cliff_garrison(self, state: CollectionState) -> bool:
         return (
-            state.has_any({item_names.REAPER, item_names.VIKING, item_names.MEDIVAC, item_names.HERCULES}, self.player)
+            state.has_any((item_names.REAPER, item_names.VIKING), self.player)
+            or (state.has_any((item_names.MEDIVAC, item_names.HERCULES), self.player)
+                and self.enemy_intelligence_garrisonable_unit(state)
+            )
             or state.has_all({item_names.GOLIATH, item_names.GOLIATH_JUMP_JETS}, self.player)
             or (self.advanced_tactics and state.has_any({item_names.HELS_ANGELS, item_names.BRYNHILDS}, self.player))
         )

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -3104,9 +3104,10 @@ class SC2Logic:
         """
         Has unit usable as a Garrison in Enemy Intelligence
         """
-        return state.has_any(
-            {
+        return (
+            state.has_any((
                 item_names.MARINE,
+                item_names.SON_OF_KORHAL,
                 item_names.REAPER,
                 item_names.MARAUDER,
                 item_names.GHOST,
@@ -3117,8 +3118,17 @@ class SC2Logic:
                 item_names.DIAMONDBACK,
                 item_names.VIKING,
                 item_names.DOMINION_TROOPER,
-            },
-            self.player,
+            ), self.player)
+            or (self.advanced_tactics
+                and state.has(item_names.ROGUE_FORCES, self.player)
+                and state.has_any((
+                    item_names.WAR_PIGS,
+                    item_names.HAMMER_SECURITIES,
+                    item_names.SPARTAN_COMPANY,
+                    item_names.HELS_ANGELS,
+                    item_names.BRYNHILDS,
+                ), self.player)
+            )
         )
 
     def enemy_intelligence_cliff_garrison(self, state: CollectionState) -> bool:

--- a/worlds/sc2/test/test_usecases.py
+++ b/worlds/sc2/test/test_usecases.py
@@ -448,3 +448,45 @@ class TestSupportedUseCases(Sc2SetupTestBase):
         nova_gadgets = [item_name for item_name in world_item_names if item_name in item_groups.nova_gadgets]
 
         self.assertLessEqual(len(nova_gadgets), target_number)
+    
+    def test_mercs_only(self) -> None:
+        world_options = {
+            'selected_races': [
+                SC2Race.TERRAN.get_title(),
+                SC2Race.ZERG.get_title(),
+            ],
+            'required_tactics': options.RequiredTactics.option_any_units,
+            'excluded_items': {
+                item_groups.ItemGroupNames.TERRAN_UNITS: 0,
+                item_groups.ItemGroupNames.ZERG_UNITS: 0,
+            },
+            'unexcluded_items': {
+                item_groups.ItemGroupNames.TERRAN_MERCENARIES: 0,
+                item_groups.ItemGroupNames.ZERG_MERCENARIES: 0,
+            },
+            'start_inventory': {
+                item_names.PROGRESSIVE_FAST_DELIVERY: 1,
+                item_names.ROGUE_FORCES: 1,
+                item_names.UNRESTRICTED_MUTATION: 1,
+                item_names.EVOLUTIONARY_LEAP: 1,
+            },
+            'mission_order': options.MissionOrder.option_grid,
+            'excluded_missions': [
+                SC2Mission.ENEMY_WITHIN.mission_name,  # Requires a unit for Niadra to build
+            ],
+        }
+        self.generate_world(world_options)
+        world_item_names = [item.name for item in self.multiworld.itempool]
+        terran_nonmerc_units = tuple(
+            item_name
+            for item_name in world_item_names
+            if item_name in item_groups.terran_units and item_name not in item_groups.terran_mercenaries
+        )
+        zerg_nonmerc_units = tuple(
+            item_name
+            for item_name in world_item_names
+            if item_name in item_groups.zerg_units and item_name not in item_groups.zerg_mercenaries
+        )
+
+        self.assertTupleEqual(terran_nonmerc_units, ())
+        self.assertTupleEqual(zerg_nonmerc_units, ())


### PR DESCRIPTION
## What is this fixing or adding?
Fixing a logic hole for beating Stone reported by Snarky. Didn't entirely test it, in particular the rule for Shotgun seems suspect, but many of the other happy paths were either reported as likely to work by Snarky (Gunblade, rifle), or I tested with the extra stuff and it worked (plasma rifle).

Also made some adjustments to any_units to make starting with only mercs less common without supporting items.

## How was this tested?
* Used debug commands to try to beat Stone several times.
* WIP -- adding a unit test that mercs-only with any_units works (the test is failing, have to track down the reason)

## If this makes graphical changes, please attach screenshots.
None