### PR TITLE
sc2: Adding a back in the saddle hard rule for getting past the ultra

### DIFF
--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2376,7 +2376,6 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Reach the Sublevel",
             SC2HOTS_LOC_ID_OFFSET + 204,
             LocationType.EXTRA,
-            hard_rule=logic.zerg_any_units_back_in_the_saddle_requirement,
         ),
         make_location_data(
             SC2Mission.BACK_IN_THE_SADDLE.mission_name,

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2345,8 +2345,9 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 200,
             LocationType.VICTORY,
             lambda state: logic.basic_kerrigan(state)
-            or kerriganless
-            or logic.grant_story_tech == GrantStoryTech.option_grant,
+                or kerriganless
+                or logic.grant_story_tech == GrantStoryTech.option_grant,
+            hard_rule=logic.zerg_any_units_back_in_the_saddle_requirement,
         ),
         make_location_data(
             SC2Mission.BACK_IN_THE_SADDLE.mission_name,
@@ -2354,8 +2355,9 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 201,
             LocationType.EXTRA,
             lambda state: logic.basic_kerrigan(state)
-            or kerriganless
-            or logic.grant_story_tech == GrantStoryTech.option_grant,
+                or kerriganless
+                or logic.grant_story_tech == GrantStoryTech.option_grant,
+            hard_rule=logic.zerg_any_units_back_in_the_saddle_requirement,
         ),
         make_location_data(
             SC2Mission.BACK_IN_THE_SADDLE.mission_name,
@@ -2374,6 +2376,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Reach the Sublevel",
             SC2HOTS_LOC_ID_OFFSET + 204,
             LocationType.EXTRA,
+            hard_rule=logic.zerg_any_units_back_in_the_saddle_requirement,
         ),
         make_location_data(
             SC2Mission.BACK_IN_THE_SADDLE.mission_name,
@@ -2381,8 +2384,9 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 205,
             LocationType.EXTRA,
             lambda state: logic.basic_kerrigan(state)
-            or kerriganless
-            or logic.grant_story_tech == GrantStoryTech.option_grant,
+                or kerriganless
+                or logic.grant_story_tech == GrantStoryTech.option_grant,
+            hard_rule=logic.zerg_any_units_back_in_the_saddle_requirement,
         ),
         make_location_data(
             SC2Mission.RENDEZVOUS.mission_name,

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -2345,8 +2345,10 @@ class SC2Logic:
             # 
             # phaneros: Technically possible without the levels, but adding them in for safety margin and to hopefully
             # make generation force this branch less often
-            or (state.has(item_names.KERRIGAN_HEROIC_FORTITUDE, self.player) and self.kerrigan_levels(state, 5))
-            # Insufficient: Wild Mutation, Assimilation Aura, Mend
+            or (state.has_any((item_names.KERRIGAN_HEROIC_FORTITUDE, item_names.KERRIGAN_MEND), self.player)
+                and self.kerrigan_levels(state, 5)
+            )
+            # Insufficient: Wild Mutation, Assimilation Aura
         )
 
     def zerg_pass_vents(self, state: CollectionState) -> bool:

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -2330,7 +2330,6 @@ class SC2Logic:
                 item_names.KERRIGAN_CRUSHING_GRIP,
                 item_names.KERRIGAN_PSIONIC_SHIFT,
                 item_names.KERRIGAN_SPAWN_BANELINGS,
-                item_names.KERRIGAN_INFEST_BROODLINGS,  # Note(Snarky): Pretty tight, but I got it fairly consistently
                 item_names.KERRIGAN_FURY,
                 item_names.KERRIGAN_APOCALYPSE,
                 item_names.KERRIGAN_DROP_PODS,
@@ -2346,7 +2345,7 @@ class SC2Logic:
             # 
             # phaneros: Technically possible without the levels, but adding them in for safety margin and to hopefully
             # make generation force this branch less often
