### PR TITLE
sc2: Fixing an issue where HotS wasn't a goal campaign on vanilla with epilogue excluded

### DIFF
--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -84,7 +84,7 @@ class SC2Campaign(Enum):
     GLOBAL = 0, "Global", SC2CampaignGoalPriority.NONE, SC2Race.ANY
     WOL = 1, "Wings of Liberty", SC2CampaignGoalPriority.VERY_HARD, SC2Race.TERRAN
     PROPHECY = 2, "Prophecy", SC2CampaignGoalPriority.MINI_CAMPAIGN, SC2Race.PROTOSS
-    HOTS = 3, "Heart of the Swarm", SC2CampaignGoalPriority.HARD, SC2Race.ZERG
+    HOTS = 3, "Heart of the Swarm", SC2CampaignGoalPriority.VERY_HARD, SC2Race.ZERG
     PROLOGUE = 4, "Whispers of Oblivion (Legacy of the Void: Prologue)", SC2CampaignGoalPriority.MINI_CAMPAIGN, SC2Race.PROTOSS
     LOTV = 5, "Legacy of the Void", SC2CampaignGoalPriority.VERY_HARD, SC2Race.PROTOSS
     EPILOGUE = 6, "Into the Void (Legacy of the Void: Epilogue)", SC2CampaignGoalPriority.EPILOGUE, SC2Race.ANY


### PR DESCRIPTION
## What is this fixing or adding?
Reported by Kaz Martell in [this discord message](https://discord.com/channels/731205301247803413/1101186175722598521/1411568482763411487)

On vanilla (and presumably vanilla shuffled) mission order, when epilogue was excluded, both WoL and LotV would be required to win the seed, but HotS would not be.

It seems this is because the "goal priority" member of the campaign wasn't updated when Reckoning was bumped to being a very hard mission.

## How was this tested?
Generated a vanilla world with epilogue excluded. Verified all 3 main campaigns were required to win.

## If this makes graphical changes, please attach screenshots.
None