### PR TITLE
sc2: Fixing the tracker using 60s update without synching to the update second

### DIFF
--- a/WebHostLib/static/assets/sc2Tracker.js
+++ b/WebHostLib/static/assets/sc2Tracker.js
@@ -5,27 +5,38 @@ let updateSection = (sectionName, fakeDOM) => {
 window.addEventListener('load', () => {
     // Reload tracker every 15 seconds
     const url = window.location;
-    window.refreshInterval = setInterval(() => {
-      const ajax = new XMLHttpRequest();
-      ajax.onreadystatechange = () => {
-        if (ajax.readyState !== 4) { return; }
-  
-        // Create a fake DOM using the returned HTML
-        const domParser = new DOMParser();
-        const fakeDOM = domParser.parseFromString(ajax.responseText, 'text/html');
-  
-        // Update dynamic sections
-        updateSection('player-info', fakeDOM);
-        updateSection('section-filler', fakeDOM);
-        updateSection('section-terran', fakeDOM);
-        updateSection('section-zerg', fakeDOM);
-        updateSection('section-protoss', fakeDOM);
-        updateSection('section-nova', fakeDOM);
-        updateSection('section-kerrigan', fakeDOM);
-        updateSection('section-keys', fakeDOM);
-        updateSection('section-locations', fakeDOM);
-      };
-      ajax.open('GET', url);
-      ajax.send();
-    }, 60000)
+    const targetSecond = parseInt(document.getElementById('player-tracker').getAttribute('data-second')) + 2;
+    console.log("Target second of refresh: " + targetSecond);
+
+    let getSleepTimeSeconds = () => {
+        // -40 % 60 is -40, which is absolutely wrong and should burn
+        var sleepSeconds = (((targetSecond - new Date().getSeconds()) % 60) + 60) % 60;
+        return sleepSeconds || 60;
+    };
+
+    let updateTracker = () => {
+        const ajax = new XMLHttpRequest();
+        ajax.onreadystatechange = () => {
+            if (ajax.readyState !== 4) { return; }
+    
+            // Create a fake DOM using the returned HTML
+            const domParser = new DOMParser();
+            const fakeDOM = domParser.parseFromString(ajax.responseText, 'text/html');
+    
+            // Update dynamic sections
+            updateSection('player-info', fakeDOM);
+            updateSection('section-filler', fakeDOM);
+            updateSection('section-terran', fakeDOM);
+            updateSection('section-zerg', fakeDOM);
+            updateSection('section-protoss', fakeDOM);
+            updateSection('section-nova', fakeDOM);
+            updateSection('section-kerrigan', fakeDOM);
+            updateSection('section-keys', fakeDOM);
+            updateSection('section-locations', fakeDOM);
+        };
+        ajax.open('GET', url);
+        ajax.send();
+        updater = setTimeout(updateTracker, getSleepTimeSeconds() * 1000);
+    };
+    var updater = setTimeout(updateTracker, getSleepTimeSeconds() * 1000);
 });

--- a/WebHostLib/static/assets/sc2Tracker.js
+++ b/WebHostLib/static/assets/sc2Tracker.js
@@ -38,5 +38,5 @@ window.addEventListener('load', () => {
         ajax.send();
         updater = setTimeout(updateTracker, getSleepTimeSeconds() * 1000);
     };
-    var updater = setTimeout(updateTracker, getSleepTimeSeconds() * 1000);
+    window.updater = setTimeout(updateTracker, getSleepTimeSeconds() * 1000);
 });

--- a/WebHostLib/templates/tracker__Starcraft2.html
+++ b/WebHostLib/templates/tracker__Starcraft2.html
@@ -11,7 +11,7 @@
   <div style="margin-bottom: 0.5rem; padding: 0.5rem">
     <a href="{{ url_for("get_generic_game_tracker", tracker=room.tracker, tracked_team=team, tracked_player=player) }}">Switch To Generic Tracker</a>
   </div>
-  <div id="player-tracker" data-tracker="{{ room.tracker|suuid }}">
+  <div id="player-tracker" data-tracker="{{ room.tracker|suuid }}" data-second="{{ saving_second }}">
     <div id="player-info">
       <h1>{{ player_name }}&apos;s Starcraft 2 Tracker{{' - Finished' if game_finished}}</h1>
     </div>

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -1463,6 +1463,7 @@ if "Starcraft 2" in network_data_package["games"]:
             location_id_to_name=location_id_to_name,
             item_id_to_name=item_id_to_name,
             keys=keys,
+            saving_second=tracker_data.get_room_saving_second(),
             **display_data,
         )
 

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -41,7 +41,7 @@ VICTORY_MODULO = 100
 
 def launch_client(*args: str):
     from .client import launch
-    launch_component(launch, name="Factorio Client", args=args)
+    launch_component(launch, name="Starcraft 2 Client", args=args)
 
 components.append(Component('Starcraft 2 Client', func=launch_client, game_name='Starcraft 2', supports_uri=True))
 


### PR DESCRIPTION
## What is this fixing or adding?
Proper fix for [Berserker's comment on the big merge PR](https://github.com/ArchipelagoMW/Archipelago/pull/5312#discussion_r2267775294). The [original fix](https://github.com/ArchipelagoMW/Archipelago/commit/201673ded63ab66dc617122055ec3baef8b85fc9) didn't actually use the new API to sync to the saving second, effectively just sending the worst-case latency from 65s to 120s.

Pinged Berserker in the discord and he pointed me towards trackerCommon.js, which seems to be the only place the API is used so far. Jinja can bake the "saving second" into the HTML, which can be fetched by the js to decide when to send an update request. I used a safety margin of 2s instead of 3s.

## How was this tested?
Launched local webhost. Opened the tracker, checked console log to find safety second. After an update, quickly used a `/send phaneros Science Vessel` and `/send_location phaneros <whatever>`. Verified that the next time my system clock reached 37s, the tracker updated and science vessel lit up.

## If this makes graphical changes, please attach screenshots.
None