-            or (state.has(item_names.KERRIGAN_HEROIC_FORTITUDE, self.player)
+            or (state.has_any((item_names.KERRIGAN_HEROIC_FORTITUDE, item_names.KERRIGAN_INFEST_BROODLINGS), self.player)
                 and self.kerrigan_levels(state, 5)
             )
             # Insufficient: Wild Mutation, Assimilation Aura

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -2336,6 +2336,7 @@ class SC2Logic:
                 item_names.KERRIGAN_DROP_PODS,
                 item_names.KERRIGAN_SPAWN_LEVIATHAN,
                 item_names.KERRIGAN_IMMOBILIZATION_WAVE,  # Involves a 1-minute cooldown wait before the ultra
+                item_names.KERRIGAN_MEND,  # See note from THE EV below
             ), self.player)
             or self.kerrigan_levels(state, 20)
             or (self.kerrigan_levels(state, 10) and state.has(item_names.KERRIGAN_CHAIN_REACTION, self.player))
@@ -2345,7 +2346,7 @@ class SC2Logic:
             # 
             # phaneros: Technically possible without the levels, but adding them in for safety margin and to hopefully
             # make generation force this branch less often
-            or (state.has_any((item_names.KERRIGAN_HEROIC_FORTITUDE, item_names.KERRIGAN_MEND), self.player)
+            or (state.has(item_names.KERRIGAN_HEROIC_FORTITUDE, self.player)
                 and self.kerrigan_levels(state, 5)
             )
             # Insufficient: Wild Mutation, Assimilation Aura

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -2319,8 +2319,7 @@ class SC2Logic:
         )
     def zerg_any_units_back_in_the_saddle_requirement(self, state: CollectionState) -> bool:
         return (
-            not self.kerrigan_unit_available
-            or self.grant_story_tech == GrantStoryTech.option_grant
+            self.grant_story_tech == GrantStoryTech.option_grant
             or state.has_any((
                 # Cases tested by Snarky
                 item_names.KERRIGAN_KINETIC_BLAST,

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -2320,6 +2320,9 @@ class SC2Logic:
     def zerg_any_units_back_in_the_saddle_requirement(self, state: CollectionState) -> bool:
         return (
             self.grant_story_tech == GrantStoryTech.option_grant
+            # Note(mm): This check isn't necessary as self.kerrigan_levels cover it,
+            # and it's not fully desirable in future when we support non-grant story tech + kerriganless.
+            # or not self.kerrigan_presence
             or state.has_any((
                 # Cases tested by Snarky
                 item_names.KERRIGAN_KINETIC_BLAST,
@@ -2336,7 +2339,14 @@ class SC2Logic:
             ), self.player)
             or self.kerrigan_levels(state, 20)
             or (self.kerrigan_levels(state, 10) and state.has(item_names.KERRIGAN_CHAIN_REACTION, self.player))
-            # Insufficient: Mend, Heroic Fortitude, Wild Mutation, Assimilation Aura
+            # Tested by THE EV, "facetank with Kerrigan and stutter step to the end with >10s left"
+            # > have to lure the first group of Zerg in the 2nd timed section into the first room of the second area
+            # > (with the heal box) so you can kill them before the timer starts.
+            # 
+            # phaneros: Technically possible without the levels, but adding them in for safety margin and to hopefully
+            # make generation force this branch less often
+            or (state.has(item_names.KERRIGAN_HEROIC_FORTITUDE, self.player) and self.kerrigan_levels(state, 5))
+            # Insufficient: Wild Mutation, Assimilation Aura, Mend
         )
 
     def zerg_pass_vents(self, state: CollectionState) -> bool:

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -2317,6 +2317,22 @@ class SC2Logic:
                 )
             )
         )
