### PR TITLE
Force-close SC2 on client close during load screen

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1021,6 +1021,9 @@ class SC2Context(CommonContext):
         await super(SC2Context, self).shutdown()
         if self.last_bot:
             self.last_bot.want_close = True
+            # If the client is not set up yet, the game is not done loading and must be force-closed
+            if not hasattr(self.last_bot, "client"):
+                bot.sc2process.kill_switch.kill_all()
         if self.sc2_run_task:
             self.sc2_run_task.cancel()
 


### PR DESCRIPTION
## What is this fixing or adding?
Via Berserker:

> So, replicatable problem, at least it works to replicate on my end:
Connect SC2 client to multiworld (the new one)
Hit launch mission. Don't actually hit any key on the SC2 client, let it stay on the load screen.
Close SC2 Client, it now freezes. Try to close SC2, it is now also frozen and needs its process terminated to clean it up.
This is on Windows 10.

I couldn't find the exact place where the freeze happens, but I identified that the bot library does not let our `ArchipelagoBot` interact with SC2 until the game is past the load screen (possibly due to a limitation of the SC2 API), which is why the existing `last_bot.want_close` method works via `ArchipelagoBot.on_step()`.

So, the only way to close SC2 while it is loading is to end its process directly, and conveniently the bot library has a kill switch set up for ending all its managed processes.

## How was this tested?
I launched a mission and closed the SC2 client before the game finished loading.