+    def zerg_any_units_back_in_the_saddle_requirement(self, state: CollectionState) -> bool:
+        return (
+            state.has_any((
+                item_names.KERRIGAN_KINETIC_BLAST,
+                item_names.KERRIGAN_HEROIC_FORTITUDE,
+                item_names.KERRIGAN_LEAPING_STRIKE,
+                item_names.KERRIGAN_CRUSHING_GRIP,
+                item_names.KERRIGAN_CHAIN_REACTION,
+                item_names.KERRIGAN_PSIONIC_SHIFT,
+                item_names.KERRIGAN_SPAWN_BANELINGS,
+                item_names.KERRIGAN_INFEST_BROODLINGS,
+                item_names.KERRIGAN_FURY,
+                # item_names.KERRIGAN_ABILITY_EFFICIENCY,
+                # item_names.KERRIGAN_MEND,
+            ), self.player)
+        )
 
     def zerg_pass_vents(self, state: CollectionState) -> bool:
         return (

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -2321,7 +2321,6 @@ class SC2Logic:
         return (
             state.has_any((
                 item_names.KERRIGAN_KINETIC_BLAST,
-                item_names.KERRIGAN_HEROIC_FORTITUDE,
                 item_names.KERRIGAN_LEAPING_STRIKE,
                 item_names.KERRIGAN_CRUSHING_GRIP,
                 item_names.KERRIGAN_CHAIN_REACTION,
@@ -2329,8 +2328,10 @@ class SC2Logic:
                 item_names.KERRIGAN_SPAWN_BANELINGS,
                 item_names.KERRIGAN_INFEST_BROODLINGS,
                 item_names.KERRIGAN_FURY,
-                # item_names.KERRIGAN_ABILITY_EFFICIENCY,
-                # item_names.KERRIGAN_MEND,
+                item_names.KERRIGAN_APOCALYPSE,
+                item_names.KERRIGAN_DROP_PODS,
+                item_names.KERRIGAN_SPAWN_LEVIATHAN,
+                item_names.KERRIGAN_IMMOBILIZATION_WAVE,
             ), self.player)
         )
 

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -2319,20 +2319,25 @@ class SC2Logic:
         )
     def zerg_any_units_back_in_the_saddle_requirement(self, state: CollectionState) -> bool:
         return (
-            state.has_any((
+            not self.kerrigan_unit_available
+            or self.grant_story_tech == GrantStoryTech.option_grant
+            or state.has_any((
+                # Cases tested by Snarky
                 item_names.KERRIGAN_KINETIC_BLAST,
                 item_names.KERRIGAN_LEAPING_STRIKE,
                 item_names.KERRIGAN_CRUSHING_GRIP,
-                item_names.KERRIGAN_CHAIN_REACTION,
                 item_names.KERRIGAN_PSIONIC_SHIFT,
                 item_names.KERRIGAN_SPAWN_BANELINGS,
-                item_names.KERRIGAN_INFEST_BROODLINGS,
+                item_names.KERRIGAN_INFEST_BROODLINGS,  # Note(Snarky): Pretty tight, but I got it fairly consistently
                 item_names.KERRIGAN_FURY,
                 item_names.KERRIGAN_APOCALYPSE,
                 item_names.KERRIGAN_DROP_PODS,
                 item_names.KERRIGAN_SPAWN_LEVIATHAN,
-                item_names.KERRIGAN_IMMOBILIZATION_WAVE,
+                item_names.KERRIGAN_IMMOBILIZATION_WAVE,  # Involves a 1-minute cooldown wait before the ultra
             ), self.player)
+            or self.kerrigan_levels(state, 20)
+            or (self.kerrigan_levels(state, 10) and state.has(item_names.KERRIGAN_CHAIN_REACTION, self.player))
+            # Insufficient: Mend, Heroic Fortitude, Wild Mutation, Assimilation Aura
         )
 
     def zerg_pass_vents(self, state: CollectionState) -> bool:


### PR DESCRIPTION
## What is this fixing or adding?
The EV ran into an issue where any_units was expecting him to beat Back in the Saddle without any Kerrigan items. Seems to be a logic hole specific to any_units with kerrigan on and grant story tech off.

## How was this tested?
Snarky and The EV ran a bunch of test runs with minimal inventories. Snarky's notes:

```markdown
✅Kinetic Blast
✅Leaping Strike
✅Spawn Banelings
✅Psionic Shift
✅Crushing Grip
✅Fury
✅20 Kerrigan Levels 

✅Apocalypse
✅Drop-Pods
✅Spawn Leviathan


🗹Immobilization Wave  (wait for cooldown)
🗹Infest Broodlings (pretty tight, but I got it fairly consistently)
🗹10 Kerrigan Levels (same as Broodlings, pretty tight, hit or miss on the timer)

❌Chain Reaction (somewhat close, but I didn't manage to get it even once. Probably enough with +10 levels)

❌Heroic Fortitude (didn't get fortitude or mend to work by themselves
❌Mend
❌Wild Mutation
❌Assimilation Aura
```

## If this makes graphical changes, please attach screenshots.
None